### PR TITLE
feat: dispatch gate for sorted set

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/internal/logging"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"github.com/llm-d-incubation/llm-d-async/pkg/pubsub"
 	"github.com/llm-d-incubation/llm-d-async/pkg/redis"
@@ -33,6 +35,7 @@ func main() {
 	var concurrency int
 	var requestMergePolicy string
 	var messageQueueImpl string
+	var dispatchGateType string
 
 	var igwBaseURL string
 
@@ -45,7 +48,8 @@ func main() {
 
 	flag.StringVar(&igwBaseURL, "igw-base-url", "", "Base URL of the IGW (e.g. https://localhost:30800)")
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
-	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub")
+	flag.StringVar(&dispatchGateType, "dispatch-gate", "noop", "The dispatch gate policy to use. Supported policies: noop")
+	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, redis-sortedset-gated, gcp-pubsub")
 
 	opts := zap.Options{
 		Development: true,
@@ -91,6 +95,18 @@ func main() {
 
 	/////
 
+	// Create dispatch gate
+	var gate flowcontrol.DispatchGate
+	switch dispatchGateType {
+	case "noop":
+		gate = flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+			return 1.0 // Full capacity
+		})
+	default:
+		setupLog.Error(nil, "Unknown dispatch gate type", "dispatch-gate", dispatchGateType)
+		os.Exit(1)
+	}
+
 	var policy api.RequestMergePolicy
 	switch requestMergePolicy {
 	case "random-robin":
@@ -106,6 +122,9 @@ func main() {
 		impl = redis.NewRedisMQFlow()
 	case "redis-sortedset":
 		impl = redis.NewRedisSortedSetFlow()
+	case "redis-sortedset-gated":
+		impl = redis.NewRedisSortedSetFlow(redis.WithDispatchGate(gate))
+		setupLog.Info("Using Redis sorted-set flow with dispatch gating", "gate-type", dispatchGateType)
 	case "gcp-pubsub":
 		impl = pubsub.NewGCPPubSubMQFlow()
 	default:

--- a/pkg/async/inference/flowcontrol/dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/dispatch_gate.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import "context"
+
+// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
+type DispatchGate interface {
+	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
+	// the fraction of system capacity available for new requests.
+	// A value of 0.0 indicates no available capacity (system at max allowed).
+	// A value of 1.0 indicates full capacity available (system is idle).
+	// The system always returns a valid value, even in case of internal error.
+	Budget(ctx context.Context) float64
+}
+
+// DispatchGateFunc is a function type that implements DispatchGate.
+// This allows any function with the signature func(context.Context) float64
+// to be used as a DispatchGate.
+type DispatchGateFunc func(context.Context) float64
+
+// Budget implements DispatchGate by calling the function itself.
+func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
+	return f(ctx)
+}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
 	"github.com/redis/go-redis/v9"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,9 +50,23 @@ type RedisSortedSetFlow struct {
 	resultChannel   chan api.ResultMessage
 	pollInterval    time.Duration
 	batchSize       int
+	gate            flowcontrol.DispatchGate
 }
 
-func NewRedisSortedSetFlow() *RedisSortedSetFlow {
+// SortedSetOption is a functional option for configuring RedisSortedSetFlow
+type SortedSetOption func(*RedisSortedSetFlow)
+
+// WithDispatchGate enables dispatch gating with the provided gate.
+// When enabled, the flow checks the "dispatch budget" before processing messages
+// and scales the batch size proportionally to available capacity.
+// Default: always dispatch all.
+func WithDispatchGate(gate flowcontrol.DispatchGate) SortedSetOption {
+	return func(r *RedisSortedSetFlow) {
+		r.gate = gate
+	}
+}
+
+func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 	configs := loadQueueConfigs()
 	channels := make([]requestChannelData, 0, len(configs))
 
@@ -65,7 +81,7 @@ func NewRedisSortedSetFlow() *RedisSortedSetFlow {
 		})
 	}
 
-	return &RedisSortedSetFlow{
+	r := &RedisSortedSetFlow{
 		rdb:             redis.NewClient(&redis.Options{Addr: *ssRedisAddr}),
 		requestChannels: channels,
 		retryChannel:    make(chan api.RetryMessage),
@@ -73,6 +89,16 @@ func NewRedisSortedSetFlow() *RedisSortedSetFlow {
 		pollInterval:    time.Duration(*ssPollIntervalMs) * time.Millisecond,
 		batchSize:       *ssBatchSize,
 	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	if r.gate == nil {
+		r.gate = flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
+	}
+
+	return r
 }
 
 func loadQueueConfigs() []queueConfig {
@@ -141,7 +167,10 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan api.RequestMessage, queueName string, logger logr.Logger) {
 	currentTime := float64(time.Now().Unix())
 
-	for i := 0; i < r.batchSize; i++ {
+	budget := r.gate.Budget(ctx)
+	batchSize := int(math.Floor(float64(r.batchSize) * budget))
+
+	for i := 0; i < batchSize; i++ {
 		results, err := r.rdb.ZPopMin(ctx, queueName, 1).Result()
 		if err == redis.Nil || len(results) == 0 {
 			break

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -10,8 +10,14 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/redis/go-redis/v9"
 )
+
+// noopGate returns a gate that always returns full budget (1.0)
+func noopGate() flowcontrol.DispatchGate {
+	return flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
+}
 
 // Test helper to create test flow and Redis
 func setupTest(t *testing.T) (*miniredis.Miniredis, *redis.Client, context.Context, context.CancelFunc) {
@@ -36,6 +42,7 @@ func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 		}},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
+		gate:         noopGate(),
 	}
 
 	// Add message with valid deadline
@@ -78,6 +85,7 @@ func TestSortedSetFlow_DeadlineOrdering(t *testing.T) {
 		rdb:          rdb,
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
+		gate:         noopGate(),
 	}
 
 	now := time.Now().Unix()
@@ -132,6 +140,7 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 		}},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
+		gate:         noopGate(),
 	}
 
 	pastDeadline := time.Now().Unix() - 100
@@ -169,6 +178,7 @@ func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 		}},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
+		gate:         noopGate(),
 	}
 
 	testCases := []struct {
@@ -214,6 +224,7 @@ func TestSortedSetFlow_RetryBackoff(t *testing.T) {
 		retryChannel: make(chan api.RetryMessage, 1),
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
+		gate:         noopGate(),
 	}
 
 	go flow.retryWorker(ctx)
@@ -260,6 +271,7 @@ func TestSortedSetFlow_ResultFIFO(t *testing.T) {
 		resultChannel: make(chan api.ResultMessage, 2),
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
+		gate:          noopGate(),
 	}
 
 	go flow.resultWorker(ctx)
@@ -301,7 +313,7 @@ func TestSortedSetFlow_NoRaceCondition(t *testing.T) {
 
 	for w := 0; w < 3; w++ {
 		wg.Add(1)
-		flow := &RedisSortedSetFlow{rdb: rdb, pollInterval: 20 * time.Millisecond, batchSize: 10}
+		flow := &RedisSortedSetFlow{rdb: rdb, pollInterval: 20 * time.Millisecond, batchSize: 10, gate: noopGate()}
 		msgChan := make(chan api.RequestMessage, 10)
 
 		go func() {
@@ -351,6 +363,7 @@ func TestSortedSetFlow_ContextCancellation(t *testing.T) {
 		resultChannel: make(chan api.ResultMessage),
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
+		gate:          noopGate(),
 	}
 
 	workerCtx, cancel := context.WithCancel(ctx)
@@ -403,5 +416,153 @@ func TestSortedSetFlow_Integration(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Integration test timeout")
+	}
+}
+
+func TestSortedSetFlow_ZeroBudget(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close()
+	defer cancel()
+
+	queue := "zero-budget-queue"
+
+	// Create a gate with zero budget initially
+	budgetValue := 0.0
+	gate := flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+		return budgetValue
+	})
+
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   api.RequestChannel{Channel: make(chan api.RequestMessage)},
+			queueName: queue,
+		}},
+		pollInterval: 50 * time.Millisecond,
+		batchSize:    10,
+		gate:         gate,
+	}
+
+	// Add message with valid deadline
+	msg := api.RequestMessage{
+		Id:              "test-zero-budget",
+		DeadlineUnixSec: "9999999999",
+		Payload:         map[string]any{"test": "data"},
+	}
+	msgBytes, _ := json.Marshal(msg)
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+
+	// Wait for several poll cycles - message should NOT be pulled (budget=0)
+	select {
+	case <-flow.requestChannels[0].channel.Channel:
+		t.Fatal("Should not receive message when budget is 0")
+	case <-time.After(200 * time.Millisecond):
+		// Expected - no message pulled
+	}
+
+	// Message should still be in Redis
+	count, _ := rdb.ZCard(ctx, queue).Result()
+	if count != 1 {
+		t.Errorf("Expected message to remain in Redis with budget=0, got count=%d", count)
+	}
+
+	// Increase budget to full capacity
+	budgetValue = 1.0
+
+	// Message should now be pulled
+	select {
+	case received := <-flow.requestChannels[0].channel.Channel:
+		if received.Id != "test-zero-budget" {
+			t.Errorf("Expected test-zero-budget, got %s", received.Id)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Message should be pulled after budget increased")
+	}
+}
+
+func TestSortedSetFlow_PartialBudget(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close()
+	defer cancel()
+
+	queue := "partial-budget-queue"
+
+	// Gate with 30% budget - should process floor(10*0.3)=3 messages per cycle
+	gate := flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+		return 0.3
+	})
+
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   api.RequestChannel{Channel: make(chan api.RequestMessage, 20)},
+			queueName: queue,
+		}},
+		pollInterval: 200 * time.Millisecond,
+		batchSize:    10,
+		gate:         gate,
+	}
+
+	// Add 10 messages
+	for i := 0; i < 10; i++ {
+		msg := api.RequestMessage{
+			Id:              "msg-" + strconv.Itoa(i),
+			DeadlineUnixSec: "9999999999",
+		}
+		msgBytes, _ := json.Marshal(msg)
+		rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix() + int64(i)), Member: string(msgBytes)})
+	}
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+
+	// Wait for one poll cycle (200ms interval + buffer)
+	time.Sleep(250 * time.Millisecond)
+
+	// With 30% budget and batchSize=10, floor(10*0.3)=3 messages should be processed per cycle
+	// After one cycle, 7 messages should remain
+	remaining, _ := rdb.ZCard(ctx, queue).Result()
+	if remaining != 7 {
+		t.Errorf("Expected 7 messages remaining with 30%% budget (3 pulled), got %d remaining", remaining)
+	}
+}
+
+func TestSortedSetFlow_WithDispatchGateOption(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close()
+	defer cancel()
+
+	queue := "option-test-queue"
+	origQueue := *ssRequestQueueName
+	*ssRequestQueueName = queue
+	defer func() { *ssRequestQueueName = origQueue }()
+
+	// Use WithDispatchGate option
+	gate := flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+		return 1.0
+	})
+
+	flow := NewRedisSortedSetFlow(WithDispatchGate(gate))
+	flow.rdb = rdb
+	flow.pollInterval = 50 * time.Millisecond
+
+	flow.Start(ctx)
+
+	// Add message
+	msg := api.RequestMessage{Id: "option-test", DeadlineUnixSec: "9999999999"}
+	msgBytes, _ := json.Marshal(msg)
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
+
+	select {
+	case received := <-flow.RequestChannels()[0].Channel:
+		if received.Id != "option-test" {
+			t.Errorf("Expected option-test, got %s", received.Id)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timeout waiting for message with WithDispatchGate option")
 	}
 }


