### PR TITLE
gate: updated dispatch budget formula + tests

### DIFF
--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -50,7 +50,7 @@ func NewGateFactory(prometheusURL string) *GateFactory {
 //   - "prometheus-saturation": Queries Prometheus for pool saturation metric.
 //     Params: pool (required), threshold (default 0.8), fallback (default 0.0)
 //   - "prometheus-budget": Queries Prometheus for dispatch budget using
-//     D = 1 - (F_SYS + F_EPP + B). Params: pool, max_sys (required),
+//     D = (1 - F_SYS) * (1 - F_EPP) * (1 - B). Params: pool, max_sys (required),
 //     baseline (default 0.05), fallback (default 0.0)
 //
 // For unsupported or unknown gate types, returns ConstOpenGate as a safe default.

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -28,9 +28,9 @@ import (
 var _ asyncapi.DispatchGate = (*MetricDispatchGate)(nil)
 
 // MetricDispatchGate implements DispatchGate by querying a MetricSource for a
-// saturation-like value and returning max(0, 1 - value), clamped to [0.0, 1.0].
+// budget value and returning it clamped to [0.0, 1.0].
 //
-// If the value is at or above the configured threshold, the gate returns 0.0.
+// If the value is at or below the configured threshold, the gate returns 0.0.
 // On error or missing/invalid data, the gate returns the configured fallback budget.
 type MetricDispatchGate struct {
 	source    MetricSource
@@ -49,18 +49,19 @@ func NewMetricDispatchGate(source MetricSource, threshold float64, fallback floa
 }
 
 // NewSaturationDispatchGate creates a MetricDispatchGate for the saturation use case.
-// The fallback parameter is a saturation value (not a budget value); it is internally
-// converted to a budget via 1 - fallback and clamped to [0.0, 1.0].
+// The source should return a budget value (e.g. 1 - saturation).
+// The threshold and fallback are saturation values; they are internally converted
+// to budget values via 1 - value.
 func NewSaturationDispatchGate(source MetricSource, threshold float64, fallback float64) *MetricDispatchGate {
-	return NewMetricDispatchGate(source, threshold, 1.0-fallback)
+	return NewMetricDispatchGate(source, 1.0-threshold, 1.0-fallback)
 }
 
 // NewBudgetDispatchGate creates a MetricDispatchGate for the dispatch budget use case.
-// The source should return the combined saturation value (e.g. F_SYS + F_EPP + B).
-// The threshold is set to 1.0 (budget is zero only when fully loaded).
+// The source should return the budget value directly: (1 - F_SYS) * (1 - F_EPP) * (1 - B).
+// The threshold is set to 0.0 (gate closes only when budget reaches zero).
 // The fallback parameter is a direct budget value, clamped to [0.0, 1.0].
 func NewBudgetDispatchGate(source MetricSource, fallback float64) *MetricDispatchGate {
-	return NewMetricDispatchGate(source, 1.0, fallback)
+	return NewMetricDispatchGate(source, 0.0, fallback)
 }
 
 // Budget implements DispatchGate.
@@ -85,8 +86,8 @@ func (g *MetricDispatchGate) Budget(ctx context.Context) float64 {
 		logger.V(logutil.DEFAULT).Info("Invalid metric value, using fallback value", "fallback", g.fallback, "value", value)
 		return g.fallback
 	}
-	if value >= g.threshold {
+	if value <= g.threshold {
 		return 0.0
 	}
-	return math.Min(1.0, math.Max(0.0, 1.0-value))
+	return math.Min(1.0, math.Max(0.0, value))
 }

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
@@ -25,282 +25,116 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- NewSaturationDispatchGate tests (fallback is a saturation value, inverted) ---
+func TestSaturationDispatchGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		saturation float64
+		err        error
+		threshold  float64
+		fallback   float64
+		expected   float64
+	}{
+		{"zero saturation", 0.0, nil, 0.8, 1.0, 1.0},
+		{"partial saturation", 0.3, nil, 0.8, 1.0, 1 - 0.3},
+		{"at threshold", 0.8, nil, 0.8, 1.0, 0.0},
+		{"above threshold", 0.95, nil, 0.8, 1.0, 0.0},
+		{"full saturation", 1.0, nil, 0.8, 1.0, 0.0},
+		{"just below threshold", 0.79, nil, 0.8, 1.0, 1 - 0.79},
+		{"threshold one", 0.99, nil, 1.0, 1.0, 1 - 0.99},
+		{"saturation above one", 1.5, nil, 0.8, 1.0, 0.0},
+		{"saturation above one high threshold", 1.5, nil, 2.0, 1.0, 0.0},
+		{"negative saturation", -0.5, nil, 0.8, 1.0, 1.0},
+		{"error fail closed", 0, errors.New("conn refused"), 0.8, 1.0, 0.0},
+		{"error fail open", 0, errors.New("conn refused"), 0.8, 0.0, 1.0},
+		{"NaN fail open", math.NaN(), nil, 0.8, 0.0, 1.0},
+		{"Inf fail open", math.Inf(-1), nil, 0.8, 0.0, 1.0},
+		{"NaN fail closed", math.NaN(), nil, 0.8, 1.0, 0.0},
+		{"Inf fail closed", math.Inf(-1), nil, 0.8, 1.0, 0.0},
+	}
 
-func TestSaturationDispatchGate_ZeroSaturation(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.0}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_PartialSaturation(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.3}}},
-		0.8, 1.0,
-	)
-	require.InDelta(t, 0.7, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestSaturationDispatchGate_AtThreshold(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.8}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_AboveThreshold(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.95}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_FullSaturation(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 1.0}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_JustBelowThreshold(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.79}}},
-		0.8, 1.0,
-	)
-	require.InDelta(t, 0.21, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestSaturationDispatchGate_Error(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{err: errors.New("connection refused")},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var source *mockMetricSource
+			if tt.err != nil {
+				source = &mockMetricSource{err: tt.err}
+			} else {
+				source = &mockMetricSource{samples: []Sample{{Value: 1 - tt.saturation}}}
+			}
+			gate := NewSaturationDispatchGate(source, tt.threshold, tt.fallback)
+			require.InDelta(t, tt.expected, gate.Budget(context.Background()), 1e-9)
+		})
+	}
 }
 
 func TestSaturationDispatchGate_EmptySamples(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{}},
