### PR TITLE
fix: prevent goroutine leak on worker shutdown

### DIFF
--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -35,7 +35,7 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 				// Only count first attempt as a new request.
 				metrics.AsyncReqs.Inc()
 			}
-			payloadBytes := validateAndMarshall(resultChannel, msg.RequestMessage)
+			payloadBytes := validateAndMarshal(ctx, resultChannel, msg.RequestMessage)
 			if payloadBytes == nil {
 				continue
 			}
@@ -53,16 +53,19 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 				reqCtx, cancel := context.WithDeadline(ctx, reqDeadline)
 				defer cancel()
 
-				logger.V(logutil.DEBUG).Info("Sending inference request: " + msg.RequestURL)
+				logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
 				responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
 
 				if err == nil {
 					// Success - got a valid response
 					metrics.SuccessfulReqs.Inc()
-					resultChannel <- asyncapi.ResultMessage{
+					select {
+					case resultChannel <- asyncapi.ResultMessage{
 						Id:       msg.Id,
 						Payload:  string(responseBody),
 						Metadata: msg.Metadata,
+					}:
+					case <-ctx.Done():
 					}
 					return
 				}
@@ -72,7 +75,10 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 				if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {
 					// Unknown error type or fatal error - fail immediately
 					metrics.FailedReqs.Inc()
-					resultChannel <- CreateErrorResultMessage(msg.RequestMessage, fmt.Sprintf("Failed to send request to inference: %s", err.Error()))
+					select {
+					case resultChannel <- CreateErrorResultMessage(msg.RequestMessage, fmt.Sprintf("Failed to send request to inference: %s", err.Error())):
+					case <-ctx.Done():
+					}
 					return
 				}
 
@@ -86,7 +92,7 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 				if errors.As(err, &clientErr) {
 					retryAfter = clientErr.RetryAfter
 				}
-				retryMessage(msg, retryChannel, resultChannel, retryAfter)
+				retryMessage(ctx, msg, retryChannel, resultChannel, retryAfter)
 			}
 			sendInferenceRequest()
 		}
@@ -94,40 +100,55 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 }
 
 // parsing and validating payload. On failure puts an error msg on the result-channel and returns nil
-func validateAndMarshall(resultChannel chan asyncapi.ResultMessage, msg asyncapi.RequestMessage) []byte {
+func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultMessage, msg asyncapi.RequestMessage) []byte {
 	deadline, err := strconv.ParseInt(msg.DeadlineUnixSec, 10, 64)
 	if err != nil {
 		metrics.FailedReqs.Inc()
-		resultChannel <- CreateErrorResultMessage(msg, "Failed to parse deadline, should be in Unix seconds.")
+		select {
+		case resultChannel <- CreateErrorResultMessage(msg, "Failed to parse deadline, should be in Unix seconds."):
+		case <-ctx.Done():
+		}
 		return nil
 	}
 
 	if deadline < time.Now().Unix() {
 		metrics.ExceededDeadlineReqs.Inc()
-		resultChannel <- CreateDeadlineExceededResultMessage(msg)
+		select {
+		case resultChannel <- CreateDeadlineExceededResultMessage(msg):
+		case <-ctx.Done():
+		}
 		return nil
 	}
 
 	payloadBytes, err := json.Marshal(msg.Payload)
 	if err != nil {
 		metrics.FailedReqs.Inc()
-		resultChannel <- CreateErrorResultMessage(msg, fmt.Sprintf("Failed to marshal message's payload: %s", err.Error()))
+		select {
+		case resultChannel <- CreateErrorResultMessage(msg, fmt.Sprintf("Failed to marshal message's payload: %s", err.Error())):
+		case <-ctx.Done():
+		}
 		return nil
 	}
 	return payloadBytes
 }
 
 // If it is not after deadline, just publish again.
-func retryMessage(msg asyncapi.EmbelishedRequestMessage, retryChannel chan asyncapi.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration) {
+func retryMessage(ctx context.Context, msg asyncapi.EmbelishedRequestMessage, retryChannel chan asyncapi.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration) {
 	deadline, err := strconv.ParseInt(msg.DeadlineUnixSec, 10, 64)
 	if err != nil { // Can't really happen because this was already parsed in the past. But we don't care to have this branch.
-		resultChannel <- CreateErrorResultMessage(msg.RequestMessage, "Failed to parse deadline. Should be in Unix time")
+		select {
+		case resultChannel <- CreateErrorResultMessage(msg.RequestMessage, "Failed to parse deadline. Should be in Unix time"):
+		case <-ctx.Done():
+		}
 		return
 	}
 	secondsToDeadline := deadline - time.Now().Unix()
 	if secondsToDeadline <= 0 {
 		metrics.ExceededDeadlineReqs.Inc()
-		resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage)
+		select {
+		case resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage):
+		case <-ctx.Done():
+		}
 		return
 	}
 
@@ -140,15 +161,21 @@ func retryMessage(msg asyncapi.EmbelishedRequestMessage, retryChannel chan async
 
 	if finalDuration >= float64(secondsToDeadline) {
 		metrics.ExceededDeadlineReqs.Inc()
-		resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage)
+		select {
+		case resultChannel <- CreateDeadlineExceededResultMessage(msg.RequestMessage):
+		case <-ctx.Done():
+		}
 		return
 	}
 
 	msg.RetryCount++
 	metrics.Retries.Inc()
