### PR TITLE
[Feature]: Support Gate per RequestChannel (Queue) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,29 @@ The architecture adheres to the following core principles:
 
 ## Table of Contents
 
-- [Overview](#overview)
-- [When to use](#when-to-use)
-- [Design Principles](#design-principles)
-- [Deployment](#deployment)
-- [Command line parameters](#command-line-parameters)
-- [Request Messages and Consusmption](#request-messages-and-consomption)
+- [Async Processor (AP) - User Guide](#async-processor-ap---user-guide)
+  - [Overview](#overview)
+  - [When to Use](#when-to-use)
+  - [Design Principles](#design-principles)
+  - [Table of Contents](#table-of-contents)
+  - [Deployment](#deployment)
+  - [Command line parameters](#command-line-parameters)
+  - [Dispatch Gates](#dispatch-gates)
+    - [Per-Queue Dispatch Gates](#per-queue-dispatch-gates)
+  - [Request Messages and Consumption](#request-messages-and-consumption)
     - [Request Merge Policy](#request-merge-policy)
-- [Retries](#retries)
-- [Results](#results)   
-- [Implementations](#implementations)
+  - [Retries](#retries)
+  - [Results](#results)
+  - [Implementations](#implementations)
     - [Redis Sorted Set (Persisted)](#redis-sorted-set-persisted)
       - [Redis Sorted Set Command line parameters](#redis-sorted-set-command-line-parameters)
-    - [Redis Channels (Ephemeral)](#redis-channels)
+    - [Redis Channels (Ephemeral)](#redis-channels-ephemeral)
       - [Redis Channels Command line parameters](#redis-channels-command-line-parameters)
-        - [Multiple Queues Configuration File Syntax](#multiple-queues-configuration-file-syntax)
-    - [GCP Pub/Sub](#gcp-pub-sub)
+      - [Multiple Queues Configuration File Syntax](#multiple-queues-configuration-file-syntax)
+    - [GCP Pub/Sub](#gcp-pubsub)
       - [GCP PubSub Command line parameters](#gcp-pubsub-command-line-parameters)
-        - [Multiple Topics Configuration File Syntax](#multiple-topics-configuration-file-syntax)
-- [Development](#development)
-
+      - [Multiple Topics Configuration File Syntax](#multiple-topics-configuration-file-syntax)
+  - [Development](#development)
 
 ## Deployment
 
@@ -78,18 +81,76 @@ make deploy-ap-on-k8s
 ## Command line parameters
 - `concurrency`: The number of concurrenct workers, default is 8.
 - `request-merge-policy`: Currently only supporting <u>random-robin</u> policy.
-- `message-queue-impl`: Implementation of the queueing system. Options are <u>gcp-pubsub</u> for GCP PubSub <u>redis-sortedset</u> for Redis Sorted Set (persisted and sorted) and  <u>redis-pubsub</u> for ephemeral Redis-based implementation.
-- `dispatch-gate`: Implementation of a dispatcher that is responsible for gating pulling messages from the queues. Options are :
-   - `noop`: The default. Represents full availability of the system. Always pulling messages.
-   - `metric-avg-queue-size`: Availability base on the model average queue size metric in Prometheus. If the queue size is non empty, messages will not be pulled from the respective queue.
-   - `redis`: Availability of the system is pulled periodically from Redis (I.e., managed by external system).
+- `message-queue-impl`: Implementation of the queueing system. Options are <u>gcp-pubsub</u> for GCP PubSub, <u>gcp-pubsub-gated</u> for GCP PubSub with per-topic gating, <u>redis-sortedset</u> for Redis Sorted Set (persisted and sorted), and <u>redis-pubsub</u> for ephemeral Redis-based implementation.
+
+ - `prometheus-url`: Prometheus server URL for metric-based gates (e.g., http://localhost:9090). For Google Managed Prometheus (GMP), point this to a local proxy or GMP frontend that handles authentication — direct GMP URLs are not supported as the Async Processor does not perform GMP authentication.  
+   This flag is required when using metric-based per-queue gates (e.g., `prometheus-saturation`).
 
 <i>additional parameters may be specified for concrete message queue implementations</i>
 
+## Dispatch Gates
 
-## Request Messages and Consusmption
+The Async Processor supports dispatch gates to control batch processing based on system capacity. Gates can be configured per-queue (via configuration files).
+
+### Per-Queue Dispatch Gates
+
+For more fine-grained control, configure gates per queue in your configuration file. Each queue can have its own gate type and parameters.
+
+**Gate Types:**
+
+- `constant`: Always returns budget 1.0 (fully open) - no throttling.
+- `redis`: Queries Redis for dispatch budget (managed by external system).
+- `prometheus-saturation`: Queries Prometheus for pool saturation metric. Returns 1.0 - saturation if below threshold, 0.0 otherwise.
+
+**Example Configuration with Per-Queue Gates:**
+
+```json
+[
+    {
+       "queue_name": "critical_queue",
+       "inference_objective": "critical-task",
+       "request_path_url": "/v1/inference",
+       "gate_type": "constant"
+    },
+    {
+       "queue_name": "batch_queue",
+       "inference_objective": "batch-task",
+       "request_path_url": "/v1/inference",
+       "gate_type": "prometheus-saturation",
+       "gate_params": {
+          "pool": "inference_pool_1",
+          "threshold": "0.8"
+       }
+    },
+    {
+       "queue_name": "redis_gated_queue",
+       "inference_objective": "gated-task",
+       "request_path_url": "/v1/inference",
+       "gate_type": "redis",
+       "gate_params": {
+          "address": "localhost:6379",
+          "budget_key": "my-budget-key"
+       }
+    }
+]
+```
+
+**Gate Parameters:**
+
+- `redis`:
+  - `address` (**required**): Redis server address for the dispatch gate (e.g., `localhost:6379`). Queues sharing the same address will share the same connection pool.
+  - `budget_key` (optional): Redis key to read dispatch budget from. Default is `dispatch-gate-budget`.
+
+- `prometheus-saturation`:
+  - `pool`: The inference pool name to query metrics for.
+  - `threshold`: Saturation threshold (0.0-1.0). When saturation >= threshold, budget is 0.0. Default is 0.8.
+  - `fallback`: Fallback saturation value (0.0-1.0) used when the metric source returns an error or empty data. Default is 0.0.
+  - `query`: Custom PromQL expression to query. If omitted, a default query using `inference_extension_flow_control_pool_saturation` with the `pool` label is used.
+
+## Request Messages and Consumption
 
 The async processor expects request messages to have the following format:
+
 ```json
 {
     "id" : "unique identifier for result mapping",
@@ -100,6 +161,7 @@ The async processor expects request messages to have the following format:
 ```
 
 Example:
+
 ```json
 {
     "id" : "19933123533434",
@@ -141,7 +203,6 @@ A persisted implementation based on Redis SortedSets.
 
 ![Async Processor - Redis Sorted Set architecture](/docs/images/redis_sortedset_architecture.png "AP - Redis SortedSet")
 
-
 #### Redis Sorted Set Command line parameters
 - `redis.ss.addr`: Address of the Redis server. Default is <u>localhost:6379</u>.
 - `redis.ss.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.ss.queues-config-file` flag.
@@ -152,6 +213,8 @@ A persisted implementation based on Redis SortedSets.
 - `redis.ss.queues-config-file`: The configuration file name when using multiple queues. <br> Mutually exclusive with `redis.ss.igw-base-url`, `redis.ss.request-queue-name`, `redis.ss.request-path-url` and `redis.ss.inference-objective` flags.
 - `redis.ss.poll-interval-ms`: Poll interval in milliseconds. Default is <u>1000</u>.
 - `redis.ss.batch-size`: Number of messages to process per poll. Default is <u>10</u>.
+- `redis.ss.gate-type`: Gate type for single-queue mode (e.g., `redis`, `prometheus-saturation`). Only used when `redis.ss.queues-config-file` is not set.
+- `redis.ss.gate-params`: JSON-encoded gate params map for single-queue mode (e.g., `{"address":"localhost:6379"}`). Only used when `redis.ss.queues-config-file` is not set.
 
 ### Redis Channels (Ephemeral)
 
@@ -182,19 +245,31 @@ An example implementation based on Redis channels is provided.
 
 The configuration file when using the `redis.queues-config-file` flag should have the following format:
 
-```json 
+```json
 [
     {
-       "queue_name": "some_channel_name", 
+       "queue_name": "some_queue_name",
        "igw_base_url": "http://localhost:30800",
-       "inference_objective": "some_inference_objective", 
-       "request_path_url": "e.g.: /v1/completions"
+       "inference_objective": "some_inference_objective",
+       "request_path_url": "/v1/completions"
     },
-    ...
+    {
+       "queue_name": "another_queue",
+       "igw_base_url": "http://localhost:30800",
+       "inference_objective": "batch_task",
+       "request_path_url": "/v1/inference"
+    }
 ]
 ```
 
+<u>Note:</u> The ephemeral Redis Channels implementation does not support per-queue dispatch gates. Use the [Redis Sorted Set](#redis-sorted-set-persisted) implementation for per-queue gating.
 
+**Configuration Fields:**
+
+- `queue_name`: The name of the Redis channel for this queue.
+- `igw_base_url`: Base URL of the IGW.
+- `inference_objective`: The inference objective header value.
+- `request_path_url`: The request path URL.
 
 ### GCP Pub/Sub
 
@@ -218,28 +293,49 @@ The GCP PubSub implementation requires the user to configure the following:
 - `pubsub.inference-objective`: InferenceObjective to use for requests (set as the HTTP header x-gateway-inference-objective if not empty). <br> Mutually exclusive with `pubsub.topics-config-file` flag.
 - `pubsub.request-subscriber-id`: The subscriber ID for the requests topic.<br> Mutually exclusive with `pubsub.topics-config-file` flag.
 - `pubsub.result-topic-id`: The results topic ID.
+- `pubsub.batch-size`: Number of inflight messages. Default is <u>10</u>.
 - `pubsub.topics-config-file`: The configuration file name when using multiple topics. <br> Mutually exclusive with `pubsub.request-subscriber-id`, `pubsub.request-path-url` and `pubsub.inference-objective` flags.
 
 #### Multiple Topics Configuration File Syntax
 
 The configuration file when using the `pubsub.topics-config-file` flag should have the following format:
 
-```json 
+```json
 [
     {
        "igw_base_url": "http://localhost:30800",
-       "subscriber_id": "some_subscriber_id", 
-       "inference_objective": "some_inference_objective", 
-       "request_path_url": "e.g.: /v1/completions"
+       "subscriber_id": "some_subscriber_id",
+       "inference_objective": "some_inference_objective",
+       "request_path_url": "e.g.: /v1/completions",
+       "gate_type": "constant",
+       "gate_params": {}
     },
-    ...
+    {
+       "subscriber_id": "another_subscriber",
+       "inference_objective": "batch_task",
+       "request_path_url": "/v1/inference",
+       "gate_type": "prometheus-saturation",
+       "gate_params": {
+           "pool": "pool_2",
+           "threshold": "0.75"
+       }
+    }
 ]
 ```
+
+**Configuration Fields:**
+
+- `subscriber_id`: The GCP PubSub subscriber ID for this topic.
+- `inference_objective`: The inference objective header value.
+- `request_path_url`: The request path URL.
+- `gate_type`: Required type of dispatch gate for this topic.
+- `gate_params` (optional): Parameters for the gate type (e.g., pool name, threshold for prometheus gates).
 
 ## Development
 
 A setup based on a KIND cluster with a Redis server for MQ is provided.
 In order to deploy everything run:
+
 ```bash
 make deploy-ap-emulated-on-kind
 ```
@@ -251,7 +347,7 @@ kubectl exec -n redis redis-master-0 -- redis-cli SUBSCRIBE result-queue
 ```
 
 Publish a message for async processing:
+
 ```bash
 kubectl exec -n redis redis-master-0 -- redis-cli PUBLISH request-queue '{"id" : "testmsg", "payload":{ "model":"unsloth/Meta-Llama-3.1-8B", "prompt":"hi"}, "deadline" :"9999999999" }'
 ```
-

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,6 @@ func main() {
 	var concurrency int
 	var requestMergePolicy string
 	var messageQueueImpl string
-	var dispatchGateType string
 
 	flag.IntVar(&loggerVerbosity, "v", logging.DEFAULT, "number for the log level verbosity")
 
@@ -43,8 +42,9 @@ func main() {
 	flag.IntVar(&concurrency, "concurrency", 8, "number of concurrent workers")
 
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
-	flag.StringVar(&dispatchGateType, "dispatch-gate", "noop", "The dispatch gate policy to use. Supported policies: noop, redis, metric-avg-queue-size, metric-saturation")
-	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, redis-sortedset-gated, gcp-pubsub, gcp-pubsub-gated")
+	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
+
+	var prometheusURL = flag.String("prometheus-url", "", "Prometheus server URL for metric-based gates (e.g., http://localhost:9090)")
 
 	opts := zap.Options{
 		Development: true,
@@ -62,23 +62,8 @@ func main() {
 	////////setupLog.Info("GIE build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
 
 	printAllFlags(setupLog)
-	// Create dispatch gate
-	var gate flowcontrol.DispatchGate
-	switch dispatchGateType {
-	case "noop":
-		gate = flowcontrol.ConstOpenGate()
-	case "redis":
-		gate = redis.NewRedisDispatchGate()
-		setupLog.Info("Using Redis-based dispatch gate")
-	case "metric-avg-queue-size":
-		gate = flowcontrol.AverageQueueSizeGate()
-	case "metric-saturation":
-		gate = flowcontrol.SaturationGate()
-		setupLog.Info("Using saturation metric dispatch gate")
-	default:
-		setupLog.Error(fmt.Errorf("unknown dispatch gate type: %s", dispatchGateType), "Unknown dispatch gate type", "dispatch-gate", dispatchGateType)
-		os.Exit(1)
-	}
+	// Create Gate Factory for per-queue gate instantiation
+	gateFactory := flowcontrol.NewGateFactory(*prometheusURL)
 
 	var policy api.RequestMergePolicy
 	switch requestMergePolicy {
@@ -94,17 +79,14 @@ func main() {
 	case "redis-pubsub":
 		impl = redis.NewRedisMQFlow()
 	case "redis-sortedset":
-		impl = redis.NewRedisSortedSetFlow()
-	case "redis-sortedset-gated":
-		impl = redis.NewRedisSortedSetFlow(redis.WithDispatchGate(gate))
-		setupLog.Info("Using Redis sorted-set flow with dispatch gating", "gate-type", dispatchGateType)
+		impl = redis.NewRedisSortedSetFlow(redis.WithGateFactory(gateFactory))
+		setupLog.Info("Using Redis sorted-set flow with per-queue gating")
 	case "gcp-pubsub":
 		impl = pubsub.NewGCPPubSubMQFlow()
 	case "gcp-pubsub-gated":
-		impl = pubsub.NewGCPPubSubMQFlow(pubsub.WithDispatchGate(gate))
-		setupLog.Info("Using GCP PubSub flow with dispatch gating", "gate-type", dispatchGateType)
+		impl = pubsub.NewGCPPubSubMQFlow(pubsub.WithGateFactory(gateFactory))
+		setupLog.Info("Using GCP PubSub flow with per-queue gating")
 	default:
-
 		setupLog.Error(fmt.Errorf("unknown message queue implementation: %s", messageQueueImpl), "Unknown message queue implementation",
 			"message-queue-impl", messageQueueImpl)
 		os.Exit(1)

--- a/pkg/async/api/api.go
+++ b/pkg/async/api/api.go
@@ -1,6 +1,8 @@
 package api
 
-import "context"
+import (
+	"context"
+)
 
 type Flow interface {
 
@@ -24,6 +26,35 @@ type Characteristics struct {
 	SupportsMessageLatency bool
 }
 
+// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
+type DispatchGate interface {
+	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
+	// the fraction of system capacity available for new requests.
+	// A value of 0.0 indicates no available capacity (system at max allowed).
+	// A value of 1.0 indicates full capacity available (system is idle).
+	// The system always returns a valid value, even in case of internal error.
+	Budget(ctx context.Context) float64
+}
+
+// GateFactory defines the interface for creating DispatchGate instances.
+type GateFactory interface {
+	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
+}
+
+// DispatchGateFunc is a function type that implements DispatchGate.
+// This allows any function with the signature func(context.Context) float64
+// to be used as a DispatchGate.
+type DispatchGateFunc func(context.Context) float64
+
+// Budget implements DispatchGate by calling the function itself.
+func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
+	return f(ctx)
+}
+
+func ConstOpenGate() DispatchGate {
+	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
+}
+
 type RequestMergePolicy interface {
 	MergeRequestChannels(channels []RequestChannel) EmbelishedRequestChannel
 }
@@ -44,6 +75,7 @@ type RequestChannel struct {
 	IGWBaseURl         string
 	InferenceObjective string
 	RequestPathURL     string
+	Gate               DispatchGate // Dispatch gate for this channel, nil defaults to always-open
 }
 
 type EmbelishedRequestChannel struct {

--- a/pkg/async/inference/flowcontrol/dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/dispatch_gate.go
@@ -16,18 +16,11 @@ limitations under the License.
 
 package flowcontrol
 
-import "context"
+import (
+	"context"
 
-// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
-type DispatchGate interface {
-	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
-	// the fraction of system capacity available for new requests.
-	// A value of 0.0 indicates no available capacity (system at max allowed).
-	// A value of 1.0 indicates full capacity available (system is idle).
-	// Implementations must always return a value in [0.0, 1.0], even in case
-	// of internal error.
-	Budget(ctx context.Context) float64
-}
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+)
 
 // DispatchGateFunc is a function type that implements DispatchGate.
 // This allows any function with the signature func(context.Context) float64
@@ -39,6 +32,6 @@ func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
 	return f(ctx)
 }
 
-func ConstOpenGate() DispatchGate {
+func ConstOpenGate() api.DispatchGate {
 	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
 }

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"fmt"
+	"strconv"
+
+	asyncapi "github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	redisgate "github.com/llm-d-incubation/llm-d-async/pkg/redis"
+	promapi "github.com/prometheus/client_golang/api"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// GateFactory creates DispatchGate instances based on configuration.
+type GateFactory struct {
+	prometheusURL string
+	redisClients  map[string]*goredis.Client
+}
+
+// NewGateFactory creates a new GateFactory with an optional Prometheus URL.
+// If prometheusURL is empty, Prometheus gates will fail at creation time.
+func NewGateFactory(prometheusURL string) *GateFactory {
+	return &GateFactory{
+		prometheusURL: prometheusURL,
+		redisClients:  make(map[string]*goredis.Client),
+	}
+}
+
+// CreateGate creates a DispatchGate based on the gate type and parameters.
+// Supported gate types:
+//   - "constant": Always returns budget 1.0 (fully open)
+//   - "redis": Queries Redis for dispatch budget
+//   - "prometheus-saturation": Queries Prometheus for pool saturation metric
+//     Optional params: threshold (default 0.8), fallback (default 0.0)
+//
+// For unsupported or unknown gate types, returns ConstOpenGate as a safe default.
+func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asyncapi.DispatchGate, error) {
+	switch gateType {
+	case "constant":
+		return ConstOpenGate(), nil
+
+	case "redis":
+		addr := params["address"]
+		if addr == "" {
+			return nil, fmt.Errorf("redis gate requires an 'address' in gate_params")
+		}
+		client, ok := f.redisClients[addr]
+		if !ok {
+			client = goredis.NewClient(&goredis.Options{Addr: addr})
+			f.redisClients[addr] = client
+		}
+		budgetKey := params["budget_key"]
+		if budgetKey == "" {
+			budgetKey = "dispatch-gate-budget"
+		}
+		return redisgate.NewRedisDispatchGate(client, budgetKey), nil
+
+	case "prometheus-saturation":
+		if f.prometheusURL == "" {
+			return nil, fmt.Errorf("prometheus-saturation gate type requires --prometheus-url flag to be set")
+		}
+
+		pool := params["pool"]
+
+		threshold := 0.8 // default threshold
+		if thresholdStr := params["threshold"]; thresholdStr != "" {
+			t, err := strconv.ParseFloat(thresholdStr, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid threshold value '%s': %w", thresholdStr, err)
+			}
+			threshold = t
+		}
+
+		fallback := 0.0 // default fallback saturation
+		if fallbackStr := params["fallback"]; fallbackStr != "" {
+			fb, err := strconv.ParseFloat(fallbackStr, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid fallback value '%s': %w", fallbackStr, err)
+			}
+			fallback = fb
+		}
+
+		queryExpr := params["query"]
+		if queryExpr == "" {
+			labels := map[string]string{}
+			if pool != "" {
+				labels["inference_pool"] = pool
+			}
+			queryExpr = buildPromQL("inference_extension_flow_control_pool_saturation", labels)
+		}
+
+		source, err := NewPromQLMetricSource(promapi.Config{Address: f.prometheusURL}, queryExpr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Prometheus metric source: %w", err)
+		}
+
+		return NewSaturationMetricDispatchGateWithSource(source, threshold, fallback), nil
+
+	default:
+		// Unknown gate types default to open gate
+		return ConstOpenGate(), nil
+	}
+}

--- a/pkg/async/inference/flowcontrol/gate_factory_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGateFactory_CreateConstantGate(t *testing.T) {
+	factory := NewGateFactory("")
+	gate, err := factory.CreateGate("constant", nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, gate)
+	budget := gate.Budget(context.Background())
+	assert.Equal(t, 1.0, budget, "constant gate should always return 1.0")
+}
+
+func TestGateFactory_UnknownGateType(t *testing.T) {
+	factory := NewGateFactory("")
+	gate, err := factory.CreateGate("unknown-type", nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, gate)
+	budget := gate.Budget(context.Background())
+	// Should fall back to ConstOpenGate
+	assert.Equal(t, 1.0, budget, "unknown gate type should default to ConstOpenGate")
+}
+
+func TestGateFactory_EmptyGateType(t *testing.T) {
+	factory := NewGateFactory("")
+	gate, err := factory.CreateGate("", nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, gate)
+	budget := gate.Budget(context.Background())
+	assert.Equal(t, 1.0, budget, "empty gate type should default to ConstOpenGate")
+}
+
+func TestGateFactory_PrometheusGateWithoutURL(t *testing.T) {
+	factory := NewGateFactory("") // No Prometheus URL
+	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{})
+	assert.Error(t, err, "should return error when Prometheus URL is not set")
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "prometheus-saturation gate type requires --prometheus-url flag to be set")
+}
+
+func TestGateFactory_PrometheusGateWithoutPoolParam(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{})
+	assert.NoError(t, err, "should not error when pool parameter is missing")
+	assert.NotNil(t, gate)
+}
+
+func TestGateFactory_PrometheusGateWithInvalidThreshold(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+		"threshold": "not-a-number",
+	})
+	assert.Error(t, err, "should return error when threshold is not a valid float")
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "invalid threshold value")
+}
+
+func TestGateFactory_PrometheusGateWithInvalidFallback(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+		"fallback": "not-a-number",
+	})
+	assert.Error(t, err, "should return error when fallback is not a valid float")
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "invalid fallback value")
+}
+
+func TestGateFactory_PrometheusGateWithThresholdAndFallback(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+		"threshold": "0.7",
+		"fallback":  "0.3",
+	})
+	assert.NoError(t, err, "should create gate when threshold and fallback are valid floats")
+	assert.NotNil(t, gate)
+}
+
+func TestGateFactory_RedisGateMissingAddress(t *testing.T) {
+	factory := NewGateFactory("")
+	gate, err := factory.CreateGate("redis", map[string]string{})
+	assert.Error(t, err, "should return error when address is missing")
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "redis gate requires an 'address' in gate_params")
+}
+
+func TestGateFactory_RedisGateNilParams(t *testing.T) {
+	factory := NewGateFactory("")
+	gate, err := factory.CreateGate("redis", nil)
+	assert.Error(t, err, "should return error when params is nil")
+	assert.Nil(t, gate)
+}
+
+func TestGateFactory_RedisGateSharesClient(t *testing.T) {
+	factory := NewGateFactory("")
+	params := map[string]string{"address": "localhost:6379"}
+	gate1, err1 := factory.CreateGate("redis", params)
+	gate2, err2 := factory.CreateGate("redis", params)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotNil(t, gate1)
+	assert.NotNil(t, gate2)
+	// Both gates should have been created from the same cached client
+	assert.Len(t, factory.redisClients, 1, "should reuse the same Redis client for the same address")
+}
+
+func TestGateFactory_RedisGateDifferentAddresses(t *testing.T) {
+	factory := NewGateFactory("")
+	gate1, err1 := factory.CreateGate("redis", map[string]string{"address": "host1:6379"})
+	gate2, err2 := factory.CreateGate("redis", map[string]string{"address": "host2:6379"})
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotNil(t, gate1)
+	assert.NotNil(t, gate2)
+	assert.Len(t, factory.redisClients, 2, "should create separate clients for different addresses")
+}

--- a/pkg/async/inference/flowcontrol/metric_source.go
+++ b/pkg/async/inference/flowcontrol/metric_source.go
@@ -65,6 +65,15 @@ func NewPromQLMetricSource(clientConfig api.Config, expr string) (*PromQLMetricS
 	}, nil
 }
 
+// NewPromQLMetricSourceWithURL creates a MetricSource with a simple URL (no auth).
+// Use this for standard Prometheus or when the URL includes authentication details.
+func NewPromQLMetricSourceWithURL(url string) (*PromQLMetricSource, error) {
+	if url == "" {
+		return nil, fmt.Errorf("prometheus URL cannot be empty")
+	}
+	return NewPromQLMetricSource(api.Config{Address: url}, "")
+}
+
 // NewGMPPromQLMetricSource creates a PromQL MetricSource for Google Managed Prometheus.
 func NewGMPPromQLMetricSource(projectID string, expr string) (*PromQLMetricSource, error) {
 	ctx := context.Background()

--- a/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate.go
@@ -96,6 +96,7 @@ func SaturationGate() *SaturationMetricDispatchGate {
 		if err != nil {
 			panic(err)
 		}
+		return NewSaturationMetricDispatchGateWithSource(source, *saturationThreshold, *saturationFallback)
 	} else {
 		var err error
 		source, err = NewPromQLMetricSource(api.Config{
@@ -104,7 +105,6 @@ func SaturationGate() *SaturationMetricDispatchGate {
 		if err != nil {
 			panic(err)
 		}
+		return NewSaturationMetricDispatchGateWithSource(source, *saturationThreshold, *saturationFallback)
 	}
-
-	return NewSaturationMetricDispatchGateWithSource(source, *saturationThreshold, *saturationFallback)
 }

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -12,7 +12,6 @@ import (
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
-	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,30 +36,35 @@ var (
 )
 
 type TopicConfig struct {
-	SubscriberID       string `json:"subscriber_id"`
-	InferenceObjective string `json:"inference_objective"`
-	RequestPathURL     string `json:"request_path_url"`
-	IGWBaseURl         string `json:"igw_base_url"`
+	SubscriberID       string            `json:"subscriber_id"`
+	InferenceObjective string            `json:"inference_objective"`
+	RequestPathURL     string            `json:"request_path_url"`
+	IGWBaseURl         string            `json:"igw_base_url"`
+	GateType           string            `json:"gate_type"`
+	GateParams         map[string]string `json:"gate_params,omitempty"`
 }
 type PubSubMQFlow struct {
 	resultTopicID   string
 	requestChannels []RequestChannelData
 	retryChannel    chan api.RetryMessage
 	resultChannel   chan api.ResultMessage
-	gate            flowcontrol.DispatchGate
+	gate            api.DispatchGate
+	gateFactory     api.GateFactory
 }
 type RequestChannelData struct {
 	requestChannel api.RequestChannel
 	subscriberID   string
+	gate           api.DispatchGate
 }
 
 // PubSubOption is a functional option for configuring PubSubMQFlow
 type PubSubOption func(*PubSubMQFlow)
 
-// WithDispatchGate enables dispatch gating with the provided gate.
-func WithDispatchGate(gate flowcontrol.DispatchGate) PubSubOption {
+// WithGateFactory sets a GateFactory for per-topic gate instantiation.
+// When set, gates are created per topic from config, overriding any global gate.
+func WithGateFactory(factory api.GateFactory) PubSubOption {
 	return func(p *PubSubMQFlow) {
-		p.gate = gate
+		p.gateFactory = factory
 	}
 }
 
@@ -86,35 +90,54 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 	} else {
 		configs = []TopicConfig{{SubscriberID: *requestSubscriberID, IGWBaseURl: *igwBaseURL, InferenceObjective: *inferenceObjective, RequestPathURL: *requestPathURL}}
 	}
+	p := &PubSubMQFlow{
+		resultTopicID:   *resultTopicID,
+		requestChannels: make([]RequestChannelData, 0, len(configs)),
+		retryChannel:    make(chan api.RetryMessage),
+		resultChannel:   make(chan api.ResultMessage),
+	}
 
-	var channels []RequestChannelData
+	// Apply functional options
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	// Create per-topic channels with gates
 	for _, cfg := range configs {
-		ch := make(chan api.RequestMessage)
+		// Determine gate for this topic
+		var gate api.DispatchGate
+		if p.gateFactory != nil && cfg.GateType != "" {
+			// Use factory to create per-topic gate
+			var err error
+			gate, err = p.gateFactory.CreateGate(cfg.GateType, cfg.GateParams)
+			if err != nil {
+				panic(fmt.Sprintf("failed to create gate for topic subscriber %q (gate_type=%q): %v", cfg.SubscriberID, cfg.GateType, err))
+			}
+		} else if p.gate != nil {
+			// Fall back to global gate if provided
+			gate = p.gate
+		} else {
+			// Default to always-open gate
+			gate = api.ConstOpenGate()
+		}
 
-		channels = append(channels, RequestChannelData{
+		ch := make(chan api.RequestMessage)
+		p.requestChannels = append(p.requestChannels, RequestChannelData{
 			requestChannel: api.RequestChannel{
 				Channel:            ch,
 				IGWBaseURl:         util.NormalizeBaseURL(cfg.IGWBaseURl),
 				InferenceObjective: cfg.InferenceObjective,
 				RequestPathURL:     util.NormalizeURLPath(cfg.RequestPathURL),
+				Gate:               gate,
 			},
 			subscriberID: cfg.SubscriberID,
+			gate:         gate,
 		})
 	}
 
-	p := &PubSubMQFlow{
-		resultTopicID:   *resultTopicID,
-		requestChannels: channels,
-		retryChannel:    make(chan api.RetryMessage),
-		resultChannel:   make(chan api.ResultMessage),
-	}
-
-	for _, opt := range opts {
-		opt(p)
-	}
-
+	// Set default gate if not already set
 	if p.gate == nil {
-		p.gate = flowcontrol.ConstOpenGate()
+		p.gate = api.ConstOpenGate()
 	}
 
 	return p
@@ -146,7 +169,7 @@ func (r *PubSubMQFlow) RequestChannels() []api.RequestChannel {
 
 func (r *PubSubMQFlow) Start(ctx context.Context) {
 	for _, channelData := range r.requestChannels {
-		go r.requestWorker(ctx, pubSubClient, channelData.subscriberID, channelData.requestChannel.Channel)
+		go r.requestWorker(ctx, pubSubClient, channelData.subscriberID, channelData.requestChannel.Channel, channelData.gate)
 	}
 	publisher := pubSubClient.Publisher(r.resultTopicID)
 	go resultWorker(ctx, publisher, r.resultChannel)
@@ -208,14 +231,14 @@ func addMsgToRetryQueue(ctx context.Context, retryChannel chan api.RetryMessage)
 
 }
 
-func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID string, ch chan api.RequestMessage) {
+func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID string, ch chan api.RequestMessage, gate api.DispatchGate) {
 	logger := log.FromContext(ctx)
 
 	sub := pubSubClient.Subscriber(subscriberID)
 
 	for {
 		receiveCtx, cancel := context.WithCancel(ctx)
-		budget := r.gate.Budget(ctx)
+		budget := gate.Budget(ctx)
 		go func() {
 			ticker := time.NewTicker(10 * time.Second)
 			defer ticker.Stop()
@@ -223,7 +246,7 @@ func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.C
 			for {
 				select {
 				case <-ticker.C:
-					if r.gate.Budget(ctx) != budget {
+					if gate.Budget(ctx) != budget {
 						cancel() // Trigger restart with different limit
 						return
 					}

--- a/pkg/redis/dispatch_gate.go
+++ b/pkg/redis/dispatch_gate.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"flag"
 	"strconv"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -10,9 +9,7 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
-var dispatchGateBudgetKey = flag.String("redis.dispatch-gate-budget-key", "dispatch-gate-budget", "Redis key for dispatch gate budget value")
-
-// RedisDispatchGate implements flowcontrol.DispatchGate by reading the budget
+// RedisDispatchGate implements api.DispatchGate by reading the budget
 // from a Redis key. This allows external systems to dynamically control
 // the dispatch rate. If the key does not exist or is invalid, it defaults
 // to full capacity (1.0).
@@ -22,12 +19,11 @@ type RedisDispatchGate struct {
 }
 
 // NewRedisDispatchGate creates a new RedisDispatchGate that reads budget
-// from the configured Redis key. It connects to the same Redis instance
-// as the sorted set flow (--redis.ss.addr).
-func NewRedisDispatchGate() *RedisDispatchGate {
+// from the given Redis client and budget key.
+func NewRedisDispatchGate(client *goredis.Client, budgetKey string) *RedisDispatchGate {
 	return &RedisDispatchGate{
-		rdb: goredis.NewClient(&goredis.Options{Addr: *ssRedisAddr}),
-		key: *dispatchGateBudgetKey,
+		rdb: client,
+		key: budgetKey,
 	}
 }
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
-	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
+
 	"github.com/redis/go-redis/v9"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -31,18 +31,35 @@ var (
 	ssQueuesConfigFile   = flag.String("redis.ss.queues-config-file", "", "Multiple queues config file")
 	ssPollIntervalMs     = flag.Int("redis.ss.poll-interval-ms", 1000, "Poll interval in milliseconds")
 	ssBatchSize          = flag.Int("redis.ss.batch-size", 10, "Number of messages to process per poll")
+	ssGateType           = flag.String("redis.ss.gate-type", "", "Gate type for single-queue mode (e.g. redis, prometheus-saturation)")
+	ssGateParamsJSON     = flag.String("redis.ss.gate-params", "{}", "JSON-encoded gate params map for single-queue mode")
 )
 
+// parseGateParams parses a JSON-encoded string (from --redis.ss.gate-params)
+// into a map[string]string for gate parameter configuration.
+// Used to pass gate parameters from CLI or YAML to the gate factory.
+func parseGateParams(s string) map[string]string {
+	m := map[string]string{}
+	if s == "" || s == "{}" {
+		return m
+	}
+	_ = json.Unmarshal([]byte(s), &m)
+	return m
+}
+
 type queueConfig struct {
-	QueueName          string `json:"queue_name"`
-	InferenceObjective string `json:"inference_objective"`
-	RequestPathURL     string `json:"request_path_url"`
-	IGWBaseURl         string `json:"igw_base_url"`
+	QueueName          string            `json:"queue_name"`
+	InferenceObjective string            `json:"inference_objective"`
+	RequestPathURL     string            `json:"request_path_url"`
+	IGWBaseURl         string            `json:"igw_base_url"`
+	GateType           string            `json:"gate_type"`
+	GateParams         map[string]string `json:"gate_params,omitempty"`
 }
 
 type requestChannelData struct {
 	channel   api.RequestChannel
 	queueName string
+	gate      api.DispatchGate
 }
 
 type RedisSortedSetFlow struct {
@@ -52,53 +69,74 @@ type RedisSortedSetFlow struct {
 	resultChannel   chan api.ResultMessage
 	pollInterval    time.Duration
 	batchSize       int
-	gate            flowcontrol.DispatchGate
+	gate            api.DispatchGate
+	gateFactory     api.GateFactory
 }
 
 // SortedSetOption is a functional option for configuring RedisSortedSetFlow
 type SortedSetOption func(*RedisSortedSetFlow)
 
-// WithDispatchGate enables dispatch gating with the provided gate.
-// When enabled, the flow checks the "dispatch budget" before processing messages
-// and scales the batch size proportionally to available capacity.
-// Default: always dispatch all.
-func WithDispatchGate(gate flowcontrol.DispatchGate) SortedSetOption {
+// WithGateFactory sets a GateFactory for per-queue gate instantiation.
+// When set, gates are created per queue from config, overriding any global gate.
+func WithGateFactory(factory api.GateFactory) SortedSetOption {
 	return func(r *RedisSortedSetFlow) {
-		r.gate = gate
+		r.gateFactory = factory
 	}
 }
 
 func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 	configs := loadQueueConfigs()
-	channels := make([]requestChannelData, 0, len(configs))
-
-	for _, cfg := range configs {
-		channels = append(channels, requestChannelData{
-			channel: api.RequestChannel{
-				Channel:            make(chan api.RequestMessage),
-				InferenceObjective: cfg.InferenceObjective,
-				RequestPathURL:     util.NormalizeURLPath(cfg.RequestPathURL),
-				IGWBaseURl:         util.NormalizeBaseURL(cfg.IGWBaseURl),
-			},
-			queueName: cfg.QueueName,
-		})
-	}
-
 	r := &RedisSortedSetFlow{
 		rdb:             redis.NewClient(&redis.Options{Addr: *ssRedisAddr}),
-		requestChannels: channels,
+		requestChannels: make([]requestChannelData, 0, len(configs)),
 		retryChannel:    make(chan api.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage),
 		pollInterval:    time.Duration(*ssPollIntervalMs) * time.Millisecond,
 		batchSize:       *ssBatchSize,
 	}
 
+	// Apply functional options
 	for _, opt := range opts {
 		opt(r)
 	}
 
+	// Create per-queue channels with gates
+	for _, cfg := range configs {
+		// Determine gate for this queue
+		var gate api.DispatchGate
+		if r.gateFactory != nil && cfg.GateType != "" {
+			// Use factory to create per-queue gate
+			var err error
+			gate, err = r.gateFactory.CreateGate(cfg.GateType, cfg.GateParams)
+			if err != nil {
+				panic(fmt.Sprintf("failed to create gate for queue %q (gate_type=%q): %v", cfg.QueueName, cfg.GateType, err))
+			}
+		} else if r.gate != nil {
+			// Fall back to global gate if provided
+			gate = r.gate
+		} else {
+			// Default to always-open gate
+			gate = api.ConstOpenGate()
+		}
+
+		ch := api.RequestChannel{
+			Channel:            make(chan api.RequestMessage),
+			InferenceObjective: cfg.InferenceObjective,
+			RequestPathURL:     util.NormalizeURLPath(cfg.RequestPathURL),
+			IGWBaseURl:         util.NormalizeBaseURL(cfg.IGWBaseURl),
+			Gate:               gate,
+		}
+
+		r.requestChannels = append(r.requestChannels, requestChannelData{
+			channel:   ch,
+			queueName: cfg.QueueName,
+			gate:      gate,
+		})
+	}
+
+	// Set default gate if not already set
 	if r.gate == nil {
-		r.gate = flowcontrol.ConstOpenGate()
+		r.gate = api.ConstOpenGate()
 	}
 
 	return r
@@ -112,15 +150,18 @@ func loadQueueConfigs() []queueConfig {
 		}
 		var configs []queueConfig
 		if err := json.Unmarshal(data, &configs); err != nil {
-			panic(fmt.Sprintf("failed to unmarshal config: %v", err))
+			panic(fmt.Sprintf("failed to unmarshal config file: %v", err))
 		}
 		return configs
 	}
+	// Single-queue mode
 	return []queueConfig{{
 		QueueName:          *ssRequestQueueName,
 		InferenceObjective: *ssInferenceObjective,
 		RequestPathURL:     *ssRequestPathURL,
 		IGWBaseURl:         *ssIGWBaseURL,
+		GateType:           *ssGateType,
+		GateParams:         parseGateParams(*ssGateParamsJSON),
 	}}
 }
 
@@ -158,20 +199,32 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 
+	// Find the gate for this queue
+	var gate api.DispatchGate
+	for _, ch := range r.requestChannels {
+		if ch.queueName == queueName {
+			gate = ch.gate
+			break
+		}
+	}
+	if gate == nil {
+		gate = r.gate
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			r.processMessages(ctx, msgChannel, queueName, logger)
+			r.processMessages(ctx, msgChannel, queueName, gate, logger)
 		}
 	}
 }
 
-func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan api.RequestMessage, queueName string, logger logr.Logger) {
+func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan api.RequestMessage, queueName string, gate api.DispatchGate, logger logr.Logger) {
 	currentTime := float64(time.Now().Unix())
 
-	budget := r.gate.Budget(ctx)
+	budget := gate.Budget(ctx)
 	batchSize := int(math.Floor(float64(r.batchSize) * budget))
 
 	for i := 0; i < batchSize; i++ {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -12,13 +12,12 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
-	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/redis/go-redis/v9"
 )
 
 // noopGate returns a gate that always returns full budget (1.0)
-func noopGate() flowcontrol.DispatchGate {
-	return flowcontrol.ConstOpenGate()
+func noopGate() api.DispatchGate {
+	return api.ConstOpenGate()
 }
 
 // Test helper to create test flow and Redis
@@ -435,7 +434,7 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 	var budgetValue atomic.Uint64 // Store as bits to represent float64
 
 	budgetValue.Store(math.Float64bits(0.0))
-	gate := flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+	gate := api.DispatchGateFunc(func(ctx context.Context) float64 {
 		return math.Float64frombits(budgetValue.Load())
 	})
 
@@ -499,7 +498,7 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 	queue := "partial-budget-queue"
 
 	// Gate with 30% budget - should process floor(10*0.3)=3 messages per cycle
-	gate := flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+	gate := api.DispatchGateFunc(func(ctx context.Context) float64 {
 		return 0.3
 	})
 
@@ -535,40 +534,5 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 	remaining, _ := rdb.ZCard(ctx, queue).Result()
 	if remaining != 7 {
 		t.Errorf("Expected 7 messages remaining with 30%% budget (3 pulled), got %d remaining", remaining)
-	}
-}
-
-func TestSortedSetFlow_WithDispatchGateOption(t *testing.T) {
-	s, rdb, ctx, cancel := setupTest(t)
-	defer s.Close()
-	defer rdb.Close() // nolint:errcheck
-	defer cancel()
-
-	queue := "option-test-queue"
-	origQueue := *ssRequestQueueName
-	*ssRequestQueueName = queue
-	defer func() { *ssRequestQueueName = origQueue }()
-
-	// Use WithDispatchGate option
-	gate := flowcontrol.ConstOpenGate()
-
-	flow := NewRedisSortedSetFlow(WithDispatchGate(gate))
-	flow.rdb = rdb
-	flow.pollInterval = 50 * time.Millisecond
-
-	flow.Start(ctx)
-
-	// Add message
-	msg := api.RequestMessage{Id: "option-test", CreatedUnixSec: strconv.FormatInt(time.Now().Unix(), 10), DeadlineUnixSec: "9999999999"}
-	msgBytes, _ := json.Marshal(msg)
-	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
-
-	select {
-	case received := <-flow.RequestChannels()[0].Channel:
-		if received.Id != "option-test" {
-			t.Errorf("Expected option-test, got %s", received.Id)
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Timeout waiting for message with WithDispatchGate option")
 	}
 }

--- a/test/e2e/yaml/async-processor-saturation.yaml
+++ b/test/e2e/yaml/async-processor-saturation.yaml
@@ -38,11 +38,10 @@ spec:
           image: ${AP_IMAGE}
           imagePullPolicy: Never
           args:
-            - "--message-queue-impl=redis-sortedset-gated"
-            - "--dispatch-gate=metric-saturation"
-            - "--gate.prometheus.url=http://prom-mock.e2e-test.svc.cluster.local:9090"
-            - "--gate.saturation.inference-pool=e2e-pool"
-            - "--gate.saturation.threshold=0.8"
+            - "--message-queue-impl=redis-sortedset"
+            - "--prometheus-url=http://prom-mock.e2e-test.svc.cluster.local:9090"
+            - "--redis.ss.gate-type=prometheus-saturation"
+            - "--redis.ss.gate-params={\"threshold\":\"0.8\"}"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
             - "--redis.ss.addr=redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"

--- a/test/e2e/yaml/async-processor.yaml
+++ b/test/e2e/yaml/async-processor.yaml
@@ -38,11 +38,11 @@ spec:
           image: ${AP_IMAGE}
           imagePullPolicy: Never
           args:
-            - "--message-queue-impl=redis-sortedset-gated"
-            - "--dispatch-gate=redis"
+            - "--message-queue-impl=redis-sortedset"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
             - "--redis.ss.addr=redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"
             - "--redis.ss.batch-size=10"
             - "--metrics-endpoint-auth=false"
             - "--concurrency=1"
+            - "--redis.ss.gate-type=redis"


### PR DESCRIPTION
Migrate to per-queue gating: remove global gate logic, update all code, tests, and documentation for GateFactory and per-queue DispatchGate support. Refactor Redis and PubSub flows, update YAMLs, and ensure all references to legacy gating are removed.

## What does this PR do?

This PR now fully migrates the Async Processor to a **Per-Queue/Per-Topic Gating** model via a new `GateFactory` abstraction. This addresses the core limitations of the previous global gating logic and resolves the import cycles mentioned in \#45.

### 🚀 Key Impact & Improvements

  * **Resource Efficiency (Shared Connections):** Refactored the `GateFactory` to manage a **shared Redis connection pool**. Multiple queues using the same Redis instance now share a single client, preventing connection leaks and reducing overhead.
  * **Decoupled Configuration:** Removed the dependency on global command-line flags for gating. Redis gates now pull their `address` and `budget_key` directly from the `GateConfigMap` (JSON config), allowing for different gates on different Redis instances.
  * **Robust Error Handling:** Replaced startup `panic()` calls with explicit `(gate, error)` returns in the `GateFactory`. Misconfigurations are now caught gracefully during the flow construction phase.
  * **Interface-Based DI:** Standardized on the `api.GateFactory` interface across both Redis and PubSub implementations, improving testability and allowing for easier mocking.
  * **Full Feature Parity:** Wired the `GateFactory` into both `redis-sortedset` and `gcp-pubsub-gated` flows in `cmd/main.go`.
  * **Documentation Accuracy:**  Updated the [README.md](https://github.com/crissepulveda-0/llm-d-async/blob/main/README.md) to reflect the changes made in this PR.

## Why is this change needed?

The previous global gating logic caused import cycles and limited flexibility. Moving to per-queue gating enables more granular control, eliminates import cycles, and aligns with modern async processing best practices. This change is required to support advanced use cases and simplify future maintenance.

## How was this tested?

  - [x] Unit tests added/updated
  - [x] Integration/e2e tests added/updated
  - [x] Manual testing performed

## Checklist

  - [x] Commits are signed off (`git commit -s`) per [[DCO](https://www.google.com/search?q=PR_SIGNOFF.md)](https://www.google.com/search?q=PR_SIGNOFF.md)
  - [x] Code follows project [[contributing guidelines](https://www.google.com/search?q=CONTRIBUTING.md)](https://www.google.com/search?q=CONTRIBUTING.md)
  - [x] Tests pass locally (`make test`)
  - [x] Linters pass (`make lint`)
  - [x] Documentation updated (if applicable)

## Related Issues

Fixes \#45