### PR TITLE
fix: configure HTTP connection pool and add per-request timeouts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d-incubation/llm-d-async/internal/logging"
@@ -32,6 +33,7 @@ func main() {
 	var metricsEndpointAuth bool
 
 	var concurrency int
+	var requestTimeout time.Duration
 	var requestMergePolicy string
 	var messageQueueImpl string
 
@@ -41,6 +43,7 @@ func main() {
 	flag.BoolVar(&metricsEndpointAuth, "metrics-endpoint-auth", true, "Enables authentication and authorization of the metrics endpoint")
 
 	flag.IntVar(&concurrency, "concurrency", 8, "number of concurrent workers")
+	flag.DurationVar(&requestTimeout, "request-timeout", 3*time.Minute, "timeout for individual inference requests")
 
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
 	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
@@ -113,18 +116,23 @@ func main() {
 		}(),
 	}
 	restConfig := ctrl.GetConfigOrDie()
-	httpClient := http.DefaultClient
 
-	msrv, _ := metricsserver.NewServer(metricsServerOptions, restConfig, httpClient)
+	msrv, _ := metricsserver.NewServer(metricsServerOptions, restConfig, http.DefaultClient)
 	go msrv.Start(ctx) // nolint:errcheck
 
-	// Create inference client
-	inferenceClient := api.NewHTTPInferenceClient(httpClient)
+	// Create inference client with a connection pool sized for the worker count.
+	inferenceTransport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: concurrency,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	inferenceHTTPClient := &http.Client{Transport: inferenceTransport}
+	inferenceClient := api.NewHTTPInferenceClient(inferenceHTTPClient)
 
 	requestChannel := policy.MergeRequestChannels(impl.RequestChannels()).Channel
 	for w := 1; w <= concurrency; w++ {
 
-		go api.Worker(ctx, impl.Characteristics(), inferenceClient, requestChannel, impl.RetryChannel(), impl.ResultChannel())
+		go api.Worker(ctx, impl.Characteristics(), inferenceClient, requestChannel, impl.RetryChannel(), impl.ResultChannel(), requestTimeout)
 	}
 
 	impl.Start(ctx)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,7 +43,7 @@ func main() {
 	flag.BoolVar(&metricsEndpointAuth, "metrics-endpoint-auth", true, "Enables authentication and authorization of the metrics endpoint")
 
 	flag.IntVar(&concurrency, "concurrency", 8, "number of concurrent workers")
-	flag.DurationVar(&requestTimeout, "request-timeout", 3*time.Minute, "timeout for individual inference requests")
+	flag.DurationVar(&requestTimeout, "request-timeout", 5*time.Minute, "timeout for individual inference requests")
 
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
 	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")

--- a/pkg/async/api/worker.go
+++ b/pkg/async/api/worker.go
@@ -18,7 +18,7 @@ import (
 var baseDelaySeconds = 2
 
 func Worker(ctx context.Context, characteristics Characteristics, client InferenceClient, requestChannel chan EmbelishedRequestMessage,
-	retryChannel chan RetryMessage, resultChannel chan ResultMessage) {
+	retryChannel chan RetryMessage, resultChannel chan ResultMessage, requestTimeout time.Duration) {
 
 	logger := log.FromContext(ctx)
 	for {
@@ -38,8 +38,19 @@ func Worker(ctx context.Context, characteristics Characteristics, client Inferen
 
 			// Using a function object for easy boundaries for 'return' and 'defer'!
 			sendInferenceRequest := func() {
+				// Create a per-request context bounded by both the message deadline
+				// and the configured request timeout, whichever comes first.
+				reqDeadline := time.Now().Add(requestTimeout)
+				if deadline, err := strconv.ParseInt(msg.DeadlineUnixSec, 10, 64); err == nil {
+					if msgDeadline := time.Unix(deadline, 0); msgDeadline.Before(reqDeadline) {
+						reqDeadline = msgDeadline
+					}
+				}
+				reqCtx, cancel := context.WithDeadline(ctx, reqDeadline)
+				defer cancel()
+
 				logger.V(logutil.DEBUG).Info("Sending inference request: " + msg.RequestURL)
-				responseBody, err := client.SendRequest(ctx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
+				responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
 
 				if err == nil {
 					// Success - got a valid response

--- a/pkg/async/api/worker_test.go
+++ b/pkg/async/api/worker_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const defaultRequestTimeout = 5 * time.Minute
+
 func TestRetryMessage_deadlinePassed(t *testing.T) {
 	retryChannel := make(chan RetryMessage, 1)
 	resultChannel := make(chan ResultMessage, 1)
@@ -102,7 +104,7 @@ func TestSheddedRequest(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- EmbelishedRequestMessage{
@@ -143,7 +145,7 @@ func TestSuccessfulRequest(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -182,7 +184,7 @@ func TestFatalError_NoRetry(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -233,7 +235,7 @@ func TestRateLimitRequest(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- EmbelishedRequestMessage{
@@ -319,7 +321,7 @@ func TestClientError_NoRetry(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- EmbelishedRequestMessage{

--- a/pkg/async/api/worker_test.go
+++ b/pkg/async/api/worker_test.go
@@ -102,7 +102,7 @@ func TestSheddedRequest(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- EmbelishedRequestMessage{
@@ -143,7 +143,7 @@ func TestSuccessfulRequest(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -182,7 +182,7 @@ func TestFatalError_NoRetry(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -233,7 +233,7 @@ func TestRateLimitRequest(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- EmbelishedRequestMessage{
@@ -260,6 +260,49 @@ func TestRateLimitRequest(t *testing.T) {
 	}
 }
 
+func TestRequestTimeout(t *testing.T) {
+	msgId := "timeout-test"
+	// Simulate a slow server that blocks longer than the request timeout.
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan EmbelishedRequestMessage, 1)
+	retryChannel := make(chan RetryMessage, 1)
+	resultChannel := make(chan ResultMessage, 1)
+	ctx := context.Background()
+
+	// Use a very short request timeout to trigger the deadline.
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond)
+	deadline := time.Now().Add(time.Second * 100).Unix()
+
+	requestChannel <- EmbelishedRequestMessage{
+		RequestMessage: RequestMessage{
+			Id:              msgId,
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", deadline),
+			Payload:         map[string]any{"model": "test", "prompt": "hi"},
+		},
+		RequestURL:  "http://localhost:30800/v1/completions",
+		HttpHeaders: map[string]string{},
+	}
+
+	select {
+	case r := <-resultChannel:
+		// The request should fail due to context deadline exceeded (fatal unknown error).
+		if r.Id != msgId {
+			t.Errorf("Expected result message id to be %s, got %s", msgId, r.Id)
+		}
+	case <-retryChannel:
+		// Context cancellation errors are wrapped as ErrCategoryUnknown (fatal), so no retry.
+		t.Errorf("Timed-out request should not be retried")
+	case <-time.After(5 * time.Second):
+		t.Errorf("Worker did not return within 5s — per-request timeout was not enforced")
+	}
+}
+
 func TestClientError_NoRetry(t *testing.T) {
 	msgId := "101112"
 	errorBody := `{"error": "invalid request"}`
@@ -276,7 +319,7 @@ func TestClientError_NoRetry(t *testing.T) {
 	resultChannel := make(chan ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel)
+	go Worker(ctx, Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 3*time.Minute)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- EmbelishedRequestMessage{


### PR DESCRIPTION
## Why is this PR needed?

The inference HTTP client uses `http.DefaultClient`, which has two problems:

1. **Connection pool too small** ([#97](https://github.com/llm-d-incubation/llm-d-async/issues/97)): `MaxIdleConnsPerHost` defaults to 2 in Go's stdlib, but the processor runs 8 concurrent workers hitting the same host — causing constant connection churn (TCP/TLS handshakes on every request instead of reuse).

2. **No per-request timeout** ([#102](https://github.com/llm-d-incubation/llm-d-async/issues/102)): Workers pass the process-level signal context directly to `SendRequest`, and `http.DefaultClient` has no `Timeout`. A single hung inference endpoint blocks a worker goroutine indefinitely, eventually stalling the entire worker pool.

## What does this PR do?

- Creates a dedicated `http.Transport` for inference requests with `MaxIdleConnsPerHost` sized to the `--concurrency` flag value.
- Adds a `--request-timeout` flag (default 5m) that bounds individual inference requests.
- Each request gets its own `context.WithDeadline` set to `min(message deadline, now + requestTimeout)`.
- The metrics server keeps using `http.DefaultClient` (separate concern, low traffic).

## How was this tested?

- [x] Unit tests added/updated/verified
  - All existing worker tests updated for new `Worker` signature.
  - New `TestRequestTimeout` test: simulates a slow server, verifies the worker returns within the timeout instead of hanging.
- [x] All 8 tests pass (`go test ./pkg/async/api/... -v`).

## Files changed

| File | Change |
|------|--------|
| `cmd/main.go` | Custom transport, `--request-timeout` flag, separate inference client |
| `pkg/async/api/worker.go` | `requestTimeout` parameter, per-request context with deadline |
| `pkg/async/api/worker_test.go` | Updated Worker calls, added `TestRequestTimeout`, extracted `defaultRequestTimeout` constant |

Fixes #97
Fixes #102