### PR TITLE
fix: use atomic enqueue in deadline-order e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -44,9 +44,7 @@ var _ = ginkgo.Describe("Redis Sorted Set E2E", func() {
 		msg3 := makeRequestMessage("deadline-200", 200*time.Second)
 		msg3.DeadlineUnixSec = fmt.Sprintf("%d", now.Add(200*time.Second).Unix())
 
-		enqueueMessage(ctx, rdb, requestQueue, msg1)
-		enqueueMessage(ctx, rdb, requestQueue, msg2)
-		enqueueMessage(ctx, rdb, requestQueue, msg3)
+		enqueueMessages(ctx, rdb, requestQueue, msg1, msg2, msg3)
 
 		// Wait for all 3 results
 		gomega.Eventually(func() int64 {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -33,6 +33,23 @@ func enqueueMessage(ctx context.Context, rdb *redis.Client, queue string, msg ap
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 }
 
+// enqueueMessages adds all messages to the sorted set in a single Redis
+// pipeline so they become visible atomically. This prevents the processor
+// from dequeuing early messages before the rest are enqueued.
+func enqueueMessages(ctx context.Context, rdb *redis.Client, queue string, msgs ...api.RequestMessage) {
+	pipe := rdb.Pipeline()
+	for _, msg := range msgs {
+		data, err := json.Marshal(msg)
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		pipe.ZAdd(ctx, queue, redis.Z{
+			Score:  parseDeadline(msg.DeadlineUnixSec),
+			Member: string(data),
+		})
+	}
+	_, err := pipe.Exec(ctx)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+}
+
 func parseDeadline(deadline string) float64 {
 	var d float64
 	_, err := fmt.Sscanf(deadline, "%f", &d)


### PR DESCRIPTION
## Summary
- Fix flaky "processes messages in deadline order" e2e test by enqueuing all three messages atomically via a single Redis pipeline instead of three separate `ZADD` calls
- Add `enqueueMessages()` helper that uses `rdb.Pipeline()` so all messages become visible at once, preventing the processor from dequeuing early messages before the rest are enqueued

## Test plan
- [x] All 10 e2e tests pass (including the previously flaky deadline-order test)
- [x] Unit tests pass

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)