-		0.8, 1.0,
-	)
+	source := &mockMetricSource{samples: []Sample{}}
+	gate := NewSaturationDispatchGate(source, 0.8, 1.0)
 	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
 
-func TestSaturationDispatchGate_ThresholdOne(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.99}}},
-		1.0, 1.0,
-	)
-	require.InDelta(t, 0.01, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestSaturationDispatchGate_Error_FailOpen(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{err: errors.New("connection refused")},
-		0.8, 0.0,
-	)
+	gate = NewSaturationDispatchGate(source, 0.8, 0.0)
 	require.Equal(t, 1.0, gate.Budget(context.Background()))
 }
 
-func TestSaturationDispatchGate_EmptySamples_FailOpen(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{}},
-		0.8, 0.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
+func TestBudgetDispatchGate(t *testing.T) {
+	tests := []struct {
+		name     string
+		budget   float64
+		err      error
+		fallback float64
+		expected float64
+	}{
+		{"core formula", 0.5 * 0.9 * 0.95, nil, 0.0, 0.5 * 0.9 * 0.95},
+		{"zero load", 1.0 * 1.0 * 0.95, nil, 0.0, 0.95},
+		{"fully saturated", 0.0, nil, 0.0, 0.0},
+		{"overloaded negative", -0.2 * 0.8 * 0.95, nil, 0.0, 0.0},
+		{"full budget", 1.0, nil, 0.0, 1.0},
+		{"near zero budget", 0.01, nil, 0.0, 0.01},
+		{"NaN", math.NaN(), nil, 0.0, 0.0},
+		{"error fail closed", 0, errors.New("conn refused"), 0.0, 0.0},
+		{"error fail open", 0, errors.New("conn refused"), 1.0, 1.0},
+		{"fallback clamped above one", 0, errors.New("error"), 2.0, 1.0},
+		{"fallback clamped below zero", 0, errors.New("error"), -1.0, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var source *mockMetricSource
+			if tt.err != nil {
+				source = &mockMetricSource{err: tt.err}
+			} else {
+				source = &mockMetricSource{samples: []Sample{{Value: tt.budget}}}
+			}
+			gate := NewBudgetDispatchGate(source, tt.fallback)
+			require.InDelta(t, tt.expected, gate.Budget(context.Background()), 1e-9)
+		})
+	}
 }
 
