### PR TITLE
fix: use equal jitter strategy for exponential backoff

### DIFF
--- a/pkg/async/api/worker.go
+++ b/pkg/async/api/worker.go
@@ -15,7 +15,10 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
-var baseDelaySeconds = 2
+const (
+	baseDelaySeconds = 2
+	maxDelaySeconds  = 60
+)
 
 func Worker(ctx context.Context, characteristics Characteristics, client InferenceClient, requestChannel chan EmbelishedRequestMessage,
 	retryChannel chan RetryMessage, resultChannel chan ResultMessage, requestTimeout time.Duration) {
@@ -115,7 +118,7 @@ func retryMessage(msg EmbelishedRequestMessage, retryChannel chan RetryMessage, 
 		return
 	}
 	secondsToDeadline := deadline - time.Now().Unix()
-	if secondsToDeadline < 0 {
+	if secondsToDeadline <= 0 {
 		metrics.ExceededDeadlineReqs.Inc()
 		resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage)
 	} else {
@@ -148,15 +151,23 @@ func CreateDeadlineExceededResultMessage(msg RequestMessage) ResultMessage {
 	return CreateErrorResultMessage(msg, "deadline exceeded")
 }
 
+// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 func expBackoffDuration(retryCount int, secondsToDeadline int) float64 {
-	backoffDurationSeconds := math.Min(
-		float64(baseDelaySeconds)*(math.Pow(2, float64(retryCount))),
-		float64(secondsToDeadline))
-
-	jitter := rand.Float64() - 0.5
-	finalDuration := backoffDurationSeconds + jitter
-	if finalDuration < 0 {
-		finalDuration = 0
+	if secondsToDeadline <= 0 {
+		return 0
 	}
-	return finalDuration
+
+	capLevel := math.Min(float64(maxDelaySeconds), float64(secondsToDeadline))
+
+	// exponential growth with cap
+	backoff := float64(baseDelaySeconds) * math.Pow(2, float64(retryCount))
+	temp := math.Min(capLevel, backoff)
+
+	if temp <= 0 {
+		return 0
+	}
+
+	// equal jitter: [temp/2, temp)
+	half := temp / 2
+	return half + rand.Float64()*half
 }

--- a/pkg/async/api/worker_test.go
+++ b/pkg/async/api/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -302,6 +303,99 @@ func TestRequestTimeout(t *testing.T) {
 		t.Errorf("Timed-out request should not be retried")
 	case <-time.After(5 * time.Second):
 		t.Errorf("Worker did not return within 5s — per-request timeout was not enforced")
+	}
+}
+
+func TestExpBackoffDuration(t *testing.T) {
+	const iterations = 1000
+
+	t.Run("normal backoff grows exponentially", func(t *testing.T) {
+		deadline := 300
+		for retry := 0; retry < 5; retry++ {
+			expectedTemp := math.Min(float64(maxDelaySeconds), float64(baseDelaySeconds)*math.Pow(2, float64(retry)))
+			lo := expectedTemp / 2
+			hi := expectedTemp
+
+			for i := 0; i < iterations; i++ {
+				got := expBackoffDuration(retry, deadline)
+				if got < lo || got >= hi {
+					t.Errorf("retry=%d: got %f, want [%f, %f)", retry, got, lo, hi)
+				}
+			}
+		}
+	})
+
+	t.Run("capped by maxDelaySeconds", func(t *testing.T) {
+		deadline := 300
+		// retry=10 → baseDelay*2^10 = 2048, far above maxDelaySeconds=60
+		for i := 0; i < iterations; i++ {
+			got := expBackoffDuration(10, deadline)
+			if got < float64(maxDelaySeconds)/2 || got >= float64(maxDelaySeconds) {
+				t.Errorf("got %f, want [%f, %f)", got, float64(maxDelaySeconds)/2, float64(maxDelaySeconds))
+			}
+		}
+	})
+
+	t.Run("capped by secondsToDeadline", func(t *testing.T) {
+		deadline := 3
+		// retry=10 → exponential is huge, but capped to deadline=3
+		for i := 0; i < iterations; i++ {
+			got := expBackoffDuration(10, deadline)
+			if got < float64(deadline)/2 || got >= float64(deadline) {
+				t.Errorf("got %f, want [%f, %f)", got, float64(deadline)/2, float64(deadline))
+			}
+		}
+	})
+
+	t.Run("small deadline respected over baseDelay", func(t *testing.T) {
+		// secondsToDeadline=1 → cap=1, temp=1, result in [0.5, 1.0)
+		for i := 0; i < iterations; i++ {
+			got := expBackoffDuration(1, 1)
+			if got < 0.5 || got >= 1.0 {
+				t.Errorf("got %f, want [0.5, 1.0)", got)
+			}
+		}
+	})
+
+	t.Run("zero deadline returns zero", func(t *testing.T) {
+		got := expBackoffDuration(1, 0)
+		if got != 0 {
+			t.Errorf("got %f, want 0", got)
+		}
+	})
+
+	t.Run("negative deadline returns zero", func(t *testing.T) {
+		got := expBackoffDuration(1, -5)
+		if got != 0 {
+			t.Errorf("got %f, want 0", got)
+		}
+	})
+}
+
+func TestRetryMessage_deadlineExact(t *testing.T) {
+	retryChannel := make(chan RetryMessage, 1)
+	resultChannel := make(chan ResultMessage, 1)
+	msg := EmbelishedRequestMessage{
+		RequestMessage: RequestMessage{
+			Id:              "exact-deadline",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Unix()), // exactly now
+		},
+	}
+	retryMessage(msg, retryChannel, resultChannel)
+	if len(retryChannel) > 0 {
+		t.Errorf("secondsToDeadline==0 should not produce a retry")
+	}
+	if len(resultChannel) != 1 {
+		t.Errorf("expected deadline-exceeded result")
+		return
+	}
+	result := <-resultChannel
+	var resultMap map[string]any
+	json.Unmarshal([]byte(result.Payload), &resultMap) // nolint:errcheck
+	if resultMap["error"] != "deadline exceeded" {
+		t.Errorf("expected 'deadline exceeded', got: %s", resultMap["error"])
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?
Follow doc https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

- Switches the retry backoff strategy from **full jitter** to **equal jitter**: the delay is sampled from `[temp/2, temp)` instead of `[0, temp)`, reducing the chance of very short backoffs on early retries.
- Introduces a `maxDelaySeconds = 60` cap so backoff does not grow unboundedly when the deadline is far away.

## Why is this change needed?

The previous full-jitter implementation could produce near-zero backoffs on early retries, causing aggressive retry storms. It also lacked a max delay cap and had a boundary bug where `secondsToDeadline == 0` still entered the retry path, wasting resources on requests that could never succeed in time.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)