### PR TITLE
chore: add compile-time interface conformance checks

### DIFF
--- a/pkg/async/api/api.go
+++ b/pkg/async/api/api.go
@@ -41,6 +41,8 @@ type GateFactory interface {
 	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
 }
 
+var _ DispatchGate = DispatchGateFunc(nil)
+
 // DispatchGateFunc is a function type that implements DispatchGate.
 // This allows any function with the signature func(context.Context) float64
 // to be used as a DispatchGate.

--- a/pkg/async/api/http_client.go
+++ b/pkg/async/api/http_client.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 )
 
+var _ InferenceClient = (*HTTPInferenceClient)(nil)
+
 // HTTPInferenceClient is the default HTTP implementation of InferenceClient.
 type HTTPInferenceClient struct {
 	client *http.Client

--- a/pkg/async/api/inference_error.go
+++ b/pkg/async/api/inference_error.go
@@ -31,6 +31,8 @@ type InferenceError interface {
 	Category() ErrorCategory
 }
 
+var _ InferenceError = (*ClientError)(nil)
+
 // ClientError represents an inference client error with category and context.
 type ClientError struct {
 	ErrorCategory ErrorCategory

--- a/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 
+	asyncapi "github.com/llm-d-incubation/llm-d-async/pkg/async/api"
 	"github.com/prometheus/client_golang/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -29,6 +30,8 @@ var isGMP = flag.Bool("gate.pmetric.is-gmp", false, "Is this GMP (Google Managed
 var prometheusURL = flag.String("gate.prometheus.url", "", "Prometheus URL for non GMP metric")
 var gmpProjectID = flag.String("gate.pmetric.gmp.project-id", "", "Project ID for Google Managed Prometheus")
 var prometheusQueryModelName = flag.String("gate.prometheus.model-name", "", "metrics name to use for avg_queue_size")
+
+var _ asyncapi.DispatchGate = (*BinaryMetricDispatchGate)(nil)
 
 // BinaryMetricDispatchGate implements DispatchGate using a MetricSource.
 // It returns 0.0 (no capacity) if the metric value is non-zero,

--- a/pkg/async/inference/flowcontrol/dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/dispatch_gate.go
@@ -22,6 +22,8 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
 )
 
+var _ api.DispatchGate = DispatchGateFunc(nil)
+
 // DispatchGateFunc is a function type that implements DispatchGate.
 // This allows any function with the signature func(context.Context) float64
 // to be used as a DispatchGate.

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -26,6 +26,8 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 )
 
+var _ asyncapi.GateFactory = (*GateFactory)(nil)
+
 // GateFactory creates DispatchGate instances based on configuration.
 type GateFactory struct {
 	prometheusURL string

--- a/pkg/async/inference/flowcontrol/metric_source.go
+++ b/pkg/async/inference/flowcontrol/metric_source.go
@@ -46,6 +46,8 @@ type MetricSource interface {
 	Query(ctx context.Context) ([]Sample, error)
 }
 
+var _ MetricSource = (*PromQLMetricSource)(nil)
+
 // PromQLMetricSource implements MetricSource by executing a PromQL expression
 // against a Prometheus-compatible API.
 type PromQLMetricSource struct {

--- a/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/saturation_metric_dispatch_gate.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"math"
 
+	asyncapi "github.com/llm-d-incubation/llm-d-async/pkg/async/api"
 	"github.com/prometheus/client_golang/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -30,6 +31,8 @@ var saturationInferencePool = flag.String("gate.saturation.inference-pool", "", 
 var saturationThreshold = flag.Float64("gate.saturation.threshold", 0.8, "saturation threshold above which budget is zero")
 var saturationFallback = flag.Float64("gate.saturation.fallback", 0.0, "fallback saturation value on error/missing metrics; default 0.0")
 var saturationQueryExpr = flag.String("gate.saturation.query-expr", "", "custom PromQL expression for saturation metric; overrides inference-pool label selector")
+
+var _ asyncapi.DispatchGate = (*SaturationMetricDispatchGate)(nil)
 
 // SaturationMetricDispatchGate implements DispatchGate based on pool saturation.
 // It queries a MetricSource for saturation samples and returns 0.0 if saturation

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -10,6 +10,8 @@ func NewRandomRobinPolicy() api.RequestMergePolicy {
 	return &RandomRobinPolicy{}
 }
 
+var _ api.RequestMergePolicy = (*RandomRobinPolicy)(nil)
+
 type RandomRobinPolicy struct {
 }
 

--- a/pkg/producer/redis_sortedset_producer.go
+++ b/pkg/producer/redis_sortedset_producer.go
@@ -12,6 +12,8 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+var _ Producer = (*RedisSortedSetProducer)(nil)
+
 // RedisSortedSetProducer implements Producer using Redis sorted set for requests
 // and Redis list for results.
 type RedisSortedSetProducer struct {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -43,6 +43,9 @@ type TopicConfig struct {
 	GateType           string            `json:"gate_type"`
 	GateParams         map[string]string `json:"gate_params,omitempty"`
 }
+
+var _ api.Flow = (*PubSubMQFlow)(nil)
+
 type PubSubMQFlow struct {
 	resultTopicID   string
 	requestChannels []RequestChannelData

--- a/pkg/redis/dispatch_gate.go
+++ b/pkg/redis/dispatch_gate.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/api"
 	goredis "github.com/redis/go-redis/v9"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
+
+var _ api.DispatchGate = (*RedisDispatchGate)(nil)
 
 // RedisDispatchGate implements api.DispatchGate by reading the budget
 // from a Redis key. This allows external systems to dynamically control

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -76,6 +76,8 @@ type RequestChannelData struct {
 	queueName      string
 }
 
+var _ api.Flow = (*RedisMQFlow)(nil)
+
 type RedisMQFlow struct {
 	rdb             *redis.Client
 	requestChannels []RequestChannelData

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -61,6 +61,8 @@ type requestChannelData struct {
 	gate      api.DispatchGate
 }
 
+var _ api.Flow = (*RedisSortedSetFlow)(nil)
+
 type RedisSortedSetFlow struct {
 	rdb             *redis.Client
 	requestChannels []requestChannelData


### PR DESCRIPTION
## What does this PR do?

Adds  `var _ Interface = (*Struct)(nil)` compile-time assertions, ensuring that var types satisfy their intended interfaces at compile time rather than at runtime

## Why is this change needed?

Without these checks, if a struct's method signature drifts out of sync with its interface (e.g., during a refactor), the error only surfaces at runtime

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
