### PR TITLE
feat: add Go producer client library for async queue API

### DIFF
--- a/pkg/producer/producer.go
+++ b/pkg/producer/producer.go
@@ -1,0 +1,28 @@
+package producer
+
+import (
+	"context"
+	"time"
+
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+)
+
+// Producer is the abstract interface for submitting requests to the async queue
+// and retrieving results. Implementations handle the underlying queue mechanics.
+type Producer interface {
+	// SubmitRequest adds a request to the processing queue.
+	// Returns error if submission fails.
+	SubmitRequest(ctx context.Context, req api.RequestMessage) error
+
+	// GetResult retrieves a result from the result queue.
+	// Blocks until a result is available or context is cancelled.
+	// Returns error if retrieval fails or context is cancelled.
+	GetResult(ctx context.Context) (*api.ResultMessage, error)
+
+	// GetResultWithTimeout retrieves a result with a timeout.
+	// Returns nil result if timeout expires without a result.
+	GetResultWithTimeout(ctx context.Context, timeout time.Duration) (*api.ResultMessage, error)
+
+	// Close releases any resources held by the producer.
+	Close() error
+}

--- a/pkg/producer/redis_sortedset_producer.go
+++ b/pkg/producer/redis_sortedset_producer.go
@@ -1,0 +1,215 @@
+package producer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisSortedSetProducer implements Producer using Redis sorted set for requests
+// and Redis list for results.
+type RedisSortedSetProducer struct {
+	client           *redis.Client
+	requestQueueName string
+	resultQueueName  string
+}
+
+// RedisSortedSetConfig contains configuration for the Redis sorted set producer.
+type RedisSortedSetConfig struct {
+	// RedisAddr is the Redis server address (e.g., "localhost:6379").
+	// Required.
+	RedisAddr string
+
+	// TenantID is the unique identifier for the tenant/customer.
+	// Required for multi-tenant isolation.
+	// System should assign this (e.g., from auth token, API key).
+	// Example: "tenant-abc123", "customer-xyz"
+	TenantID string
+
+	// RequestQueueName is the name of the Redis sorted set for requests.
+	// Typically shared across all tenants.
+	// Default: "request-sortedset"
+	RequestQueueName string
+
+	// ResultQueueName is the customer's choice for their result queue name.
+	// Will be namespaced as: results:{tenantID}:{resultQueueName}
+	// Default: "default"
+	ResultQueueName string
+}
+
+// NewRedisSortedSetProducer creates a new producer using Redis sorted set.
+// Multi-tenant safe: TenantID ensures result queue isolation between tenants.
+func NewRedisSortedSetProducer(config RedisSortedSetConfig) (*RedisSortedSetProducer, error) {
+	if config.RedisAddr == "" {
+		return nil, errors.New("RedisAddr is required")
+	}
+
+	if config.TenantID == "" {
+		return nil, errors.New("TenantID is required for multi-tenant isolation")
+	}
+
+	if config.RequestQueueName == "" {
+		config.RequestQueueName = "request-sortedset"
+	}
+
+	if config.ResultQueueName == "" {
+		config.ResultQueueName = "default"
+	}
+
+	// Namespace result queue with tenant ID to prevent collisions
+	// Format: results:{tenantID}:{customerQueueName}
+	namespacedResultQueue := fmt.Sprintf("results:%s:%s", config.TenantID, config.ResultQueueName)
+
+	client := redis.NewClient(&redis.Options{
+		Addr: config.RedisAddr,
+	})
+
+	// Test connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
+	}
+
+	return &RedisSortedSetProducer{
+		client:           client,
+		requestQueueName: config.RequestQueueName,
+		resultQueueName:  namespacedResultQueue,
+	}, nil
+}
+
+// SubmitRequest adds a request to the Redis sorted set.
+// The score is the deadline, ensuring earlier deadlines are processed first.
+// The request metadata includes the result queue name so workers know where to send results.
+func (p *RedisSortedSetProducer) SubmitRequest(ctx context.Context, req api.RequestMessage) error {
+	if req.Id == "" {
+		return errors.New("request ID is required")
+	}
+
+	if req.DeadlineUnixSec == "" {
+		return errors.New("deadline is required")
+	}
+
+	// Parse deadline to validate and get score
+	deadline, err := strconv.ParseInt(req.DeadlineUnixSec, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid deadline format: %w", err)
+	}
+
+	if deadline <= 0 {
+		return errors.New("deadline must be a positive Unix timestamp")
+	}
+
+	// Initialize metadata if not present
+	if req.Metadata == nil {
+		req.Metadata = make(map[string]string)
+	}
+
+	// Add result queue name to metadata so worker knows where to send the result
+	req.Metadata["result_queue"] = p.resultQueueName
+
+	// Marshal request message to JSON
+	msgBytes, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Add to sorted set with deadline as score
+	score := float64(deadline)
+	if err := p.client.ZAdd(ctx, p.requestQueueName, redis.Z{
+		Score:  score,
+		Member: string(msgBytes),
+	}).Err(); err != nil {
+		return fmt.Errorf("failed to add request to queue: %w", err)
+	}
+
+	return nil
+}
+
+// GetResult retrieves a result from the Redis list, blocking until one is available.
+func (p *RedisSortedSetProducer) GetResult(ctx context.Context) (*api.ResultMessage, error) {
+	// Use BRPOP (blocking right pop) to wait for a result
+	result, err := p.client.BRPop(ctx, 0, p.resultQueueName).Result()
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to get result: %w", err)
+	}
+
+	// BRPOP returns [queueName, value]
+	if len(result) != 2 {
+		return nil, errors.New("unexpected BRPOP result format")
+	}
+
+	return p.parseResult(result[1])
+}
+
+// GetResultWithTimeout retrieves a result with a timeout.
+func (p *RedisSortedSetProducer) GetResultWithTimeout(ctx context.Context, timeout time.Duration) (*api.ResultMessage, error) {
+	// Use BRPOP with timeout
+	result, err := p.client.BRPop(ctx, timeout, p.resultQueueName).Result()
+	if err != nil {
+		if err == redis.Nil {
+			// Timeout occurred
+			return nil, nil
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to get result: %w", err)
+	}
+
+	// BRPOP returns [queueName, value]
+	if len(result) != 2 {
+		return nil, errors.New("unexpected BRPOP result format")
+	}
+
+	return p.parseResult(result[1])
+}
+
+// parseResult parses a JSON result message.
+func (p *RedisSortedSetProducer) parseResult(data string) (*api.ResultMessage, error) {
+	var result api.ResultMessage
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
+	}
+
+	if result.Id == "" {
+		return nil, errors.New("result missing 'id' field")
+	}
+
+	return &result, nil
+}
+
+// Close closes the Redis connection.
+func (p *RedisSortedSetProducer) Close() error {
+	return p.client.Close()
+}
+
+// QueueDepth returns the number of pending requests in the queue.
+func (p *RedisSortedSetProducer) QueueDepth(ctx context.Context) (int64, error) {
+	return p.client.ZCard(ctx, p.requestQueueName).Result()
+}
+
+// ResultQueueDepth returns the number of results waiting to be consumed.
+func (p *RedisSortedSetProducer) ResultQueueDepth(ctx context.Context) (int64, error) {
+	return p.client.LLen(ctx, p.resultQueueName).Result()
+}
+
+// ClearRequestQueue removes all pending requests from the queue.
+func (p *RedisSortedSetProducer) ClearRequestQueue(ctx context.Context) error {
+	return p.client.Del(ctx, p.requestQueueName).Err()
+}
+
+// ClearResultQueue removes all results from the queue.
+func (p *RedisSortedSetProducer) ClearResultQueue(ctx context.Context) error {
+	return p.client.Del(ctx, p.resultQueueName).Err()
+}

