### PR TITLE
feat: PrometheusMetricSource changed into PromQLMetricSource 

### DIFF
--- a/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
@@ -34,26 +34,13 @@ var prometheusQueryModelName = flag.String("gate.prometheus.model-name", "", "me
 // It returns 0.0 (no capacity) if the metric value is non-zero,
 // and 1.0 (full capacity) if the metric value is zero.
 type BinaryMetricDispatchGate struct {
-	source     MetricSource
-	metricName string
-	labels     map[string]string
-}
-
-// NewBinaryMetricDispatchGate creates a new gate that queries Prometheus for the given metric.
-func NewBinaryMetricDispatchGate(clientConfig api.Config, metricName string, labels map[string]string) *BinaryMetricDispatchGate {
-	source, err := NewPrometheusMetricSource(clientConfig)
-	if err != nil {
-		panic(err)
-	}
-	return NewBinaryMetricDispatchGateWithSource(source, metricName, labels)
+	source MetricSource
 }
 
 // NewBinaryMetricDispatchGateWithSource creates a new gate using the provided MetricSource.
-func NewBinaryMetricDispatchGateWithSource(source MetricSource, metricName string, labels map[string]string) *BinaryMetricDispatchGate {
+func NewBinaryMetricDispatchGateWithSource(source MetricSource) *BinaryMetricDispatchGate {
 	return &BinaryMetricDispatchGate{
-		source:     source,
-		metricName: metricName,
-		labels:     labels,
+		source: source,
 	}
 }
 
@@ -61,7 +48,7 @@ func NewBinaryMetricDispatchGateWithSource(source MetricSource, metricName strin
 func (g *BinaryMetricDispatchGate) Budget(ctx context.Context) float64 {
 	logger := log.FromContext(ctx)
 
-	samples, err := g.source.Query(ctx, g.metricName, g.labels)
+	samples, err := g.source.Query(ctx)
 	if err != nil {
 		logger.V(logutil.DEFAULT).Info("MetricSource error, failing open", "error", err)
 		return 1.0
@@ -78,19 +65,27 @@ func (g *BinaryMetricDispatchGate) Budget(ctx context.Context) float64 {
 	return 0.0
 }
 
+// AverageQueueSizeGate creates a BinaryMetricDispatchGate from command-line flags.
 func AverageQueueSizeGate() *BinaryMetricDispatchGate {
-	metricName := "inference_pool_average_queue_size"
-	labels := map[string]string{"name": *prometheusQueryModelName}
+	expr := buildPromQL("inference_pool_average_queue_size",
+		map[string]string{"name": *prometheusQueryModelName})
 
+	var source MetricSource
 	if *isGMP {
-		source, err := NewGMPMetricSource(*gmpProjectID)
+		var err error
+		source, err = NewGMPPromQLMetricSource(*gmpProjectID, expr)
 		if err != nil {
 			panic(err)
 		}
-		return NewBinaryMetricDispatchGateWithSource(source, metricName, labels)
+	} else {
+		var err error
+		source, err = NewPromQLMetricSource(api.Config{
+			Address: *prometheusURL,
+		}, expr)
+		if err != nil {
+			panic(err)
+		}
 	}
 
-	return NewBinaryMetricDispatchGate(api.Config{
-		Address: *prometheusURL,
-	}, metricName, labels)
+	return NewBinaryMetricDispatchGateWithSource(source)
 }

--- a/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate_test.go
@@ -34,7 +34,7 @@ type mockMetricSource struct {
 	err     error
 }
 
-func (m *mockMetricSource) Query(_ context.Context, _ string, _ map[string]string) ([]Sample, error) {
+func (m *mockMetricSource) Query(_ context.Context) ([]Sample, error) {
 	return m.samples, m.err
 }
 
@@ -55,7 +55,9 @@ func TestBinaryMetricDispatchGate_MetricValueZero(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusOK, body)
 	defer server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", map[string]string{"name": "test"})
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, buildPromQL("test_metric", map[string]string{"name": "test"}))
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
 
@@ -64,7 +66,9 @@ func TestBinaryMetricDispatchGate_MetricValueNonZero(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusOK, body)
 	defer server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", map[string]string{"name": "test"})
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, buildPromQL("test_metric", map[string]string{"name": "test"}))
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
 
@@ -73,7 +77,9 @@ func TestBinaryMetricDispatchGate_EmptyVector(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusOK, body)
 	defer server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", nil)
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, "test_metric")
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
 
@@ -82,15 +88,20 @@ func TestBinaryMetricDispatchGate_ServerError(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusInternalServerError, body)
 	defer server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", nil)
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, "test_metric")
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
 
 func TestBinaryMetricDispatchGate_ServerUnreachable(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusOK, "")
+	serverURL := server.URL
 	server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", nil)
+	source, err := NewPromQLMetricSource(api.Config{Address: serverURL}, "test_metric")
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
 
@@ -100,7 +111,9 @@ func TestBinaryMetricDispatchGate_MultipleSamples(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusOK, body)
 	defer server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", nil)
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, "test_metric")
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
 
@@ -110,7 +123,9 @@ func TestBinaryMetricDispatchGate_MultipleSamplesFirstNonZero(t *testing.T) {
 	server := newTestPrometheusServer(http.StatusOK, body)
 	defer server.Close()
 
-	gate := NewBinaryMetricDispatchGate(api.Config{Address: server.URL}, "test_metric", nil)
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, "test_metric")
+	require.NoError(t, err)
+	gate := NewBinaryMetricDispatchGateWithSource(source)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
 
@@ -119,7 +134,6 @@ func TestBinaryMetricDispatchGate_MultipleSamplesFirstNonZero(t *testing.T) {
 func TestBinaryMetricDispatchGateWithSource_ZeroValue(t *testing.T) {
 	gate := NewBinaryMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.0}}},
