### PR TITLE
added 'created' timestamp to RequestMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ make deploy-ap-on-k8s
 - `request-merge-policy`: Currently only supporting <u>random-robin</u> policy.
 - `message-queue-impl`: Implementation of the queueing system. Options are <u>gcp-pubsub</u> for GCP PubSub <u>redis-sortedset</u> for Redis Sorted Set (persisted and sorted) and  <u>redis-pubsub</u> for ephemeral Redis-based implementation.
 - `dispatch-gate`: Implementation of a dispatcher that is responsible for gating pulling messages from the queues. Options are :
-   - `noop`: The default. Respresents full availability of the system. Always pulling messages.
+   - `noop`: The default. Represents full availability of the system. Always pulling messages.
    - `metric-avg-queue-size`: Availability base on the model average queue size metric in Prometheus. If the queue size is non empty, messages will not be pulled from the respective queue.
    - `redis`: Availability of the system is pulled periodically from Redis (I.e., managed by external system).
 
@@ -94,6 +94,7 @@ The async processor expects request messages to have the following format:
 ```json
 {
     "id" : "unique identifier for result mapping",
+    "created": "created timestamp in Unix seconds",
     "deadline" : "deadline in Unix seconds",
     "payload" : {regular inference payload as a byte array}
 }
@@ -103,6 +104,7 @@ Example:
 ```json
 {
     "id" : "19933123533434",
+    "created": "1764044000",
     "deadline" : "1764045130",
     "payload": byte[]({"model":"food-review","prompt":"hi", "max_tokens":10,"temperature":0})
 }