### PR DESCRIPTION
related issue #2 and to PR #28; ~~this PR is actually for illustrative purposes, because in its current state is a bit broken (and because I just noticed #28 :D -- this can be seen as a complement)~~

The idea is to put a "DispatchGate" in front of the queue implementation, but that requires also the queue to have a "pull" semantics instead of push, with the goal of gating the dequeue operation if the system has not enough capacity.


EDIT: I have rebased the implementation on top of @RishabhSaini's sorted set, which already has a pull-based semantics. 
- we define a DispatchGate interface, returning a [0,1] float `budget` (a the system rate of capacity to ingest new requests); 
- An optional DispatchGate can be set on the SortedSet queue
- the sorted set queue computes `N=budget*batchSize` and processes `N` elements from the sorted set
- the default DispatchGate always returns a `budget` of 1.0, meaning the sorted set always processes `batchSize` elements (as in the original implementation)

<details><summary>EDIT: no longer applies</summary>

1. this proposes to implement a new interface for pull-based semantics in a queue
2. it implements a pull-based Redis queue (sorted set)
3. it overrides the original Redis Flow using the pull-based impl 
4. it proposes and implements the DispatchGate interface, returning a [0,1] float `budget` (a the system rate of capacity to ingest new requests); 
5. when the budget is >0, the new Redis Flow and pulls `N=budget*MaxRequests` and dumps them in the channel for concurrent dispatch
</details>

minor issue: had to use `time.Sleep` in the tests but I can't use the fake clock (`synctest`) because it looks like it is not compatible with `miniredis` 