-		"test_metric", nil,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -127,7 +141,6 @@ func TestBinaryMetricDispatchGateWithSource_ZeroValue(t *testing.T) {
 func TestBinaryMetricDispatchGateWithSource_NonZeroValue(t *testing.T) {
 	gate := NewBinaryMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 42.0}}},
-		"test_metric", nil,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -135,7 +148,6 @@ func TestBinaryMetricDispatchGateWithSource_NonZeroValue(t *testing.T) {
 func TestBinaryMetricDispatchGateWithSource_Error(t *testing.T) {
 	gate := NewBinaryMetricDispatchGateWithSource(
 		&mockMetricSource{err: errors.New("connection refused")},
-		"test_metric", nil,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -143,7 +155,6 @@ func TestBinaryMetricDispatchGateWithSource_Error(t *testing.T) {
 func TestBinaryMetricDispatchGateWithSource_EmptySamples(t *testing.T) {
 	gate := NewBinaryMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{}},
-		"test_metric", nil,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }

--- a/pkg/async/inference/flowcontrol/metric_source.go
+++ b/pkg/async/inference/flowcontrol/metric_source.go
@@ -39,29 +39,34 @@ type Sample struct {
 }
 
 // MetricSource queries a metrics backend for time-series data.
+// The query configuration is baked into the implementation at construction time;
+// callers simply invoke Query to retrieve the current samples.
 type MetricSource interface {
-	// Query returns the current samples for the given metric name and label matchers.
-	Query(ctx context.Context, metricName string, labels map[string]string) ([]Sample, error)
+	// Query returns the current samples for the preconfigured query.
+	Query(ctx context.Context) ([]Sample, error)
 }
 
-// PrometheusMetricSource implements MetricSource by querying a Prometheus-compatible API.
-type PrometheusMetricSource struct {
-	api v1.API
+// PromQLMetricSource implements MetricSource by executing a PromQL expression
+// against a Prometheus-compatible API.
+type PromQLMetricSource struct {
+	api  v1.API
+	expr string
 }
 
-// NewPrometheusMetricSource creates a MetricSource backed by a Prometheus-compatible API.
-func NewPrometheusMetricSource(clientConfig api.Config) (*PrometheusMetricSource, error) {
+// NewPromQLMetricSource creates a MetricSource that executes the given PromQL expression.
+func NewPromQLMetricSource(clientConfig api.Config, expr string) (*PromQLMetricSource, error) {
 	client, err := api.NewClient(clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Prometheus API client: %w", err)
 	}
-	return &PrometheusMetricSource{
-		api: v1.NewAPI(client),
+	return &PromQLMetricSource{
+		api:  v1.NewAPI(client),
+		expr: expr,
 	}, nil
 }
 
-// NewGMPMetricSource creates a MetricSource for Google Managed Prometheus.
-func NewGMPMetricSource(projectID string) (*PrometheusMetricSource, error) {
+// NewGMPPromQLMetricSource creates a PromQL MetricSource for Google Managed Prometheus.
+func NewGMPPromQLMetricSource(projectID string, expr string) (*PromQLMetricSource, error) {
 	ctx := context.Background()
 	gcpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/monitoring.read")
 	if err != nil {
@@ -69,10 +74,10 @@ func NewGMPMetricSource(projectID string) (*PrometheusMetricSource, error) {
 	}
 
 	promURL := fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus", projectID)
-	return NewPrometheusMetricSource(api.Config{
+	return NewPromQLMetricSource(api.Config{
 		Address:      promURL,
 		RoundTripper: gcpClient.Transport,
-	})
+	}, expr)
 }
 
 // buildPromQL constructs a PromQL instant vector selector from a metric name and label matchers.
@@ -95,13 +100,11 @@ func buildPromQL(metricName string, labels map[string]string) string {
 	return fmt.Sprintf(`%s{%s}`, metricName, strings.Join(parts, ","))
 }
 
-// Query executes a PromQL instant query and returns the result as samples.
-func (s *PrometheusMetricSource) Query(ctx context.Context, metricName string, labels map[string]string) ([]Sample, error) {
-	query := buildPromQL(metricName, labels)
-
+// Query executes the preconfigured PromQL expression and returns the result as samples.
+func (s *PromQLMetricSource) Query(ctx context.Context) ([]Sample, error) {
 	logger := log.FromContext(ctx)
 
-	result, warnings, err := s.api.Query(ctx, query, time.Now())
+	result, warnings, err := s.api.Query(ctx, s.expr, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error querying Prometheus: %w", err)
 	}

--- a/pkg/async/inference/flowcontrol/metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/metric_source_test.go
@@ -45,16 +45,16 @@ func TestBuildPromQL_MultipleLabels(t *testing.T) {
 	require.Equal(t, `my_metric{app="bar",name="foo"}`, buildPromQL("my_metric", map[string]string{"name": "foo", "app": "bar"}))
 }
 
-// PrometheusMetricSource.Query tests
+// PromQLMetricSource.Query tests
 
-func newTestSource(t *testing.T, statusCode int, responseBody string) (*PrometheusMetricSource, *httptest.Server) {
+func newTestSource(t *testing.T, statusCode int, responseBody string, expr string) (*PromQLMetricSource, *httptest.Server) {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 		_, _ = fmt.Fprint(w, responseBody)
 	}))
-	source, err := NewPrometheusMetricSource(api.Config{Address: server.URL})
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, expr)
 	if err != nil {
 		server.Close()
 	}
@@ -62,12 +62,12 @@ func newTestSource(t *testing.T, statusCode int, responseBody string) (*Promethe
 	return source, server
 }
 
-func TestPrometheusMetricSource_SingleSample(t *testing.T) {
+func TestPromQLMetricSource_SingleSample(t *testing.T) {
 	body := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"my_metric","name":"foo"},"value":[1234567890,"42.5"]}]}}`
-	source, server := newTestSource(t, http.StatusOK, body)
+	source, server := newTestSource(t, http.StatusOK, body, buildPromQL("my_metric", map[string]string{"name": "foo"}))
 	defer server.Close()
 
-	samples, err := source.Query(context.Background(), "my_metric", map[string]string{"name": "foo"})
+	samples, err := source.Query(context.Background())
 	require.NoError(t, err)
 	require.Len(t, samples, 1)
 	require.Equal(t, 42.5, samples[0].Value)
@@ -75,15 +75,15 @@ func TestPrometheusMetricSource_SingleSample(t *testing.T) {
 	require.Equal(t, "my_metric", samples[0].Labels["__name__"])
 }
 
-func TestPrometheusMetricSource_MultipleSamples(t *testing.T) {
+func TestPromQLMetricSource_MultipleSamples(t *testing.T) {
 	body := `{"status":"success","data":{"resultType":"vector","result":[` +
 		`{"metric":{"name":"a"},"value":[1234567890,"1"]},` +
 		`{"metric":{"name":"b"},"value":[1234567890,"2"]},` +
 		`{"metric":{"name":"c"},"value":[1234567890,"3"]}]}}`
-	source, server := newTestSource(t, http.StatusOK, body)
+	source, server := newTestSource(t, http.StatusOK, body, "my_metric")
 	defer server.Close()
 
-	samples, err := source.Query(context.Background(), "my_metric", nil)
+	samples, err := source.Query(context.Background())
 	require.NoError(t, err)
 	require.Len(t, samples, 3)
 	for i, expected := range []struct {
@@ -95,34 +95,34 @@ func TestPrometheusMetricSource_MultipleSamples(t *testing.T) {
 	}
 }
 
-func TestPrometheusMetricSource_EmptyVector(t *testing.T) {
+func TestPromQLMetricSource_EmptyVector(t *testing.T) {
 	body := `{"status":"success","data":{"resultType":"vector","result":[]}}`
-	source, server := newTestSource(t, http.StatusOK, body)
+	source, server := newTestSource(t, http.StatusOK, body, "my_metric")
 	defer server.Close()
 
-	samples, err := source.Query(context.Background(), "my_metric", nil)
+	samples, err := source.Query(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, samples)
 }
 
-func TestPrometheusMetricSource_ServerError(t *testing.T) {
+func TestPromQLMetricSource_ServerError(t *testing.T) {
 	body := `{"status":"error","errorType":"internal","error":"something went wrong"}`
-	source, server := newTestSource(t, http.StatusInternalServerError, body)
+	source, server := newTestSource(t, http.StatusInternalServerError, body, "my_metric")
 	defer server.Close()
 
-	_, err := source.Query(context.Background(), "my_metric", nil)
+	_, err := source.Query(context.Background())
 	require.Error(t, err)
 }
 
-func TestPrometheusMetricSource_ServerUnreachable(t *testing.T) {
-	source, server := newTestSource(t, http.StatusOK, "")
+func TestPromQLMetricSource_ServerUnreachable(t *testing.T) {
+	source, server := newTestSource(t, http.StatusOK, "", "my_metric")
 	server.Close()
 
-	_, err := source.Query(context.Background(), "my_metric", nil)
+	_, err := source.Query(context.Background())
 	require.Error(t, err)
 }
 
-func TestPrometheusMetricSource_QueryPassthrough(t *testing.T) {
+func TestPromQLMetricSource_QueryPassthrough(t *testing.T) {
 	var receivedQuery string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedQuery = r.FormValue("query")
@@ -131,15 +131,34 @@ func TestPrometheusMetricSource_QueryPassthrough(t *testing.T) {
 	}))
 	defer server.Close()
 
-	source, err := NewPrometheusMetricSource(api.Config{Address: server.URL})
+	expr := buildPromQL("inference_pool_average_queue_size", map[string]string{"name": "my-model"})
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, expr)
 	require.NoError(t, err)
 
-	_, err = source.Query(context.Background(), "inference_pool_average_queue_size", map[string]string{"name": "my-model"})
+	_, err = source.Query(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, `inference_pool_average_queue_size{name="my-model"}`, receivedQuery)
 }
 
-func TestNewPrometheusMetricSource_InvalidAddress(t *testing.T) {
-	_, err := NewPrometheusMetricSource(api.Config{Address: "://invalid"})
+func TestPromQLMetricSource_CustomExprPassthrough(t *testing.T) {
+	var receivedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	}))
+	defer server.Close()
+
+	expr := `max(avg_over_time(inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}[5m]))`
+	source, err := NewPromQLMetricSource(api.Config{Address: server.URL}, expr)
+	require.NoError(t, err)
+
+	_, err = source.Query(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expr, receivedQuery)
+}
+
+func TestNewPromQLMetricSource_InvalidAddress(t *testing.T) {
+	_, err := NewPromQLMetricSource(api.Config{Address: "://invalid"}, "my_metric")
 	require.Error(t, err)
 }

--- a/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate.go
@@ -29,39 +29,27 @@ import (
 var saturationInferencePool = flag.String("gate.saturation.inference-pool", "", "inference pool name for saturation metric")
 var saturationThreshold = flag.Float64("gate.saturation.threshold", 0.8, "saturation threshold above which budget is zero")
 var saturationFallback = flag.Float64("gate.saturation.fallback", 0.0, "fallback saturation value on error/missing metrics; default 0.0")
+var saturationQueryExpr = flag.String("gate.saturation.query-expr", "", "custom PromQL expression for saturation metric; overrides inference-pool label selector")
 
 // SaturationMetricDispatchGate implements DispatchGate based on pool saturation.
-// It reads the inference_extension_flow_control_pool_saturation metric and
-// returns 0.0 if saturation is at or above the configured threshold,
-// otherwise returns 1 - saturation, clamped to [0.0, 1.0].
+// It queries a MetricSource for saturation samples and returns 0.0 if saturation
+// is at or above the configured threshold, otherwise returns max(0, 1 - saturation),
+// clamped to [0.0, 1.0].
 //
 // On error or missing/invalid data, the gate returns the configured fallback
 // budget (derived from the fallback saturation value, also clamped to [0.0, 1.0]).
 type SaturationMetricDispatchGate struct {
-	source     MetricSource
-	metricName string
-	labels     map[string]string
-	threshold  float64
-	fallback   float64
-}
-
-// NewSaturationMetricDispatchGate creates a new gate that queries Prometheus for the pool saturation metric.
-func NewSaturationMetricDispatchGate(clientConfig api.Config, inferencePool string, threshold float64, fallback float64) *SaturationMetricDispatchGate {
-	source, err := NewPrometheusMetricSource(clientConfig)
-	if err != nil {
-		panic(err)
-	}
-	return NewSaturationMetricDispatchGateWithSource(source, inferencePool, threshold, fallback)
+	source    MetricSource
+	threshold float64
+	fallback  float64
 }
 
 // NewSaturationMetricDispatchGateWithSource creates a new gate using the provided MetricSource.
-func NewSaturationMetricDispatchGateWithSource(source MetricSource, inferencePool string, threshold float64, fallback float64) *SaturationMetricDispatchGate {
+func NewSaturationMetricDispatchGateWithSource(source MetricSource, threshold float64, fallback float64) *SaturationMetricDispatchGate {
 	return &SaturationMetricDispatchGate{
-		source:     source,
-		metricName: "inference_extension_flow_control_pool_saturation",
-		labels:     map[string]string{"inference_pool": inferencePool},
-		threshold:  threshold,
-		fallback:   math.Max(0.0, math.Min(1.0, 1.0-fallback)), // fallback is a saturation value; budget is clamped to [0,1]
+		source:    source,
+		threshold: threshold,
+		fallback:  math.Max(0.0, math.Min(1.0, 1.0-fallback)), // fallback is a saturation value; budget is clamped to [0,1]
 	}
 }
 
@@ -71,7 +59,7 @@ func NewSaturationMetricDispatchGateWithSource(source MetricSource, inferencePoo
 func (g *SaturationMetricDispatchGate) Budget(ctx context.Context) float64 {
 	logger := log.FromContext(ctx)
 
-	samples, err := g.source.Query(ctx, g.metricName, g.labels)
+	samples, err := g.source.Query(ctx)
 	if err != nil {
 		logger.V(logutil.DEFAULT).Info("MetricSource error, using fallback value", "fallback", g.fallback, "error", err)
 		return g.fallback
@@ -95,15 +83,28 @@ func (g *SaturationMetricDispatchGate) Budget(ctx context.Context) float64 {
 
 // SaturationGate creates a SaturationMetricDispatchGate from command-line flags.
 func SaturationGate() *SaturationMetricDispatchGate {
+	expr := buildPromQL("inference_extension_flow_control_pool_saturation",
+		map[string]string{"inference_pool": *saturationInferencePool})
+	if *saturationQueryExpr != "" {
+		expr = *saturationQueryExpr
+	}
+
+	var source MetricSource
 	if *isGMP {
-		source, err := NewGMPMetricSource(*gmpProjectID)
+		var err error
+		source, err = NewGMPPromQLMetricSource(*gmpProjectID, expr)
 		if err != nil {
 			panic(err)
 		}
-		return NewSaturationMetricDispatchGateWithSource(source, *saturationInferencePool, *saturationThreshold, *saturationFallback)
+	} else {
+		var err error
+		source, err = NewPromQLMetricSource(api.Config{
+			Address: *prometheusURL,
+		}, expr)
+		if err != nil {
+			panic(err)
+		}
 	}
 
-	return NewSaturationMetricDispatchGate(api.Config{
-		Address: *prometheusURL,
-	}, *saturationInferencePool, *saturationThreshold, *saturationFallback)
+	return NewSaturationMetricDispatchGateWithSource(source, *saturationThreshold, *saturationFallback)
 }

--- a/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate_test.go
@@ -28,7 +28,7 @@ import (
 func TestSaturationMetricDispatchGate_ZeroSaturation(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.0}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -36,7 +36,7 @@ func TestSaturationMetricDispatchGate_ZeroSaturation(t *testing.T) {
 func TestSaturationMetricDispatchGate_PartialSaturation(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.3}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.InDelta(t, 0.7, gate.Budget(context.Background()), 1e-9)
 }
@@ -44,7 +44,7 @@ func TestSaturationMetricDispatchGate_PartialSaturation(t *testing.T) {
 func TestSaturationMetricDispatchGate_AtThreshold(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.8}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -52,7 +52,7 @@ func TestSaturationMetricDispatchGate_AtThreshold(t *testing.T) {
 func TestSaturationMetricDispatchGate_AboveThreshold(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.95}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -60,7 +60,7 @@ func TestSaturationMetricDispatchGate_AboveThreshold(t *testing.T) {
 func TestSaturationMetricDispatchGate_FullSaturation(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 1.0}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -68,7 +68,7 @@ func TestSaturationMetricDispatchGate_FullSaturation(t *testing.T) {
 func TestSaturationMetricDispatchGate_JustBelowThreshold(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.79}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.InDelta(t, 0.21, gate.Budget(context.Background()), 1e-9)
 }
@@ -76,7 +76,7 @@ func TestSaturationMetricDispatchGate_JustBelowThreshold(t *testing.T) {
 func TestSaturationMetricDispatchGate_Error(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{err: errors.New("connection refused")},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -84,7 +84,7 @@ func TestSaturationMetricDispatchGate_Error(t *testing.T) {
 func TestSaturationMetricDispatchGate_EmptySamples(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -92,7 +92,7 @@ func TestSaturationMetricDispatchGate_EmptySamples(t *testing.T) {
 func TestSaturationMetricDispatchGate_ThresholdOne(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 0.99}}},
-		"my-pool", 1.0, 1.0,
+		1.0, 1.0,
 	)
 	require.InDelta(t, 0.01, gate.Budget(context.Background()), 1e-9)
 }
@@ -100,7 +100,7 @@ func TestSaturationMetricDispatchGate_ThresholdOne(t *testing.T) {
 func TestSaturationMetricDispatchGate_Error_FailOpen(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{err: errors.New("connection refused")},
-		"my-pool", 0.8, 0.0,
+		0.8, 0.0,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -108,7 +108,7 @@ func TestSaturationMetricDispatchGate_Error_FailOpen(t *testing.T) {
 func TestSaturationMetricDispatchGate_EmptySamples_FailOpen(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{}},
-		"my-pool", 0.8, 0.0,
+		0.8, 0.0,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -116,7 +116,7 @@ func TestSaturationMetricDispatchGate_EmptySamples_FailOpen(t *testing.T) {
 func TestSaturationMetricDispatchGate_NaN_FailOpen(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: math.NaN()}}},
-		"my-pool", 0.8, 0.0,
+		0.8, 0.0,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -124,7 +124,7 @@ func TestSaturationMetricDispatchGate_NaN_FailOpen(t *testing.T) {
 func TestSaturationMetricDispatchGate_Inf_FailOpen(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: math.Inf(1)}}},
-		"my-pool", 0.8, 0.0,
+		0.8, 0.0,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
@@ -132,7 +132,7 @@ func TestSaturationMetricDispatchGate_Inf_FailOpen(t *testing.T) {
 func TestSaturationMetricDispatchGate_NaN_FailClosed(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: math.NaN()}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -140,7 +140,7 @@ func TestSaturationMetricDispatchGate_NaN_FailClosed(t *testing.T) {
 func TestSaturationMetricDispatchGate_Inf_FailClosed(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: math.Inf(1)}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -148,7 +148,7 @@ func TestSaturationMetricDispatchGate_Inf_FailClosed(t *testing.T) {
 func TestSaturationMetricDispatchGate_SaturationAboveOne_AboveThreshold(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 1.5}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -156,7 +156,7 @@ func TestSaturationMetricDispatchGate_SaturationAboveOne_AboveThreshold(t *testi
 func TestSaturationMetricDispatchGate_SaturationAboveOne_HighThreshold(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: 1.5}}},
-		"my-pool", 2.0, 1.0,
+		2.0, 1.0,
 	)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
 }
@@ -164,7 +164,7 @@ func TestSaturationMetricDispatchGate_SaturationAboveOne_HighThreshold(t *testin
 func TestSaturationMetricDispatchGate_NegativeSaturation(t *testing.T) {
 	gate := NewSaturationMetricDispatchGateWithSource(
 		&mockMetricSource{samples: []Sample{{Value: -0.5}}},
-		"my-pool", 0.8, 1.0,
+		0.8, 1.0,
 	)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }


### PR DESCRIPTION
## What does this PR do?

improves the MetricSource introduced in #60 addressing the suggestion in #68:

> MetricSource: Support other type of queries (e.g. aggregates)
>> The MetricSource interface and Query signature would also need to support aggregating metrics to allow max(metric_name{...}) and a smoothing function like avg_over_time(metric_name{...}[5m]) so we can produce more stable gating decisions

notice now each metric source takes exactly one query. However, a DispatchGate may be provided with several MetricSources (if the implementor decides so), each corresponding to a different metric, and takes decisions itself.

## Why is this change needed?

improves the MetricSource interface and the corresponding Prometheus implementation for added flexibility

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

related to #68 