### PR TITLE
feat: honor Retry-After header on HTTP 429 responses

### DIFF
--- a/api/inference_error.go
+++ b/api/inference_error.go
@@ -1,6 +1,9 @@
 package api
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // ErrorCategory defines the category of an inference client error.
 type ErrorCategory string
@@ -37,7 +40,8 @@ var _ InferenceError = (*ClientError)(nil)
 type ClientError struct {
 	ErrorCategory ErrorCategory
 	Message       string
-	RawError      error // original error if available
+	RawError      error         // original error if available
+	RetryAfter    time.Duration // server-specified retry delay from Retry-After header (0 means not set)
 }
 
 func (e *ClientError) Error() string {

--- a/pkg/asyncworker/http_client.go
+++ b/pkg/asyncworker/http_client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 )
@@ -59,10 +61,12 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 
 	// Check for rate limiting / load shedding (429)
 	if result.StatusCode == 429 {
+		retryAfter, _ := parseRetryAfter(result.Header.Get("Retry-After"))
 		return body, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryRateLimit,
 			Message:       fmt.Sprintf("rate limited: status code %d", result.StatusCode),
 			RawError:      nil,
+			RetryAfter:    retryAfter,
 		}
 	}
 
@@ -85,4 +89,26 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 	}
 
 	return body, nil
+}
+
+// parseRetryAfter parses a Retry-After header value, which can be either
+// a number of seconds (e.g. "120") or an HTTP-date (e.g. "Thu, 01 Dec 1994 16:00:00 GMT").
+// Returns the parsed duration and true if successful, or (0, false) if empty or unparseable.
+func parseRetryAfter(value string) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	// Try integer seconds first
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second, true
+	}
+	// Try HTTP-date formats (IMF-fixdate, RFC 850, asctime)
+	if t, err := http.ParseTime(value); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			d = 0
+		}
+		return d, true
+	}
+	return 0, false
 }

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -80,7 +80,13 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 				if inferenceErr.Category().Sheddable() {
 					metrics.SheddedRequests.Inc()
 				}
-				retryMessage(msg, retryChannel, resultChannel)
+				// Pass server-specified Retry-After duration if available.
+				var retryAfter time.Duration
+				var clientErr *asyncapi.ClientError
+				if errors.As(err, &clientErr) {
+					retryAfter = clientErr.RetryAfter
+				}
+				retryMessage(msg, retryChannel, resultChannel, retryAfter)
 			}
 			sendInferenceRequest()
 		}
@@ -112,7 +118,7 @@ func validateAndMarshall(resultChannel chan asyncapi.ResultMessage, msg asyncapi
 }
 
 // If it is not after deadline, just publish again.