--- a/pkg/producer/redis_sortedset_producer_test.go
+++ b/pkg/producer/redis_sortedset_producer_test.go
@@ -1,0 +1,364 @@
+package producer
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestProducer(t *testing.T) (*RedisSortedSetProducer, *miniredis.Miniredis) {
+	t.Helper()
+
+	// Start mini Redis
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(func() { mr.Close() })
+
+	producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
+		RedisAddr:        mr.Addr(),
+		TenantID:         "test-tenant",
+		RequestQueueName: "test-request-queue",
+		ResultQueueName:  "test-result-queue",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := producer.Close(); err != nil {
+			t.Logf("failed to close producer: %v", err)
+		}
+	})
+
+	return producer, mr
+}
+
+func TestSubmitRequest(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx := context.Background()
+
+	req := api.RequestMessage{
+		Id:              "test-123",
+		DeadlineUnixSec: strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
+		Payload: map[string]interface{}{
+			"model":  "gpt-3.5-turbo",
+			"prompt": "Hello, world!",
+		},
+		Metadata: map[string]string{
+			"user": "test-user",
+		},
+	}
+
+	err := producer.SubmitRequest(ctx, req)
+	assert.NoError(t, err)
+
+	// Verify the message was added to the sorted set
+	assert.True(t, mr.Exists("test-request-queue"))
+	members, err := mr.ZMembers("test-request-queue")
+	require.NoError(t, err)
+	assert.Len(t, members, 1)
+
+	// Verify the message content
+	var msg api.RequestMessage
+	err = json.Unmarshal([]byte(members[0]), &msg)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-123", msg.Id)
+
+	// Verify metadata includes result_queue with tenant namespace
+	assert.Equal(t, "test-user", msg.Metadata["user"])
+	assert.Equal(t, "results:test-tenant:test-result-queue", msg.Metadata["result_queue"])
+}
+
+func TestSubmitRequest_Validation(t *testing.T) {
+	producer, _ := setupTestProducer(t)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     api.RequestMessage
+		wantErr string
+	}{
+		{
+			name: "missing ID",
+			req: api.RequestMessage{
+				DeadlineUnixSec: strconv.FormatInt(time.Now().Unix(), 10),
+				Payload:         map[string]interface{}{},
+			},
+			wantErr: "request ID is required",
+		},
+		{
+			name: "missing deadline",
+			req: api.RequestMessage{
+				Id:      "test",
+				Payload: map[string]interface{}{},
+			},
+			wantErr: "deadline is required",
+		},
+		{
+			name: "invalid deadline",
+			req: api.RequestMessage{
+				Id:              "test",
+				DeadlineUnixSec: "0",
+				Payload:         map[string]interface{}{},
+			},
+			wantErr: "deadline must be a positive Unix timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := producer.SubmitRequest(ctx, tt.req)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestGetResult(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Push a result to the namespaced list
+	resultMsg := api.ResultMessage{
+		Id:      "test-123",
+		Payload: `{"response": "Hello!"}`,
+	}
+	resultJSON, _ := json.Marshal(resultMsg)
+	_, err := mr.Lpush("results:test-tenant:test-result-queue", string(resultJSON))
+	require.NoError(t, err)
+
+	// Get the result
+	result, err := producer.GetResult(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "test-123", result.Id)
+	assert.Contains(t, result.Payload, "Hello!")
+}
+
+func TestGetResultWithTimeout(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx := context.Background()
+
+	t.Run("timeout with no result", func(t *testing.T) {
+		result, err := producer.GetResultWithTimeout(ctx, 100*time.Millisecond)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("get result before timeout", func(t *testing.T) {
+		// Push a result to namespaced queue
+		resultMsg := api.ResultMessage{
+			Id:      "test-456",
+			Payload: "test response",
+		}
+		resultJSON, _ := json.Marshal(resultMsg)
+		_, err := mr.Lpush("results:test-tenant:test-result-queue", string(resultJSON))
+		require.NoError(t, err)
+
+		result, err := producer.GetResultWithTimeout(ctx, 1*time.Second)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "test-456", result.Id)
+	})
+}
+
+func TestMultipleTenantsIsolation(t *testing.T) {
+	// Start mini Redis
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	ctx := context.Background()
+
+	// Create producers for two different tenants
+	tenant1Producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
+		RedisAddr:        mr.Addr(),
+		TenantID:         "tenant-alice",
+		RequestQueueName: "shared-request-queue",
+		ResultQueueName:  "my-results", // Same name but different tenant
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := tenant1Producer.Close(); err != nil {
+			t.Logf("failed to close tenant1Producer: %v", err)
+		}
+	})
+
+	tenant2Producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
+		RedisAddr:        mr.Addr(),
+		TenantID:         "tenant-bob",
+		RequestQueueName: "shared-request-queue",
+		ResultQueueName:  "my-results", // Same name but different tenant
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := tenant2Producer.Close(); err != nil {
+			t.Logf("failed to close tenant2Producer: %v", err)
+		}
+	})
+
+	// Verify they have different namespaced result queues
+	assert.Equal(t, "results:tenant-alice:my-results", tenant1Producer.resultQueueName)
+	assert.Equal(t, "results:tenant-bob:my-results", tenant2Producer.resultQueueName)
+	assert.NotEqual(t, tenant1Producer.resultQueueName, tenant2Producer.resultQueueName,
+		"Different tenants should have different result queues even with same ResultQueueName")
+
+	// Submit requests from both tenants
+	req1 := api.RequestMessage{
+		Id:              "alice-request",
+		DeadlineUnixSec: strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
+		Payload:         map[string]interface{}{"tenant": "alice"},
+	}
+	err = tenant1Producer.SubmitRequest(ctx, req1)
+	require.NoError(t, err)
+
+	req2 := api.RequestMessage{
+		Id:              "bob-request",
+		DeadlineUnixSec: strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
+		Payload:         map[string]interface{}{"tenant": "bob"},
+	}
+	err = tenant2Producer.SubmitRequest(ctx, req2)
+	require.NoError(t, err)
+
+	// Verify both requests have different result_queue metadata
+	members, err := mr.ZMembers("shared-request-queue")
+	require.NoError(t, err)
+	assert.Len(t, members, 2)
+
+	var msg1, msg2 api.RequestMessage
+	require.NoError(t, json.Unmarshal([]byte(members[0]), &msg1))
+	require.NoError(t, json.Unmarshal([]byte(members[1]), &msg2))
+
+	assert.Equal(t, "results:tenant-alice:my-results", msg1.Metadata["result_queue"])
+	assert.Equal(t, "results:tenant-bob:my-results", msg2.Metadata["result_queue"])
+
+	// Simulate worker routing results to correct tenant queues
+	result1 := api.ResultMessage{
+		Id:      "alice-request",
+		Payload: `{"response": "alice result"}`,
+	}
+	result1JSON, _ := json.Marshal(result1)
+	_, err = mr.Lpush("results:tenant-alice:my-results", string(result1JSON))
+	require.NoError(t, err)
+
+	result2 := api.ResultMessage{
+		Id:      "bob-request",
+		Payload: `{"response": "bob result"}`,
+	}
+	result2JSON, _ := json.Marshal(result2)
+	_, err = mr.Lpush("results:tenant-bob:my-results", string(result2JSON))
+	require.NoError(t, err)
+
+	// Each tenant should only receive their own result
+	res1, err := tenant1Producer.GetResultWithTimeout(ctx, 1*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res1)
+	assert.Equal(t, "alice-request", res1.Id)
+	assert.Contains(t, res1.Payload, "alice result")
+
+	res2, err := tenant2Producer.GetResultWithTimeout(ctx, 1*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res2)
+	assert.Equal(t, "bob-request", res2.Id)
+	assert.Contains(t, res2.Payload, "bob result")
+}
+
+func TestTenantIDRequired(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	// Should fail without TenantID
+	_, err = NewRedisSortedSetProducer(RedisSortedSetConfig{
+		RedisAddr:        mr.Addr(),
+		RequestQueueName: "test",
+		ResultQueueName:  "test",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "TenantID is required")
+}
+
+func TestContextCancellation(t *testing.T) {
+	producer, _ := setupTestProducer(t)
+
+	// Test context cancellation with timeout-based retrieval
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	result, err := producer.GetResultWithTimeout(ctx, 5*time.Second)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestMalformedResultHandling(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx := context.Background()
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		_, err := mr.Lpush("results:test-tenant:test-result-queue", "invalid-json{{{")
+		require.NoError(t, err)
+
+		result, err := producer.GetResultWithTimeout(ctx, 1*time.Second)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "unmarshal")
+	})
+
+	t.Run("missing id field", func(t *testing.T) {
+		invalidResult := map[string]interface{}{"payload": "data"}
+		resultJSON, _ := json.Marshal(invalidResult)
+		_, err := mr.Lpush("results:test-tenant:test-result-queue", string(resultJSON))
+		require.NoError(t, err)
+
+		result, err := producer.GetResultWithTimeout(ctx, 1*time.Second)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "missing 'id' field")
+	})
+}
+
+func TestSameTenantMultipleQueues(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	// Same tenant creates two producers with different result queues
+	prod1, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
+		RedisAddr:        mr.Addr(),
+		TenantID:         "alice",
+		ResultQueueName:  "batch-jobs",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := prod1.Close(); err != nil {
+			t.Logf("failed to close prod1: %v", err)
+		}
+	})
+
+	prod2, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
+		RedisAddr:        mr.Addr(),
+		TenantID:         "alice",
+		ResultQueueName:  "realtime",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := prod2.Close(); err != nil {
+			t.Logf("failed to close prod2: %v", err)
+		}
+	})
+
+	// Verify different namespaced queues
+	assert.Equal(t, "results:alice:batch-jobs", prod1.resultQueueName)
+	assert.Equal(t, "results:alice:realtime", prod2.resultQueueName)
+	assert.NotEqual(t, prod1.resultQueueName, prod2.resultQueueName)
+}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -248,6 +248,7 @@ func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
 }
 
 // Pushes results to Redis list (FIFO)