-func TestSaturationDispatchGate_NaN_FailOpen(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: math.NaN()}}},
-		0.8, 0.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
+func TestMetricDispatchGate(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     float64
+		err       error
+		threshold float64
+		fallback  float64
+		expected  float64
+	}{
+		{"above threshold", 0.5, nil, 0.3, 0.0, 0.5},
+		{"at threshold", 0.3, nil, 0.3, 0.0, 0.0},
+		{"below threshold", 0.2, nil, 0.3, 0.0, 0.0},
+		{"fallback on error", 0, errors.New("error"), 0.8, 0.5, 0.5},
+	}
 
-func TestSaturationDispatchGate_Inf_FailOpen(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: math.Inf(1)}}},
-		0.8, 0.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_NaN_FailClosed(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: math.NaN()}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_Inf_FailClosed(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: math.Inf(1)}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_SaturationAboveOne_AboveThreshold(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 1.5}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_SaturationAboveOne_HighThreshold(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 1.5}}},
-		2.0, 1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestSaturationDispatchGate_NegativeSaturation(t *testing.T) {
-	gate := NewSaturationDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: -0.5}}},
-		0.8, 1.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
-
-// --- NewBudgetDispatchGate tests (threshold=1.0, fallback is direct budget) ---
-
-func TestBudgetDispatchGate_CoreFormula(t *testing.T) {
-	// PromQL returns combined saturation: F_SYS=0.5 + F_EPP=0.1 + B=0.05 = 0.65
-	// Budget = 1 - 0.65 = 0.35
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.65}}},
-		0.0,
-	)
-	require.InDelta(t, 0.35, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestBudgetDispatchGate_ZeroLoad(t *testing.T) {
-	// Combined saturation: 0 + 0 + 0.05 = 0.05 → budget 0.95
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.05}}},
-		0.0,
-	)
-	require.InDelta(t, 0.95, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestBudgetDispatchGate_Overloaded(t *testing.T) {
-	// Combined saturation: 0.8 + 0.2 + 0.05 = 1.05 → budget clamped to 0
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 1.05}}},
-		0.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_Error_FailClosed(t *testing.T) {
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{err: errors.New("connection refused")},
-		0.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_Error_FailOpen(t *testing.T) {
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{err: errors.New("connection refused")},
-		1.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_EmptySamples(t *testing.T) {
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{}},
-		0.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_NaN(t *testing.T) {
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: math.NaN()}}},
-		0.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_ExactlyOne(t *testing.T) {
-	// Combined saturation = 1.0 → at threshold → budget 0.0
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 1.0}}},
-		0.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_JustBelowOne(t *testing.T) {
-	// Combined saturation = 0.99 → budget = 0.01
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.99}}},
-		0.0,
-	)
-	require.InDelta(t, 0.01, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestBudgetDispatchGate_NegativeClamped(t *testing.T) {
-	// Negative combined saturation → budget clamped to 1.0
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: -0.5}}},
-		0.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_FallbackClampedAboveOne(t *testing.T) {
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{err: errors.New("error")},
-		2.0,
-	)
-	require.Equal(t, 1.0, gate.Budget(context.Background()))
-}
-
-func TestBudgetDispatchGate_FallbackClampedBelowZero(t *testing.T) {
-	gate := NewBudgetDispatchGate(
-		&mockMetricSource{err: errors.New("error")},
-		-1.0,
-	)
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-// --- NewMetricDispatchGate tests (generic, fallback is direct budget) ---
-
-func TestMetricDispatchGate_CustomThreshold(t *testing.T) {
-	gate := NewMetricDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.5}}},
-		0.6, 0.0,
-	)
-	// 0.5 < 0.6 threshold → budget = 1 - 0.5 = 0.5
-	require.InDelta(t, 0.5, gate.Budget(context.Background()), 1e-9)
-}
-
-func TestMetricDispatchGate_AtCustomThreshold(t *testing.T) {
-	gate := NewMetricDispatchGate(
-		&mockMetricSource{samples: []Sample{{Value: 0.6}}},
-		0.6, 0.0,
-	)
-	// 0.6 >= 0.6 threshold → budget = 0.0
-	require.Equal(t, 0.0, gate.Budget(context.Background()))
-}
-
-func TestMetricDispatchGate_FallbackDirect(t *testing.T) {
-	gate := NewMetricDispatchGate(
-		&mockMetricSource{err: errors.New("error")},
-		0.8, 0.5,
-	)
-	// Error → returns fallback budget directly (0.5)
-	require.Equal(t, 0.5, gate.Budget(context.Background()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var source *mockMetricSource
+			if tt.err != nil {
+				source = &mockMetricSource{err: tt.err}
+			} else {
+				source = &mockMetricSource{samples: []Sample{{Value: tt.value}}}
+			}
+			gate := NewMetricDispatchGate(source, tt.threshold, tt.fallback)
+			require.InDelta(t, tt.expected, gate.Budget(context.Background()), 1e-9)
+		})
+	}
 }

