### PR TITLE
perf: batch Redis writes for result publishing

### DIFF
--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -142,7 +142,8 @@ func resultWorker(ctx context.Context, rdb *redis.Client, resultChannel chan api
 		case msg := <-resultChannel:
 			// Collect a batch: start with the message we already received,
 			// then drain any additional available messages without blocking.
-			batch := []api.ResultMessage{msg}
+			batch := make([]api.ResultMessage, 1, maxResultBatchSize)
+			batch[0] = msg
 		drain:
 			for len(batch) < maxResultBatchSize {
 				select {

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -144,13 +144,13 @@ func resultWorker(ctx context.Context, rdb *redis.Client, resultChannel chan api
 			// then drain any additional available messages without blocking.
 			batch := make([]api.ResultMessage, 1, maxResultBatchSize)
 			batch[0] = msg
-		drain:
-			for len(batch) < maxResultBatchSize {
+			done := false
+			for len(batch) < maxResultBatchSize && !done {
 				select {
 				case m := <-resultChannel:
 					batch = append(batch, m)
 				default:
-					break drain
+					done = true
 				}
 			}
 

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -147,16 +147,16 @@ func resultWorker(ctx context.Context, rdb *redis.Client, resultChannel chan api
 			done := false
 			for len(batch) < maxResultBatchSize && !done {
 				select {
-				case m := <-resultChannel:
-					batch = append(batch, m)
+				case result := <-resultChannel:
+					batch = append(batch, result)
 				default:
 					done = true
 				}
 			}
 
 			pipe := rdb.Pipeline()
-			for _, m := range batch {
-				pipe.Publish(ctx, resultsQueueName, marshalResultMessage(m))
+			for _, result := range batch {
+				pipe.Publish(ctx, resultsQueueName, marshalResultMessage(result))
 			}
 			if _, err := pipe.Exec(ctx); err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to publish result batch to Redis", "batchSize", len(batch))

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -20,6 +20,15 @@ import (
 
 const QUEUE_NAME_KEY = "queue_name"
 
+const (
+	// resultChannelBuffer decouples inference workers from the result writer.
+	// Workers can send results without blocking until the buffer is full.
+	resultChannelBuffer = 64
+	// maxResultBatchSize is the maximum number of results flushed in a single
+	// Redis pipeline call.
+	maxResultBatchSize = 32
+)
+
 var (
 	igwBaseURL         = flag.String("redis.igw-base-url", "", "Base URL for IGW. Mutually exclusive with redis.queues-config-file flag.")
 	requestPathURL     = flag.String("redis.request-path-url", "/v1/completions", "request path url. Mutually exclusive with redis.queues-config-file flag.")
@@ -87,7 +96,7 @@ func NewRedisMQFlow() *RedisMQFlow {
 		rdb:             rdb,
 		requestChannels: channels,
 		retryChannel:    make(chan api.RetryMessage),
-		resultChannel:   make(chan api.ResultMessage),
+		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
 	}
 }
 
@@ -122,6 +131,7 @@ func (r *RedisMQFlow) ResultChannel() chan api.ResultMessage {
 }
 
 // Listening on the results channel and responsible for writing results into Redis.
+// Batches multiple results into a single Redis pipeline call to reduce round-trips.
 func resultWorker(ctx context.Context, rdb *redis.Client, resultChannel chan api.ResultMessage, resultsQueueName string) {
 	logger := log.FromContext(ctx)
 	for {
@@ -130,23 +140,37 @@ func resultWorker(ctx context.Context, rdb *redis.Client, resultChannel chan api
 			return
 
 		case msg := <-resultChannel:
-			bytes, err := json.Marshal(msg)
-			var msgStr string
-			if err != nil {
-				// Safely marshal the fallback error message
-				fallback := map[string]string{"id": msg.Id, "error": "Failed to marshal result to string"}
-				fallbackBytes, _ := json.Marshal(fallback)
-				msgStr = string(fallbackBytes)
-			} else {
-				msgStr = string(bytes)
+			// Collect a batch: start with the message we already received,
+			// then drain any additional available messages without blocking.
+			batch := []api.ResultMessage{msg}
+		drain:
+			for len(batch) < maxResultBatchSize {
+				select {
+				case m := <-resultChannel:
+					batch = append(batch, m)
+				default:
+					break drain
+				}
 			}
-			err = publishRedis(ctx, rdb, resultsQueueName, msgStr)
-			if err != nil {
-				// Not going to retry here. Just log the error.
-				logger.V(logutil.DEFAULT).Error(err, "Failed to publish result message to Redis")
+
+			pipe := rdb.Pipeline()
+			for _, m := range batch {
+				pipe.Publish(ctx, resultsQueueName, marshalResultMessage(m))
+			}
+			if _, err := pipe.Exec(ctx); err != nil {
+				logger.V(logutil.DEFAULT).Error(err, "Failed to publish result batch to Redis", "batchSize", len(batch))
 			}
 		}
 	}
+}
+
+func marshalResultMessage(msg api.ResultMessage) string {
+	if bytes, err := json.Marshal(msg); err == nil {
+		return string(bytes)
+	}
+	fallback := map[string]string{"id": msg.Id, "error": "Failed to marshal result to string"}
+	fallbackBytes, _ := json.Marshal(fallback)
+	return string(fallbackBytes)
 }
 
 // pulls from Redis channel and put in the request channel
@@ -265,12 +289,3 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 
 }
 
-func publishRedis(ctx context.Context, rdb *redis.Client, channelId, msg string) error {
-	logger := log.FromContext(ctx)
-	err := rdb.Publish(ctx, channelId, msg).Err()
-	if err != nil {
-		logger.V(logutil.DEFAULT).Error(err, "Error publishing message:%s\n", err.Error())
-		return err
-	}
-	return nil
-}

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -3,6 +3,8 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -109,5 +111,132 @@ func TestMarshalResultMessage_Fallback(t *testing.T) {
 	}
 	if rm.Id != "ok" {
 		t.Errorf("Expected id 'ok', got %s", rm.Id)
+	}
+}
+
+func TestPubsubResultWorker_ContextCancellation(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+
+	done := make(chan bool)
+	go func() {
+		resultWorker(ctx, rdb, resultCh, "cancel-queue")
+		done <- true
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Worker stopped gracefully
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Worker did not stop after context cancellation")
+	}
+}
+
+func TestPubsubResultWorker_BatchSizeCap(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue := "batch-cap-queue"
+	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+
+	sub := rdb.Subscribe(ctx, queue)
+	defer sub.Close() // nolint:errcheck
+	pubsubCh := sub.Channel()
+
+	// Send more than maxResultBatchSize messages. The worker should still
+	// deliver all of them across multiple pipeline flushes.
+	totalMessages := maxResultBatchSize + 10
+	for i := 0; i < totalMessages; i++ {
+		resultCh <- api.ResultMessage{
+			Id:      "cap-" + strconv.Itoa(i),
+			Payload: "data",
+		}
+	}
+
+	go resultWorker(ctx, rdb, resultCh, queue)
+
+	received := make(map[string]bool)
+	timeout := time.After(3 * time.Second)
+	for len(received) < totalMessages {
+		select {
+		case msg := <-pubsubCh:
+			var rm api.ResultMessage
+			if err := json.Unmarshal([]byte(msg.Payload), &rm); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+			received[rm.Id] = true
+		case <-timeout:
+			t.Fatalf("Timeout: received only %d/%d messages", len(received), totalMessages)
+		}
+	}
+}
+
+func TestPubsubResultWorker_ConcurrentProducers(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue := "concurrent-queue"
+	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+
+	sub := rdb.Subscribe(ctx, queue)
+	defer sub.Close() // nolint:errcheck
+	pubsubCh := sub.Channel()
+
+	go resultWorker(ctx, rdb, resultCh, queue)
+
+	// Simulate multiple inference workers sending results concurrently.
+	numProducers := 8
+	msgsPerProducer := 5
+	totalMessages := numProducers * msgsPerProducer
+
+	var wg sync.WaitGroup
+	for p := 0; p < numProducers; p++ {
+		wg.Add(1)
+		go func(producerID int) {
+			defer wg.Done()
+			for i := 0; i < msgsPerProducer; i++ {
+				resultCh <- api.ResultMessage{
+					Id:      "p" + strconv.Itoa(producerID) + "-" + strconv.Itoa(i),
+					Payload: "data",
+				}
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	received := make(map[string]bool)
+	timeout := time.After(3 * time.Second)
+	for len(received) < totalMessages {
+		select {
+		case msg := <-pubsubCh:
+			var rm api.ResultMessage
+			if err := json.Unmarshal([]byte(msg.Payload), &rm); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+			if received[rm.Id] {
+				t.Errorf("Duplicate message: %s", rm.Id)
+			}
+			received[rm.Id] = true
+		case <-timeout:
+			t.Fatalf("Timeout: received only %d/%d messages", len(received), totalMessages)
+		}
 	}
 }

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -1,0 +1,113 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestPubsubResultWorker_BatchPublish(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue := "result-pubsub-queue"
+	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+
+	// Subscribe so published messages are captured.
+	sub := rdb.Subscribe(ctx, queue)
+	defer sub.Close() // nolint:errcheck
+	pubsubCh := sub.Channel()
+
+	// Pre-fill the channel with multiple results before starting the worker
+	// so they are all available for a single batch drain.
+	numMessages := 5
+	for i := 0; i < numMessages; i++ {
+		resultCh <- api.ResultMessage{
+			Id:      "msg-" + string(rune('A'+i)),
+			Payload: "payload-" + string(rune('A'+i)),
+		}
+	}
+
+	go resultWorker(ctx, rdb, resultCh, queue)
+
+	received := make(map[string]bool)
+	timeout := time.After(2 * time.Second)
+	for len(received) < numMessages {
+		select {
+		case msg := <-pubsubCh:
+			var rm api.ResultMessage
+			if err := json.Unmarshal([]byte(msg.Payload), &rm); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+			received[rm.Id] = true
+		case <-timeout:
+			t.Fatalf("Timeout: received only %d/%d messages", len(received), numMessages)
+		}
+	}
+
+	for i := 0; i < numMessages; i++ {
+		id := "msg-" + string(rune('A'+i))
+		if !received[id] {
+			t.Errorf("Missing message %s", id)
+		}
+	}
+}
+
+func TestPubsubResultWorker_SingleMessage(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue := "result-single-queue"
+	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+
+	sub := rdb.Subscribe(ctx, queue)
+	defer sub.Close() // nolint:errcheck
+	pubsubCh := sub.Channel()
+
+	go resultWorker(ctx, rdb, resultCh, queue)
+
+	// Send a single message — should be flushed immediately as a batch of 1.
+	resultCh <- api.ResultMessage{Id: "solo", Payload: "data"}
+
+	select {
+	case msg := <-pubsubCh:
+		var rm api.ResultMessage
+		if err := json.Unmarshal([]byte(msg.Payload), &rm); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if rm.Id != "solo" {
+			t.Errorf("Expected id 'solo', got %s", rm.Id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for single message")
+	}
+}
+
+func TestMarshalResultMessage_Fallback(t *testing.T) {
+	// A normal message should marshal fine.
+	msg := api.ResultMessage{Id: "ok", Payload: "data"}
+	result := marshalResultMessage(msg)
+
+	var rm api.ResultMessage
+	if err := json.Unmarshal([]byte(result), &rm); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+	if rm.Id != "ok" {
+		t.Errorf("Expected id 'ok', got %s", rm.Id)
+	}
+}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -333,9 +333,10 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 			}
 
 			// Group by target queue and flush via pipeline.
+			defaultQueue := *ssResultQueueName
 			queued := make(map[string][]string)
 			for _, result := range batch {
-				resultQueue := *ssResultQueueName
+				resultQueue := defaultQueue
 				if result.Metadata != nil {
 					if customQueue, ok := result.Metadata["result_queue"]; ok && customQueue != "" {
 						resultQueue = customQueue

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -322,13 +322,13 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 			// then drain any additional available messages without blocking.
 			batch := make([]api.ResultMessage, 1, maxResultBatchSize)
 			batch[0] = msg
-		drain:
-			for len(batch) < maxResultBatchSize {
+			done := false
+			for len(batch) < maxResultBatchSize && !done {
 				select {
 				case m := <-r.resultChannel:
 					batch = append(batch, m)
 				default:
-					break drain
+					done = true
 				}
 			}
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -93,7 +93,7 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 		}),
 		requestChannels: make([]requestChannelData, 0, len(configs)),
 		retryChannel:    make(chan api.RetryMessage),
-		resultChannel:   make(chan api.ResultMessage),
+		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
 		pollInterval:    time.Duration(*ssPollIntervalMs) * time.Millisecond,
 		batchSize:       *ssBatchSize,
 	}
@@ -308,7 +308,8 @@ func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
 }
 
 // Pushes results to Redis list (FIFO)
-// Routes results to the queue specified in request metadata, or default queue if not specified
+// Routes results to the queue specified in request metadata, or default queue if not specified.
+// Batches multiple results into a single Redis pipeline call to reduce round-trips.
 func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 	logger := log.FromContext(ctx)
 
@@ -317,19 +318,41 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case msg := <-r.resultChannel:
-			// Check metadata for custom result queue (set by producer)
-			resultQueue := *ssResultQueueName // default queue
-			if msg.Metadata != nil {
-				if customQueue, ok := msg.Metadata["result_queue"]; ok && customQueue != "" {
-					resultQueue = customQueue
+			// Collect a batch: start with the message we already received,
+			// then drain any additional available messages without blocking.
+			batch := []api.ResultMessage{msg}
+		drain:
+			for len(batch) < maxResultBatchSize {
+				select {
+				case m := <-r.resultChannel:
+					batch = append(batch, m)
+				default:
+					break drain
 				}
 			}
 
-			msgStr := r.marshalResult(msg)
-			if err := r.rdb.LPush(ctx, resultQueue, msgStr).Err(); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to push result", "queue", resultQueue)
+			// Group by target queue and flush via pipeline.
+			queued := make(map[string][]string)
+			for _, m := range batch {
+				resultQueue := *ssResultQueueName
+				if m.Metadata != nil {
+					if customQueue, ok := m.Metadata["result_queue"]; ok && customQueue != "" {
+						resultQueue = customQueue
+					}
+				}
+				queued[resultQueue] = append(queued[resultQueue], r.marshalResult(m))
+			}
+
+			pipe := r.rdb.Pipeline()
+			for q, msgs := range queued {
+				for _, msgStr := range msgs {
+					pipe.LPush(ctx, q, msgStr)
+				}
+			}
+			if _, err := pipe.Exec(ctx); err != nil {
+				logger.V(logutil.DEFAULT).Error(err, "Failed to push result batch to Redis", "batchSize", len(batch))
 			} else {
-				logger.V(logutil.DEBUG).Info("Pushed result to queue", "id", msg.Id, "queue", resultQueue)
+				logger.V(logutil.DEBUG).Info("Pushed result batch", "batchSize", len(batch))
 			}
 		}
 	}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -320,7 +320,8 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 		case msg := <-r.resultChannel:
 			// Collect a batch: start with the message we already received,
 			// then drain any additional available messages without blocking.
-			batch := []api.ResultMessage{msg}
+			batch := make([]api.ResultMessage, 1, maxResultBatchSize)
+			batch[0] = msg
 		drain:
 			for len(batch) < maxResultBatchSize {
 				select {

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -325,8 +325,8 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 			done := false
 			for len(batch) < maxResultBatchSize && !done {
 				select {
-				case m := <-r.resultChannel:
-					batch = append(batch, m)
+				case result := <-r.resultChannel:
+					batch = append(batch, result)
 				default:
 					done = true
 				}
@@ -334,20 +334,20 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 
 			// Group by target queue and flush via pipeline.
 			queued := make(map[string][]string)
-			for _, m := range batch {
+			for _, result := range batch {
 				resultQueue := *ssResultQueueName
-				if m.Metadata != nil {
-					if customQueue, ok := m.Metadata["result_queue"]; ok && customQueue != "" {
+				if result.Metadata != nil {
+					if customQueue, ok := result.Metadata["result_queue"]; ok && customQueue != "" {
 						resultQueue = customQueue
 					}
 				}
-				queued[resultQueue] = append(queued[resultQueue], r.marshalResult(m))
+				queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
 			}
 
 			pipe := r.rdb.Pipeline()
-			for q, msgs := range queued {
+			for queue, msgs := range queued {
 				for _, msgStr := range msgs {
-					pipe.LPush(ctx, q, msgStr)
+					pipe.LPush(ctx, queue, msgStr)
 				}
 			}
 			if _, err := pipe.Exec(ctx); err != nil {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -296,6 +296,109 @@ func TestSortedSetFlow_ResultFIFO(t *testing.T) {
 	}
 }
 
+func TestSortedSetFlow_ResultBatch(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "batch-result-queue"
+	origQueue := *ssResultQueueName
+	*ssResultQueueName = queue
+	defer func() { *ssResultQueueName = origQueue }()
+
+	flow := &RedisSortedSetFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
+	}
+
+	// Pre-fill the channel before starting the worker so all messages
+	// are available for a single batch drain.
+	numMessages := 10
+	for i := 0; i < numMessages; i++ {
+		flow.resultChannel <- api.ResultMessage{
+			Id:      "batch-" + strconv.Itoa(i),
+			Payload: "data-" + strconv.Itoa(i),
+		}
+	}
+
+	go flow.resultWorker(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	// All messages should be in Redis
+	length, err := rdb.LLen(ctx, queue).Result()
+	if err != nil {
+		t.Fatalf("LLen error: %v", err)
+	}
+	if length != int64(numMessages) {
+		t.Errorf("Expected %d results in Redis, got %d", numMessages, length)
+	}
+
+	// Verify FIFO order via RPOP
+	for i := 0; i < numMessages; i++ {
+		raw, _ := rdb.RPop(ctx, queue).Result()
+		var msg api.ResultMessage
+		json.Unmarshal([]byte(raw), &msg) // nolint:errcheck
+		expected := "batch-" + strconv.Itoa(i)
+		if msg.Id != expected {
+			t.Errorf("Position %d: expected %s, got %s", i, expected, msg.Id)
+		}
+	}
+}
+
+func TestSortedSetFlow_ResultBatchMultiQueue(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	defaultQueue := "default-result-queue"
+	customQueue := "custom-result-queue"
+	origQueue := *ssResultQueueName
+	*ssResultQueueName = defaultQueue
+	defer func() { *ssResultQueueName = origQueue }()
+
+	flow := &RedisSortedSetFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
+	}
+
+	// Send messages targeting different queues in a single batch.
+	flow.resultChannel <- api.ResultMessage{Id: "default-1", Payload: "d1"}
+	flow.resultChannel <- api.ResultMessage{
+		Id:       "custom-1",
+		Payload:  "c1",
+		Metadata: map[string]string{"result_queue": customQueue},
+	}
+	flow.resultChannel <- api.ResultMessage{Id: "default-2", Payload: "d2"}
+	flow.resultChannel <- api.ResultMessage{
+		Id:       "custom-2",
+		Payload:  "c2",
+		Metadata: map[string]string{"result_queue": customQueue},
+	}
+
+	go flow.resultWorker(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify default queue
+	defaultLen, _ := rdb.LLen(ctx, defaultQueue).Result()
+	if defaultLen != 2 {
+		t.Errorf("Expected 2 messages in default queue, got %d", defaultLen)
+	}
+
+	// Verify custom queue
+	customLen, _ := rdb.LLen(ctx, customQueue).Result()
+	if customLen != 2 {
+		t.Errorf("Expected 2 messages in custom queue, got %d", customLen)
+	}
+}
+
 func TestSortedSetFlow_NoRaceCondition(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()


### PR DESCRIPTION
## Summary

- **Buffer the result channel** (capacity 64) so inference workers do not block on every send while the single `resultWorker` completes a Redis write
- **Batch Redis writes with pipelining** — the result worker drains all available results from the channel (up to 32) and flushes them in a single Redis pipeline round-trip, reducing per-result network overhead
- Both Redis flow implementations are updated:
  - **pubsub** (`redisimpl.go`): batched `Publish` via pipeline
  - **sorted-set** (`sortedset_impl.go`): batched `LPush` via pipeline, with per-queue routing preserved

## Test plan

- [x] Batch publish: multiple messages pre-filled in channel are flushed in a single batch
- [x] Single message: a lone result is flushed immediately as a batch of 1
- [x] Batch size cap: more than `maxResultBatchSize` (32) messages are delivered across multiple pipeline flushes
- [x] Context cancellation: worker exits cleanly when context is cancelled
- [x] Concurrent producers: 8 goroutines sending results simultaneously — no duplicates or lost messages
- [x] Marshal fallback: verifies `marshalResultMessage` produces valid JSON
- [x] Sorted-set batch writes: 10 messages flushed via pipeline, FIFO order preserved
- [x] Sorted-set multi-queue routing: messages routed to different queues within a single batch
- [x] Existing `TestSortedSetFlow_ResultFIFO` still passes
- [x] Full test suite passes
- [x] Race detector clean (`go test -race`)

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)