### PR TITLE
fix: prevent result loss on worker shutdown

### DIFF
--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -135,7 +135,7 @@ func (r *RedisMQFlow) Start(ctx context.Context) {
 
 	go r.retryWorker(ctx, r.rdb)
 
-	go resultWorker(ctx, r.rdb, r.resultChannel, *resultQueueName)
+	go r.resultWorker(ctx, *resultQueueName)
 }
 func (r *RedisMQFlow) RequestChannels() []api.RequestChannel {
 
@@ -157,35 +157,59 @@ func (r *RedisMQFlow) ResultChannel() chan api.ResultMessage {
 
 // Listening on the results channel and responsible for writing results into Redis.
 // Batches multiple results into a single Redis pipeline call to reduce round-trips.
-func resultWorker(ctx context.Context, rdb *redis.Client, resultChannel chan api.ResultMessage, resultsQueueName string) {
-	logger := log.FromContext(ctx)
+func (r *RedisMQFlow) resultWorker(ctx context.Context, resultsQueueName string) {
+	processMsg := func(flushCtx context.Context, msg api.ResultMessage) {
+		batch := r.collectResultBatch(msg)
+		r.flushResultBatch(flushCtx, batch, resultsQueueName)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
-			return
-
-		case msg := <-resultChannel:
-			// Collect a batch: start with the message we already received,
-			// then drain any additional available messages without blocking.
-			batch := make([]api.ResultMessage, 1, maxResultBatchSize)
-			batch[0] = msg
-			done := false
-			for len(batch) < maxResultBatchSize && !done {
+			for {
 				select {
-				case result := <-resultChannel:
-					batch = append(batch, result)
+				case msg := <-r.resultChannel:
+					processMsg(context.Background(), msg)
 				default:
-					done = true
+					return
 				}
 			}
+		case msg := <-r.resultChannel:
+			processMsg(ctx, msg)
+		}
+	}
+}
 
-			pipe := rdb.Pipeline()
-			for _, result := range batch {
-				pipe.Publish(ctx, resultsQueueName, marshalResultMessage(result))
+func (r *RedisMQFlow) collectResultBatch(first api.ResultMessage) []api.ResultMessage {
+	batch := make([]api.ResultMessage, 1, maxResultBatchSize)
+	batch[0] = first
+	for len(batch) < maxResultBatchSize {
+		select {
+		case result := <-r.resultChannel:
+			batch = append(batch, result)
+		default:
+			return batch
+		}
+	}
+	return batch
+}
+
+func (r *RedisMQFlow) flushResultBatch(ctx context.Context, batch []api.ResultMessage, resultsQueueName string) {
+	logger := log.FromContext(ctx)
+	const maxRetries = 3
+	for attempt := range maxRetries {
+		pipe := r.rdb.Pipeline()
+		for _, result := range batch {
+			pipe.Publish(ctx, resultsQueueName, marshalResultMessage(result))
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to publish result batch to Redis",
+				"batchSize", len(batch), "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * 100 * time.Millisecond)
 			}
-			if _, err := pipe.Exec(ctx); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to publish result batch to Redis", "batchSize", len(batch))
-			}
+		} else {
+			return
 		}
 	}
 }

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+func newTestMQFlow(rdb *redis.Client) *RedisMQFlow {
+	return &RedisMQFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+	}
+}
+
 func TestPubsubResultWorker_BatchPublish(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
@@ -23,7 +30,7 @@ func TestPubsubResultWorker_BatchPublish(t *testing.T) {
 	defer cancel()
 
 	queue := "result-pubsub-queue"
-	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+	flow := newTestMQFlow(rdb)
 
 	// Subscribe so published messages are captured.
 	sub := rdb.Subscribe(ctx, queue)
@@ -34,13 +41,13 @@ func TestPubsubResultWorker_BatchPublish(t *testing.T) {
 	// so they are all available for a single batch drain.
 	numMessages := 5
 	for i := 0; i < numMessages; i++ {
-		resultCh <- api.ResultMessage{
+		flow.resultChannel <- api.ResultMessage{
 			Id:      "msg-" + string(rune('A'+i)),
 			Payload: "payload-" + string(rune('A'+i)),
 		}
 	}
 
-	go resultWorker(ctx, rdb, resultCh, queue)
+	go flow.resultWorker(ctx, queue)
 
 	received := make(map[string]bool)
 	timeout := time.After(2 * time.Second)
@@ -75,16 +82,16 @@ func TestPubsubResultWorker_SingleMessage(t *testing.T) {
 	defer cancel()
 
 	queue := "result-single-queue"
-	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+	flow := newTestMQFlow(rdb)
 
 	sub := rdb.Subscribe(ctx, queue)
 	defer sub.Close() // nolint:errcheck
 	pubsubCh := sub.Channel()
 
-	go resultWorker(ctx, rdb, resultCh, queue)
+	go flow.resultWorker(ctx, queue)
 
 	// Send a single message — should be flushed immediately as a batch of 1.
-	resultCh <- api.ResultMessage{Id: "solo", Payload: "data"}
+	flow.resultChannel <- api.ResultMessage{Id: "solo", Payload: "data"}
 
 	select {
 	case msg := <-pubsubCh:
@@ -121,11 +128,11 @@ func TestPubsubResultWorker_ContextCancellation(t *testing.T) {
 	defer rdb.Close() // nolint:errcheck
 
 	ctx, cancel := context.WithCancel(context.Background())
-	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+	flow := newTestMQFlow(rdb)
 
 	done := make(chan bool)
 	go func() {
-		resultWorker(ctx, rdb, resultCh, "cancel-queue")
+		flow.resultWorker(ctx, "cancel-queue")
 		done <- true
 	}()
 
@@ -150,7 +157,7 @@ func TestPubsubResultWorker_BatchSizeCap(t *testing.T) {
 	defer cancel()
 
 	queue := "batch-cap-queue"
-	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+	flow := newTestMQFlow(rdb)
 
 	sub := rdb.Subscribe(ctx, queue)
 	defer sub.Close() // nolint:errcheck
@@ -160,13 +167,13 @@ func TestPubsubResultWorker_BatchSizeCap(t *testing.T) {
 	// deliver all of them across multiple pipeline flushes.
 	totalMessages := maxResultBatchSize + 10
 	for i := 0; i < totalMessages; i++ {
-		resultCh <- api.ResultMessage{
+		flow.resultChannel <- api.ResultMessage{
 			Id:      "cap-" + strconv.Itoa(i),
 			Payload: "data",
 		}
 	}
 
-	go resultWorker(ctx, rdb, resultCh, queue)
+	go flow.resultWorker(ctx, queue)
 
 	received := make(map[string]bool)
 	timeout := time.After(3 * time.Second)
@@ -194,13 +201,13 @@ func TestPubsubResultWorker_ConcurrentProducers(t *testing.T) {
 	defer cancel()
 
 	queue := "concurrent-queue"
-	resultCh := make(chan api.ResultMessage, resultChannelBuffer)
+	flow := newTestMQFlow(rdb)
 
 	sub := rdb.Subscribe(ctx, queue)
 	defer sub.Close() // nolint:errcheck
 	pubsubCh := sub.Channel()
 
-	go resultWorker(ctx, rdb, resultCh, queue)
+	go flow.resultWorker(ctx, queue)
 
 	// Simulate multiple inference workers sending results concurrently.
 	numProducers := 8
@@ -213,7 +220,7 @@ func TestPubsubResultWorker_ConcurrentProducers(t *testing.T) {
 		go func(producerID int) {
 			defer wg.Done()
 			for i := 0; i < msgsPerProducer; i++ {
-				resultCh <- api.ResultMessage{
+				flow.resultChannel <- api.ResultMessage{
 					Id:      "p" + strconv.Itoa(producerID) + "-" + strconv.Itoa(i),
 					Payload: "data",
 				}
@@ -238,6 +245,49 @@ func TestPubsubResultWorker_ConcurrentProducers(t *testing.T) {
 		case <-timeout:
 			t.Fatalf("Timeout: received only %d/%d messages", len(received), totalMessages)
 		}
+	}
+}
+
+func TestPubsubResultWorker_RetryAfterFailure(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	queue := "retry-pubsub-queue"
+	flow := newTestMQFlow(rdb)
+
+	sub := rdb.Subscribe(ctx, queue)
+	defer sub.Close() // nolint:errcheck
+	pubsubCh := sub.Channel()
+
+	// Start worker, then inject error so first Exec fails.
+	go flow.resultWorker(ctx, queue)
+	time.Sleep(50 * time.Millisecond)
+
+	s.SetError("READONLY simulated failure")
+	flow.resultChannel <- api.ResultMessage{Id: "retry-msg", Payload: "data"}
+
+	// Wait for the first attempt to fail.
+	time.Sleep(150 * time.Millisecond)
+
+	// Clear error so retry succeeds.
+	s.SetError("")
+
+	select {
+	case msg := <-pubsubCh:
+		var rm api.ResultMessage
+		if err := json.Unmarshal([]byte(msg.Payload), &rm); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if rm.Id != "retry-msg" {
+			t.Errorf("Expected retry-msg, got %s", rm.Id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for retried message")
 	}
 }
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -313,51 +313,71 @@ func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
 // Routes results to the queue specified in request metadata, or default queue if not specified.
 // Batches multiple results into a single Redis pipeline call to reduce round-trips.
 func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
-	logger := log.FromContext(ctx)
+	processMsg := func(flushCtx context.Context, msg api.ResultMessage) {
+		batch := r.collectResultBatch(msg)
+		r.flushResultBatch(flushCtx, batch)
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case msg := <-r.resultChannel:
-			// Collect a batch: start with the message we already received,
-			// then drain any additional available messages without blocking.
-			batch := make([]api.ResultMessage, 1, maxResultBatchSize)
-			batch[0] = msg
-			done := false
-			for len(batch) < maxResultBatchSize && !done {
+			for {
 				select {
-				case result := <-r.resultChannel:
-					batch = append(batch, result)
+				case msg := <-r.resultChannel:
+					processMsg(context.Background(), msg)
 				default:
-					done = true
+					return
 				}
 			}
+		case msg := <-r.resultChannel:
+			processMsg(ctx, msg)
+		}
+	}
+}
 
-			// Group by target queue and flush via pipeline.
-			defaultQueue := *ssResultQueueName
-			queued := make(map[string][]string)
-			for _, result := range batch {
-				resultQueue := defaultQueue
-				if result.Metadata != nil {
-					if customQueue, ok := result.Metadata["result_queue"]; ok && customQueue != "" {
-						resultQueue = customQueue
-					}
-				}
-				queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
-			}
+func (r *RedisSortedSetFlow) collectResultBatch(first api.ResultMessage) []api.ResultMessage {
+	batch := make([]api.ResultMessage, 1, maxResultBatchSize)
+	batch[0] = first
+	for len(batch) < maxResultBatchSize {
+		select {
+		case result := <-r.resultChannel:
+			batch = append(batch, result)
+		default:
+			return batch
+		}
+	}
+	return batch
+}
 
-			pipe := r.rdb.Pipeline()
-			for queue, msgs := range queued {
-				for _, msgStr := range msgs {
-					pipe.LPush(ctx, queue, msgStr)
-				}
+func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.ResultMessage) {
+	logger := log.FromContext(ctx)
+	defaultQueue := *ssResultQueueName
+	queued := make(map[string][]string)
+	for _, result := range batch {
+		resultQueue := defaultQueue
+		if customQueue := result.Metadata["result_queue"]; customQueue != "" {
+			resultQueue = customQueue
+		}
+		queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
+	}
+
+	const maxRetries = 3
+	for attempt := range maxRetries {
+		pipe := r.rdb.Pipeline()
+		for queue, msgs := range queued {
+			for _, msgStr := range msgs {
+				pipe.LPush(ctx, queue, msgStr)
 			}
-			if _, err := pipe.Exec(ctx); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to push result batch to Redis", "batchSize", len(batch))
-			} else {
-				logger.V(logutil.DEBUG).Info("Pushed result batch", "batchSize", len(batch))
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to push result batch to Redis",
+				"batchSize", len(batch), "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * 100 * time.Millisecond)
 			}
+		} else {
+			logger.V(logutil.DEBUG).Info("Pushed result batch", "batchSize", len(batch))
+			return
 		}
 	}
 }

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -592,6 +592,60 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 	}
 }
 
+func TestSortedSetFlow_ResultRetryAfterFailure(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "retry-result-queue"
+	origQueue := *ssResultQueueName
+	*ssResultQueueName = queue
+	defer func() { *ssResultQueueName = origQueue }()
+
+	flow := &RedisSortedSetFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
+	}
+
+	// Inject an error so the first Exec fails.
+	s.SetError("READONLY simulated failure")
+
+	go flow.resultWorker(ctx)
+
+	flow.resultChannel <- api.ResultMessage{Id: "retry-msg", Payload: "data"}
+
+	// Wait long enough for the first attempt to fail.
+	time.Sleep(150 * time.Millisecond)
+
+	// No results should be in Redis yet.
+	length, _ := rdb.LLen(ctx, queue).Result()
+	if length != 0 {
+		t.Fatalf("Expected 0 results while Redis is failing, got %d", length)
+	}
+
+	// Clear the error so subsequent retries succeed.
+	s.SetError("")
+
+	// Wait for retry to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	length, _ = rdb.LLen(ctx, queue).Result()
+	if length != 1 {
+		t.Fatalf("Expected 1 result after retry, got %d", length)
+	}
+
+	raw, _ := rdb.RPop(ctx, queue).Result()
+	var msg api.ResultMessage
+	json.Unmarshal([]byte(raw), &msg) // nolint:errcheck
+	if msg.Id != "retry-msg" {
+		t.Errorf("Expected retry-msg, got %s", msg.Id)
+	}
+}
+
 func TestSortedSetFlow_PartialBudget(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()


### PR DESCRIPTION
## What does this PR do?

- Refactors `resultWorker` in both `RedisMQFlow` and `RedisSortedSetFlow` to drain `resultChannel` on graceful shutdown (`ctx.Done()`),  so they are not silently dropped.

## Why is this change needed?

Previously, when the worker received a shutdown signal (context cancellation), it returned immediately — any results still buffered in `resultChannel` were permanently lost.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes https://github.com/llm-d-incubation/llm-d-async/issues/130
