### PR TITLE
fix: correct Retry-After typo comment

### DIFF
--- a/pkg/asyncworker/http_client.go
+++ b/pkg/asyncworker/http_client.go
@@ -93,7 +93,7 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 
 // parseRetryAfter parses a Retry-After header value, which can be either
 // a number of seconds (e.g. "120") or an HTTP-date (e.g. "Thu, 01 Dec 1994 16:00:00 GMT").
-// Returns the parsed duration and true if successful, or (0, false) if empty or unparseable.
+// Returns the parsed duration and true if successful, or (0, false) if empty or unparsable.
 func parseRetryAfter(value string) (time.Duration, bool) {
 	if value == "" {
 		return 0, false


### PR DESCRIPTION
## Summary
- correct the typo in the Retry-After parser comment
- change `unparseable` to `unparsable`

## Testing
- `go test $(go list ./... | grep -v /test/e2e)`
- full `go test ./...` attempted; e2e suite requires external environment and fails in BeforeSuite unrelated to this doc-only change

Fixes #125