+// Routes results to the queue specified in request metadata, or default queue if not specified
 func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 	logger := log.FromContext(ctx)
 
@@ -256,9 +257,19 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case msg := <-r.resultChannel:
+			// Check metadata for custom result queue (set by producer)
+			resultQueue := *ssResultQueueName // default queue
+			if msg.Metadata != nil {
+				if customQueue, ok := msg.Metadata["result_queue"]; ok && customQueue != "" {
+					resultQueue = customQueue
+				}
+			}
+
 			msgStr := r.marshalResult(msg)
-			if err := r.rdb.LPush(ctx, *ssResultQueueName, msgStr).Err(); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to push result")
+			if err := r.rdb.LPush(ctx, resultQueue, msgStr).Err(); err != nil {
+				logger.V(logutil.DEFAULT).Error(err, "Failed to push result", "queue", resultQueue)
+			} else {
+				logger.V(logutil.DEBUG).Info("Pushed result to queue", "id", msg.Id, "queue", resultQueue)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves: #54 
  
Implement Producer interface with Redis sorted set backend for submitting
  requests and retrieving results from async processing queue.

  - Add Producer interface using existing api.RequestMessage/ResultMessage types
  - Implement RedisSortedSetProducer with multi-tenant isolation via TenantID
  - Results namespaced as results:{tenantID}:{queueName} to prevent collisions
  - Update sortedset_impl resultWorker to route results via metadata
  - Add comprehensive tests covering validation, error handling, and tenant isolation

  Multi-tenant safe: each tenant gets isolated result queue while sharing
  request queue for efficient priority-based processing.