--- a/pkg/async/api/api.go
+++ b/pkg/async/api/api.go
@@ -32,6 +32,7 @@ type RequestMergePolicy interface {
 // add endpoint to message level.
 type RequestMessage struct {
 	Id              string            `json:"id"`
+	CreatedUnixSec  string            `json:"created"`               // Unix seconds
 	RetryCount      int               `json:"retry_count,omitempty"` // TODO: Consider
 	DeadlineUnixSec string            `json:"deadline"`              // TODO: check about using int64, change name to timeout
 	Payload         map[string]any    `json:"payload"`

--- a/pkg/async/api/worker_test.go
+++ b/pkg/async/api/worker_test.go
@@ -15,6 +15,7 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 	msg := EmbelishedRequestMessage{
 		RequestMessage: RequestMessage{
 			Id:              "123",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
 			RetryCount:      0,
 			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Add(time.Second*-10).Unix()),
 		},
@@ -46,6 +47,7 @@ func TestRetryMessage_retry(t *testing.T) {
 	msg := EmbelishedRequestMessage{
 		RequestMessage: RequestMessage{
 			Id:              "123",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
 			RetryCount:      0,
 			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Add(time.Second*10).Unix()),
 		},
@@ -103,6 +105,7 @@ func TestSheddedRequest(t *testing.T) {
 	requestChannel <- EmbelishedRequestMessage{
 		RequestMessage: RequestMessage{
 			Id:              msgId,
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
 			RetryCount:      0,
 			DeadlineUnixSec: fmt.Sprintf(("%d"), deadline),
 			Payload:         map[string]any{"model": "food-review", "prompt": "hi", "max_tokens": 10, "temperature": 0},
@@ -143,6 +146,7 @@ func TestSuccessfulRequest(t *testing.T) {
 	requestChannel <- EmbelishedRequestMessage{
 		RequestMessage: RequestMessage{
 			Id:              msgId,
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
 			RetryCount:      0,
 			DeadlineUnixSec: fmt.Sprintf(("%d"), deadline),
 			Payload:         map[string]any{"model": "food-review", "prompt": "hi", "max_tokens": 10, "temperature": 0},

--- a/pkg/producer/redis_sortedset_producer_test.go
+++ b/pkg/producer/redis_sortedset_producer_test.go
@@ -44,6 +44,7 @@ func TestSubmitRequest(t *testing.T) {
 
 	req := api.RequestMessage{
 		Id:              "test-123",
+		CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 		DeadlineUnixSec: strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
 		Payload: map[string]interface{}{
 			"model":  "gpt-3.5-turbo",
@@ -87,6 +88,7 @@ func TestSubmitRequest_Validation(t *testing.T) {
 		{
 			name: "missing ID",
 			req: api.RequestMessage{
+				CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 				DeadlineUnixSec: strconv.FormatInt(time.Now().Unix(), 10),
 				Payload:         map[string]interface{}{},
 			},
@@ -95,8 +97,9 @@ func TestSubmitRequest_Validation(t *testing.T) {
 		{
 			name: "missing deadline",
 			req: api.RequestMessage{
-				Id:      "test",
-				Payload: map[string]interface{}{},
+				Id:             "test",
+				CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10),
+				Payload:        map[string]interface{}{},
 			},
 			wantErr: "deadline is required",
 		},
@@ -104,6 +107,7 @@ func TestSubmitRequest_Validation(t *testing.T) {
 			name: "invalid deadline",
 			req: api.RequestMessage{
 				Id:              "test",
+				CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 				DeadlineUnixSec: "0",
 				Payload:         map[string]interface{}{},
 			},
@@ -214,6 +218,7 @@ func TestMultipleTenantsIsolation(t *testing.T) {
 	// Submit requests from both tenants
 	req1 := api.RequestMessage{
 		Id:              "alice-request",
+		CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 		DeadlineUnixSec: strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
 		Payload:         map[string]interface{}{"tenant": "alice"},
 	}
@@ -222,6 +227,7 @@ func TestMultipleTenantsIsolation(t *testing.T) {
 
 	req2 := api.RequestMessage{
 		Id:              "bob-request",
+		CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 		DeadlineUnixSec: strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
 		Payload:         map[string]interface{}{"tenant": "bob"},
 	}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -50,6 +50,7 @@ func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 	// Add message with valid deadline
 	msg := api.RequestMessage{
 		Id:              "msg-1",
+		CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 		DeadlineUnixSec: "9999999999",
 		Payload:         map[string]any{"test": "data"},
 	}
@@ -101,7 +102,7 @@ func TestSortedSetFlow_DeadlineOrdering(t *testing.T) {
 	}
 
 	for _, m := range messages {
-		msg := api.RequestMessage{Id: m.id, DeadlineUnixSec: strconv.FormatInt(m.deadline, 10)}
+		msg := api.RequestMessage{Id: m.id, CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: strconv.FormatInt(m.deadline, 10)}
 		msgBytes, _ := json.Marshal(msg)
 		rdb.ZAdd(ctx, queue, redis.Z{Score: float64(m.deadline), Member: string(msgBytes)})
 	}
@@ -146,7 +147,7 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	}
 
 	pastDeadline := time.Now().Unix() - 100
-	msg := api.RequestMessage{Id: "expired", DeadlineUnixSec: strconv.FormatInt(pastDeadline, 10)}
+	msg := api.RequestMessage{Id: "expired", CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: strconv.FormatInt(pastDeadline, 10)}
 	msgBytes, _ := json.Marshal(msg)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(pastDeadline), Member: string(msgBytes)})
 
@@ -197,7 +198,7 @@ func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 	}
 
 	// Add valid message after malformed ones
-	validMsg := api.RequestMessage{Id: "valid", DeadlineUnixSec: "9999999999"}
+	validMsg := api.RequestMessage{Id: "valid", CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: "9999999999"}
 	validBytes, _ := json.Marshal(validMsg)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(validBytes)})
 
@@ -235,6 +236,7 @@ func TestSortedSetFlow_RetryBackoff(t *testing.T) {
 		EmbelishedRequestMessage: api.EmbelishedRequestMessage{
 			RequestMessage: api.RequestMessage{
 				Id:              "retry-1",
+				CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 				DeadlineUnixSec: "9999999999",
 				RetryCount:      1,
 			},
@@ -305,7 +307,7 @@ func TestSortedSetFlow_NoRaceCondition(t *testing.T) {
 	numMessages := 20
 
 	for i := 0; i < numMessages; i++ {
-		msg := api.RequestMessage{Id: string(rune('A' + i)), DeadlineUnixSec: "9999999999"}
+		msg := api.RequestMessage{Id: string(rune('A' + i)), CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: "9999999999"}
 		msgBytes, _ := json.Marshal(msg)
 		rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
 	}
@@ -406,7 +408,7 @@ func TestSortedSetFlow_Integration(t *testing.T) {
 	flow.Start(ctx)
 
 	// Add message
-	msg := api.RequestMessage{Id: "integration", DeadlineUnixSec: "9999999999"}
+	msg := api.RequestMessage{Id: "integration", CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: "9999999999"}
 	msgBytes, _ := json.Marshal(msg)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
 
@@ -451,6 +453,7 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 	// Add message with valid deadline
 	msg := api.RequestMessage{
 		Id:              "test-zero-budget",
+		CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 		DeadlineUnixSec: "9999999999",
 		Payload:         map[string]any{"test": "data"},
 	}
@@ -515,6 +518,7 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		msg := api.RequestMessage{
 			Id:              "msg-" + strconv.Itoa(i),
+			CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 			DeadlineUnixSec: "9999999999",
 		}
 		msgBytes, _ := json.Marshal(msg)
@@ -555,7 +559,7 @@ func TestSortedSetFlow_WithDispatchGateOption(t *testing.T) {
 	flow.Start(ctx)
 
 	// Add message
-	msg := api.RequestMessage{Id: "option-test", DeadlineUnixSec: "9999999999"}
+	msg := api.RequestMessage{Id: "option-test", CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: "9999999999"}
 	msgBytes, _ := json.Marshal(msg)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -120,6 +121,7 @@ func makeRequestMessage(id string, deadlineOffset time.Duration) api.RequestMess
 	deadline := time.Now().Add(deadlineOffset)
 	return api.RequestMessage{
 		Id:              id,
+		CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 		DeadlineUnixSec: fmt.Sprintf("%d", deadline.Unix()),
 		Payload:         map[string]any{"model": id, "prompt": "test"},
 	}

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -31,6 +31,7 @@ func TestRedisImpl(t *testing.T) {
 		EmbelishedRequestMessage: api.EmbelishedRequestMessage{
 			RequestMessage: api.RequestMessage{
 				Id:              "test-id",
+				CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
 				DeadlineUnixSec: strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10),
 				Payload:         map[string]any{"model": "food-review", "prompt": "hi", "max_tokens": 10, "temperature": 0},
 				Metadata:        map[string]string{redis.QUEUE_NAME_KEY: "request-queue"},


### PR DESCRIPTION
## What does this PR do?

Added 'created' timestamp to RequestMessage.

## Why is this change needed?

Important to add this field to the protocol in order to support later on a 'time_in_queue' metric.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

https://github.com/llm-d-incubation/llm-d-async/issues/62