-	retryChannel <- asyncapi.RetryMessage{
+	select {
+	case retryChannel <- asyncapi.RetryMessage{
 		EmbelishedRequestMessage: msg,
 		BackoffDurationSeconds:   finalDuration,
+	}:
+	case <-ctx.Done():
 	}
 }
 func CreateErrorResultMessage(msg asyncapi.RequestMessage, errMsg string) asyncapi.ResultMessage {

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -29,7 +29,7 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 		HttpHeaders: map[string]string{},
 		RequestURL:  "",
 	}
-	retryMessage(msg, retryChannel, resultChannel, 0)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0)
 	if len(retryChannel) > 0 {
 		t.Errorf("Message that its deadline passed should not be retried. Got a message in the retry channel")
 		return
@@ -61,7 +61,7 @@ func TestRetryMessage_retry(t *testing.T) {
 		HttpHeaders: map[string]string{},
 		RequestURL:  "",
 	}
-	retryMessage(msg, retryChannel, resultChannel, 0)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0)
 	if len(resultChannel) > 0 {
 		t.Errorf("Should not have any messages in the result channel")
 		return
@@ -385,7 +385,7 @@ func TestRetryMessage_deadlineExact(t *testing.T) {
 			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Unix()), // exactly now
 		},
 	}
-	retryMessage(msg, retryChannel, resultChannel, 0)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0)
 	if len(retryChannel) > 0 {
 		t.Errorf("secondsToDeadline==0 should not produce a retry")
 	}
@@ -449,7 +449,7 @@ func TestRetryMessage_retryAfterHonored(t *testing.T) {
 
 	// Server says wait 30s; expBackoff for retry 1 would be ~[1,2) seconds,
 	// so the Retry-After value should win.
-	retryMessage(msg, retryChannel, resultChannel, 30*time.Second)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second)
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
@@ -473,7 +473,7 @@ func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
 
 	// Server says wait 1s, but expBackoff at retry 5 is much larger.
 	// expBackoff should win.
-	retryMessage(msg, retryChannel, resultChannel, 1*time.Second)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 1*time.Second)
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
@@ -496,7 +496,7 @@ func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
 	}
 
 	// Server says wait 30s, but deadline is only 5s away → deadline exceeded.
-	retryMessage(msg, retryChannel, resultChannel, 30*time.Second)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second)
 	if len(retryChannel) > 0 {
 		t.Errorf("should not retry when Retry-After exceeds deadline")
 	}
@@ -555,6 +555,110 @@ func TestRateLimitRequest_WithRetryAfterHeader(t *testing.T) {
 		t.Errorf("should not get result from a 429 response, should retry")
 	case <-time.After(time.Second):
 		t.Errorf("timeout waiting for retry")
+	}
+}
+
+func TestValidateAndMarshal_cancelledCtxDoesNotBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Unbuffered channel: without the select guard this would block forever.
+	resultChannel := make(chan asyncapi.ResultMessage)
+
+	msg := asyncapi.RequestMessage{
+		Id:              "cancel-test",
+		DeadlineUnixSec: "not-a-number", // triggers the parse-error send path
+	}
+
+	done := make(chan struct{})
+	go func() {
+		validateAndMarshal(ctx, resultChannel, msg)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Function returned without blocking — test passes.
+	case <-time.After(2 * time.Second):
+		t.Fatal("validateAndMarshal blocked on cancelled ctx with full/unbuffered channel")
+	}
+}
+
+func TestRetryMessage_cancelledCtxDoesNotBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Unbuffered channels: sends would block without the select guard.
+	retryChannel := make(chan asyncapi.RetryMessage)
+	resultChannel := make(chan asyncapi.ResultMessage)
+
+	msg := asyncapi.EmbelishedRequestMessage{
+		RequestMessage: asyncapi.RequestMessage{
+			Id:              "cancel-retry-test",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", time.Now().Add(10*time.Second).Unix()),
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		retryMessage(ctx, msg, retryChannel, resultChannel, 0)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retryMessage blocked on cancelled ctx with unbuffered channels")
+	}
+}
+
+func TestWorker_cancelledCtxExitsPromptly(t *testing.T) {
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       nil,
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
+	// Unbuffered result channel: the worker must not block trying to send.
+	retryChannel := make(chan asyncapi.RetryMessage)
+	resultChannel := make(chan asyncapi.ResultMessage)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(100 * time.Second).Unix()
+	requestChannel <- asyncapi.EmbelishedRequestMessage{
+		RequestMessage: asyncapi.RequestMessage{
+			Id:              "worker-cancel-test",
+			CreatedUnixSec:  fmt.Sprintf("%d", time.Now().Unix()),
+			RetryCount:      0,
+			DeadlineUnixSec: fmt.Sprintf("%d", deadline),
+			Payload:         map[string]any{"model": "test", "prompt": "hi"},
+		},
+		RequestURL:  "http://localhost:30800/v1/completions",
+		HttpHeaders: map[string]string{},
+	}
+
+	// Give the worker a moment to pick up the message and attempt the send,
+	// then cancel so it must exit via the ctx.Done() branch.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker goroutine did not exit after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

All channel sends in the async worker (`resultChannel`, `retryChannel`) are wrapped with `select { case ch <- ...; case <-ctx.Done(): }` so that goroutines are no longer blocked indefinitely when the context is cancelled during shutdown and no consumer is draining the channels.

Also fixes a typo: `validateAndMarshall` → `validateAndMarshal`.

## Why is this change needed?

When the worker process shuts down (context cancelled), goroutines that are sending to unbuffered or full channels will block forever — leaking goroutines and preventing clean shutdown.

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)

## Related Issues

N/A