--- a/pkg/async/inference/flowcontrol/metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/metric_source_test.go
@@ -171,10 +171,10 @@ func TestBuildBudgetPromQL_ContainsExpectedMetrics(t *testing.T) {
 		"my-pool", 100, 0.05,
 	)
 	require.NoError(t, err)
-	require.Contains(t, source.expr, `inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
+	require.Contains(t, source.expr, `1 - inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
 	require.Contains(t, source.expr, `inference_extension_flow_control_queue_size{inference_pool="my-pool"}`)
 	require.Contains(t, source.expr, "/ 100")
-	require.Contains(t, source.expr, "0.05")
+	require.Contains(t, source.expr, "0.95")
 }
 
 func TestBuildBudgetPromQL_RequiresPool(t *testing.T) {
@@ -192,7 +192,7 @@ func TestNewSaturationPromQLSourceFromConfig_DefaultQuery(t *testing.T) {
 		map[string]string{"pool": "my-pool"},
 	)
 	require.NoError(t, err)
-	require.Contains(t, source.expr, `inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
+	require.Contains(t, source.expr, `1 - inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
 }
 
 func TestNewSaturationPromQLSourceFromConfig_RequiresPool(t *testing.T) {

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -34,8 +34,9 @@ func NewSaturationPromQLSourceFromConfig(promConfig promapi.Config, params map[s
 		return nil, fmt.Errorf("inference pool name is required for saturation PromQL")
 	}
 
-	return NewPromQLMetricSourceFromLabels(promConfig, "inference_extension_flow_control_pool_saturation",
+	queryExpr := "1 - " + buildPromQL("inference_extension_flow_control_pool_saturation",
 		map[string]string{"inference_pool": inferencePool})
+	return NewPromQLMetricSource(promConfig, queryExpr)
 }
 
 // NewPromQLMetricSourceFromLabels constructs a PromQL instant vector selector from a metric
@@ -81,9 +82,9 @@ func NewBudgetPromQLSourceFromConfig(promConfig promapi.Config, params map[strin
 	return NewBudgetPromQL(promConfig, inferencePoolStr, maxSys, baseline)
 }
 
-// NewBudgetPromQL constructs a PromQL expression for the dispatch budget formula:
+// NewBudgetPromQL constructs a PromQL expression for the multiplicative dispatch budget:
 //
-//	F_SYS + F_EPP + B
+//	(1 - F_SYS) * (1 - F_EPP) * (1 - B)
 //
 // where:
 //   - F_SYS = inference_extension_flow_control_pool_saturation
@@ -94,9 +95,9 @@ func NewBudgetPromQL(promConfig promapi.Config, inferencePool string, maxSys flo
 		return nil, fmt.Errorf("inference pool name is required for budget PromQL")
 	}
 	label := strconv.Quote(inferencePool)
-	query := fmt.Sprintf(`inference_extension_flow_control_pool_saturation{inference_pool=%s}
-			+ on(inference_pool) (sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / %g)
-			+ %g`, label, label, maxSys, baseline)
+	query := fmt.Sprintf(`(1 - inference_extension_flow_control_pool_saturation{inference_pool=%s})
+			* on(inference_pool) (1 - sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / %g)
+			* %g`, label, label, maxSys, 1-baseline)
 
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -26,8 +26,8 @@ import (
 )
 
 // NewSaturationPromQLSourceFromConfig builds a PromQLMetricSource for the saturation use case.
-// It constructs a PromQL query for inference_extension_flow_control_pool_saturation
-// filtered by the "pool" param (required).
+// It returns a budget value (1 - saturation) by constructing a PromQL query of the form
+// "1 - inference_extension_flow_control_pool_saturation{...}", filtered by the "pool" param (required).
 func NewSaturationPromQLSourceFromConfig(promConfig promapi.Config, params map[string]string) (*PromQLMetricSource, error) {
 	inferencePool := params["pool"]
 	if inferencePool == "" {

--- a/test/e2e/prom-mock/main.go
+++ b/test/e2e/prom-mock/main.go
@@ -32,8 +32,8 @@ func main() {
 
 // handleQuery returns a single Prometheus vector result. If the query contains
 // "queue_size" it is a budget gate query: the mock returns the dispatch budget D
-// directly. Otherwise it returns the plain saturation value (used by the
-// saturation gate, which expects 1 - saturation from its PromQL source).
+// directly. Otherwise it returns the saturation budget (1 - saturation),
+// matching what the saturation gate's PromQL source produces.
 //
 // The Prometheus client sends queries as POST form body, so we parse both
 // URL params and form body to find the query expression.

--- a/test/e2e/prom-mock/main.go
+++ b/test/e2e/prom-mock/main.go
@@ -31,14 +31,13 @@ func main() {
 }
 
 // handleQuery returns a single Prometheus vector result. If the query contains
-// "queue_size" it is a budget gate query: the mock stores the dispatch budget D and
-// returns 1 - D as the combined saturation (F_SYS + F_EPP + B) that the gate expects.
-// Otherwise it returns the plain saturation value.
+// "queue_size" it is a budget gate query: the mock returns the dispatch budget D
+// directly. Otherwise it returns the plain saturation value (used by the
+// saturation gate, which expects 1 - saturation from its PromQL source).
 //
 // The Prometheus client sends queries as POST form body, so we parse both
 // URL params and form body to find the query expression.
 func (s *server) handleQuery(w http.ResponseWriter, r *http.Request) {
-	// Prometheus client_golang sends the query as a POST form body.
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "failed to parse form", http.StatusBadRequest)
 		return
@@ -48,10 +47,10 @@ func (s *server) handleQuery(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	var value string
 	if strings.Contains(query, "inference_extension_flow_control_queue_size") {
-		budget, _ := strconv.ParseFloat(s.budget, 64)
-		value = strconv.FormatFloat(1.0-budget, 'f', -1, 64)
+		value = s.budget
 	} else {
-		value = s.saturation
+		saturation, _ := strconv.ParseFloat(s.saturation, 64)
+		value = strconv.FormatFloat(1.0-saturation, 'f', -1, 64)
 	}
 	s.mu.Unlock()
 


### PR DESCRIPTION
## What does this PR do?

Follow up to #106, improves the formula according to https://github.com/llm-d-incubation/batch-gateway/pull/371

## Why is this change needed?

As noted in #106 the previous version of the formula was adding together different quantities (different denominators); the multiplicative version addresses the problem.

- originally: Additive, `1 - (F_SYS + F_EPP + B)`
- updated: Multiplicative, `(1 - F_SYS) × (1 - F_EPP) × (1 - B)`

Contextually, I am also making the following changes, to streamline the semantics of the gate:

- metric_dispatch_gate.go: Gate now passes through the value directly (no `1 - value`
 inversion). Threshold flipped to <= (closes when budget is at or below threshold).
- promql_metric_source_factory.go: Budget PromQL returns the product directly. Saturation
  PromQL returns 1 - saturation so the value is already a budget.

The tests have been updated accordingly, but I am also updating them to table-based tests, for conciseness and readability.


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Follow up to #106; e2e tests might need adjustments in #115