-func retryMessage(msg asyncapi.EmbelishedRequestMessage, retryChannel chan asyncapi.RetryMessage, resultChannel chan asyncapi.ResultMessage) {
+func retryMessage(msg asyncapi.EmbelishedRequestMessage, retryChannel chan asyncapi.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration) {
 	deadline, err := strconv.ParseInt(msg.DeadlineUnixSec, 10, 64)
 	if err != nil { // Can't really happen because this was already parsed in the past. But we don't care to have this branch.
 		resultChannel <- CreateErrorResultMessage(msg.RequestMessage, "Failed to parse deadline. Should be in Unix time")
@@ -122,17 +128,28 @@ func retryMessage(msg asyncapi.EmbelishedRequestMessage, retryChannel chan async
 	if secondsToDeadline <= 0 {
 		metrics.ExceededDeadlineReqs.Inc()
 		resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage)
-	} else {
-		msg.RetryCount++
-		finalDuration := expBackoffDuration(msg.RetryCount, int(secondsToDeadline))
-		metrics.Retries.Inc()
-		retryChannel <- asyncapi.RetryMessage{
-			EmbelishedRequestMessage: msg,
-			BackoffDurationSeconds:   finalDuration,
-		}
-
+		return
 	}
 
+	finalDuration := expBackoffDuration(msg.RetryCount+1, int(secondsToDeadline))
+	// Honor server-specified Retry-After when it exceeds the computed backoff,
+	// but never schedule a retry beyond the message deadline.
+	if retryAfterSec := retryAfter.Seconds(); retryAfterSec > finalDuration {
+		finalDuration = retryAfterSec
+	}
+
+	if finalDuration >= float64(secondsToDeadline) {
+		metrics.ExceededDeadlineReqs.Inc()
+		resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage)
+		return
+	}
+
+	msg.RetryCount++
+	metrics.Retries.Inc()
+	retryChannel <- asyncapi.RetryMessage{
+		EmbelishedRequestMessage: msg,
+		BackoffDurationSeconds:   finalDuration,
+	}
 }
 func CreateErrorResultMessage(msg asyncapi.RequestMessage, errMsg string) asyncapi.ResultMessage {
 	errorPayload := map[string]string{"error": errMsg}

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -29,7 +29,7 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 		HttpHeaders: map[string]string{},
 		RequestURL:  "",
 	}
-	retryMessage(msg, retryChannel, resultChannel)
+	retryMessage(msg, retryChannel, resultChannel, 0)
 	if len(retryChannel) > 0 {
 		t.Errorf("Message that its deadline passed should not be retried. Got a message in the retry channel")
 		return
@@ -61,7 +61,7 @@ func TestRetryMessage_retry(t *testing.T) {
 		HttpHeaders: map[string]string{},
 		RequestURL:  "",
 	}
-	retryMessage(msg, retryChannel, resultChannel)
+	retryMessage(msg, retryChannel, resultChannel, 0)
 	if len(resultChannel) > 0 {
 		t.Errorf("Should not have any messages in the result channel")
 		return
@@ -385,7 +385,7 @@ func TestRetryMessage_deadlineExact(t *testing.T) {
 			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Unix()), // exactly now
 		},
 	}
-	retryMessage(msg, retryChannel, resultChannel)
+	retryMessage(msg, retryChannel, resultChannel, 0)
 	if len(retryChannel) > 0 {
 		t.Errorf("secondsToDeadline==0 should not produce a retry")
 	}
@@ -398,6 +398,163 @@ func TestRetryMessage_deadlineExact(t *testing.T) {
 	json.Unmarshal([]byte(result.Payload), &resultMap) // nolint:errcheck
 	if resultMap["error"] != "deadline exceeded" {
 		t.Errorf("expected 'deadline exceeded', got: %s", resultMap["error"])
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantOK   bool
+		wantZero bool
+	}{
+		{name: "integer seconds", value: "120", wantOK: true},
+		{name: "zero seconds", value: "0", wantOK: true, wantZero: true},
+		{name: "HTTP-date future", value: time.Now().Add(10 * time.Second).UTC().Format(http.TimeFormat), wantOK: true},
+		{name: "HTTP-date past", value: time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat), wantOK: true, wantZero: true},
+		{name: "negative integer", value: "-5", wantOK: false},
+		{name: "invalid value", value: "abc", wantOK: false},
+		{name: "empty string", value: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := parseRetryAfter(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("parseRetryAfter(%q): ok = %v, want %v", tt.value, ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if tt.wantZero && d != 0 {
+				t.Errorf("expected zero duration, got %v", d)
+			}
+			if !tt.wantZero && d <= 0 {
+				t.Errorf("expected positive duration, got %v", d)
+			}
+		})
+	}
+}
+
+func TestRetryMessage_retryAfterHonored(t *testing.T) {
+	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	msg := asyncapi.EmbelishedRequestMessage{
+		RequestMessage: asyncapi.RequestMessage{
+			Id:              "retry-after-test",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Add(time.Second*100).Unix()),
+		},
+	}
+
+	// Server says wait 30s; expBackoff for retry 1 would be ~[1,2) seconds,
+	// so the Retry-After value should win.
+	retryMessage(msg, retryChannel, resultChannel, 30*time.Second)
+	if len(retryChannel) != 1 {
+		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
+	}
+	retryMsg := <-retryChannel
+	if retryMsg.BackoffDurationSeconds < 30 {
+		t.Errorf("expected backoff >= 30s (Retry-After), got %f", retryMsg.BackoffDurationSeconds)
+	}
+}
+
+func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
+	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	msg := asyncapi.EmbelishedRequestMessage{
+		RequestMessage: asyncapi.RequestMessage{
+			Id:              "retry-after-small",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      5, // high retry count → large expBackoff
+			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Add(time.Second*100).Unix()),
+		},
+	}
+
+	// Server says wait 1s, but expBackoff at retry 5 is much larger.
+	// expBackoff should win.
+	retryMessage(msg, retryChannel, resultChannel, 1*time.Second)
+	if len(retryChannel) != 1 {
+		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
+	}
+	retryMsg := <-retryChannel
+	if retryMsg.BackoffDurationSeconds <= 1.0 {
+		t.Errorf("expected backoff > 1s (expBackoff should dominate), got %f", retryMsg.BackoffDurationSeconds)
+	}
+}
+
+func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
+	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	msg := asyncapi.EmbelishedRequestMessage{
+		RequestMessage: asyncapi.RequestMessage{
+			Id:              "retry-after-exceeds-deadline",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Add(5*time.Second).Unix()),
+		},
+	}
+
+	// Server says wait 30s, but deadline is only 5s away → deadline exceeded.
+	retryMessage(msg, retryChannel, resultChannel, 30*time.Second)
+	if len(retryChannel) > 0 {
+		t.Errorf("should not retry when Retry-After exceeds deadline")
+	}
+	if len(resultChannel) != 1 {
+		t.Fatalf("expected deadline-exceeded result, got %d messages", len(resultChannel))
+	}
+	result := <-resultChannel
+	var resultMap map[string]any
+	json.Unmarshal([]byte(result.Payload), &resultMap) // nolint:errcheck
+	if resultMap["error"] != "deadline exceeded" {
+		t.Errorf("expected 'deadline exceeded', got: %s", resultMap["error"])
+	}
+}
+
+func TestRateLimitRequest_WithRetryAfterHeader(t *testing.T) {
+	msgId := "429-with-header"
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set("Retry-After", "25")
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       nil,
+			Header:     header,
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	deadline := time.Now().Add(time.Second * 100).Unix()
+
+	requestChannel <- asyncapi.EmbelishedRequestMessage{
+		RequestMessage: asyncapi.RequestMessage{
+			Id:              msgId,
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", deadline),
+			Payload:         map[string]any{"model": "test", "prompt": "hi"},
+		},
+		RequestURL:  "http://localhost:30800/v1/completions",
+		HttpHeaders: map[string]string{},
+	}
+
+	select {
+	case r := <-retryChannel:
+		if r.Id != msgId {
+			t.Errorf("expected retry message id %s, got %s", msgId, r.Id)
+		}
+		if r.BackoffDurationSeconds < 25 {
+			t.Errorf("expected backoff >= 25s (Retry-After header), got %f", r.BackoffDurationSeconds)
+		}
+	case <-resultChannel:
+		t.Errorf("should not get result from a 429 response, should retry")
+	case <-time.After(time.Second):
+		t.Errorf("timeout waiting for retry")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

When the inference backend returns HTTP 429 (Too Many Requests) with a `Retry-After` header, the worker will parses and uses it as a floor for the retry backoff duration. 

## Why is this change needed?

Without this, the worker uses purely client-side exponential backoff on 429 responses, ignoring the server's explicit guidance on when to retry.

Honoring `Retry-After` aligns retry behavior with the server's load-shedding strategy and avoids wasted work.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
