### PR TITLE
fix: correct index misalignment after channel removal

### DIFF
--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -18,9 +18,18 @@ type RandomRobinPolicy struct {
 func (r *RandomRobinPolicy) MergeRequestChannels(channels []api.RequestChannel) api.EmbelishedRequestChannel {
 	mergedChannel := make(chan api.EmbelishedRequestMessage, len(channels))
 
+	// reflect.Select blocks forever on an empty cases slice, so return
+	// a closed channel immediately to avoid goroutine leaks.
+	if len(channels) == 0 {
+		close(mergedChannel)
+		return api.EmbelishedRequestChannel{Channel: mergedChannel}
+	}
+
 	cases := make([]reflect.SelectCase, len(channels)) //nolint:staticcheck
+	meta := make([]api.RequestChannel, len(channels))
 	for i, ch := range channels {
 		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch.Channel)}
+		meta[i] = ch
 	}
 
 	go func() {
@@ -28,13 +37,8 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []api.RequestChannel) 
 			i1, val, ok := reflect.Select(cases)
 			if !ok {
 				// one of the channels is closed, remove it
-				newCases := make([]reflect.SelectCase, 0, len(cases)-1)
-				for i2, c := range cases {
-					if i2 != i1 {
-						newCases = append(newCases, c)
-					}
-				}
-				cases = newCases
+				cases = append(cases[:i1], cases[i1+1:]...)
+				meta = append(meta[:i1], meta[i1+1:]...)
 				if len(cases) == 0 {
 					close(mergedChannel)
 					break
@@ -46,9 +50,9 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []api.RequestChannel) 
 					// TODO: move from here
 					HttpHeaders: map[string]string{
 						"Content-Type":                  "application/json",
-						"x-gateway-inference-objective": channels[i1].InferenceObjective,
+						"x-gateway-inference-objective": meta[i1].InferenceObjective,
 					},
-					RequestURL: channels[i1].IGWBaseURl + channels[i1].RequestPathURL,
+					RequestURL: meta[i1].IGWBaseURl + meta[i1].RequestPathURL,
 					Metadata:   rm.Metadata,
 				}
 				mergedChannel <- erm

--- a/pkg/async/random_robin_policy_test.go
+++ b/pkg/async/random_robin_policy_test.go
@@ -43,6 +43,88 @@ func TestProcessAllChannels(t *testing.T) {
 	}
 }
 
+func TestEmptyChannelsReturnsClosed(t *testing.T) {
+	policy := NewRandomRobinPolicy()
+	merged := policy.MergeRequestChannels(nil)
+
+	select {
+	case _, ok := <-merged.Channel:
+		if ok {
+			t.Fatal("expected closed channel, but received a message")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("merged channel was not closed")
+	}
+}
+
+func TestMetaAlignmentAfterChannelClosure(t *testing.T) {
+	// Three channels, each with distinct metadata.
+	channels := []api.RequestChannel{
+		{Channel: make(chan api.RequestMessage, 1), IGWBaseURl: "http://a", InferenceObjective: "obj-a", RequestPathURL: "/a"},
+		{Channel: make(chan api.RequestMessage, 1), IGWBaseURl: "http://b", InferenceObjective: "obj-b", RequestPathURL: "/b"},
+		{Channel: make(chan api.RequestMessage, 1), IGWBaseURl: "http://c", InferenceObjective: "obj-c", RequestPathURL: "/c"},
+	}
+	policy := NewRandomRobinPolicy()
+	merged := policy.MergeRequestChannels(channels)
+
+	// Close the middle channel to shift indices.
+	close(channels[1].Channel)
+
+	// Wait until the merge goroutine observes the closure and realigns
+	// channel metadata. This avoids timing flakes from fixed sleeps.
+	realigned := false
+	realignDeadline := time.After(2 * time.Second)
+	for !realigned {
+		select {
+		case <-realignDeadline:
+			t.Fatal("timed out waiting for channel metadata realignment")
+		case channels[2].Channel <- api.RequestMessage{Id: "probe-c"}:
+		}
+
+		select {
+		case <-realignDeadline:
+			t.Fatal("timed out waiting for channel metadata realignment")
+		case msg := <-merged.Channel:
+			if msg.Id != "probe-c" {
+				t.Fatalf("unexpected message id while waiting for realignment: %s", msg.Id)
+			}
+			realigned = msg.RequestURL == "http://c/c" &&
+				msg.HttpHeaders["x-gateway-inference-objective"] == "obj-c"
+		}
+	}
+
+	// Send one message on each remaining channel.
+	channels[0].Channel <- api.RequestMessage{Id: "from-a"}
+	channels[2].Channel <- api.RequestMessage{Id: "from-c"}
+
+	deadline := time.After(2 * time.Second)
+	for range 2 {
+		select {
+		case msg := <-merged.Channel:
+			switch msg.Id {
+			case "from-a":
+				if msg.RequestURL != "http://a/a" {
+					t.Errorf("expected RequestURL http://a/a, got %s", msg.RequestURL)
+				}
+				if msg.HttpHeaders["x-gateway-inference-objective"] != "obj-a" {
+					t.Errorf("expected InferenceObjective obj-a, got %s", msg.HttpHeaders["x-gateway-inference-objective"])
+				}
+			case "from-c":
+				if msg.RequestURL != "http://c/c" {
+					t.Errorf("expected RequestURL http://c/c, got %s", msg.RequestURL)
+				}
+				if msg.HttpHeaders["x-gateway-inference-objective"] != "obj-c" {
+					t.Errorf("expected InferenceObjective obj-c, got %s", msg.HttpHeaders["x-gateway-inference-objective"])
+				}
+			default:
+				t.Fatalf("unexpected message id: %s", msg.Id)
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for messages")
+		}
+	}
+}
+
 func TestMergedChannelIsBuffered(t *testing.T) {
 	numChannels := 3
 	channels := make([]api.RequestChannel, numChannels)


### PR DESCRIPTION

## What does this PR do?

In `MergeRequestChannels`, after a channel is removed from cases, `reflect.Select` returns indices into the shortened slice — but metadata was still read from the original channels parameter. 

The PR will fix the bug

## Why is this change needed?

The index misalignment will cause request routed to the wrong URL after one channel close

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
