### PR TITLE
fix: check sync.Map load result in PubSub workers

### DIFF
--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -178,6 +178,7 @@ func (r *PubSubMQFlow) Start(ctx context.Context) {
 }
 
 func resultWorker(ctx context.Context, publisher *pubsub.Publisher, resultChannel chan api.ResultMessage) {
+	logger := log.FromContext(ctx)
 
 	for {
 		select {
@@ -195,7 +196,11 @@ func resultWorker(ctx context.Context, publisher *pubsub.Publisher, resultChanne
 			}
 			publishPubSub(ctx, publisher, msgBytes, map[string]string{})
 			pubsubID := msg.Metadata[PUBSUB_ID]
-			value, _ := resultChannels.Load(pubsubID)
+			value, ok := resultChannels.Load(pubsubID)
+			if !ok {
+				logger.V(logutil.DEFAULT).Error(nil, "Result channel not found for message", "pubsubID", pubsubID)
+				continue
+			}
 			resultChannel := value.(chan bool)
 			resultChannel <- true
 
@@ -222,7 +227,11 @@ func addMsgToRetryQueue(ctx context.Context, retryChannel chan api.RetryMessage)
 
 		case msg := <-retryChannel:
 			pubsubID := msg.RequestMessage.Metadata[PUBSUB_ID]
-			value, _ := resultChannels.Load(pubsubID)
+			value, ok := resultChannels.Load(pubsubID)
+			if !ok {
+				logger.V(logutil.DEFAULT).Error(nil, "Result channel not found for retry message", "pubsubID", pubsubID)
+				continue
+			}
 			resultChannel := value.(chan bool)
 			logger.V(logutil.DEBUG).Info("Retrying message", "pubsubID", pubsubID)
 			resultChannel <- false


### PR DESCRIPTION
## What does this PR do?

During reading the code, I found there are places calling `sync.Map.Load()` but ignore the ok return value
If the key is missing, value is nil, then it will get panic in the subsequent

## Why is this change needed?

To check return value from `sync.Map.Load()`  to avoid panic

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
