### PR TITLE
fix: prevent retry message loss on worker shutdown

### DIFF
--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -22,9 +22,9 @@ const (
 	// resultChannelBuffer decouples inference workers from the result writer.
 	// Workers can send results without blocking until the buffer is full.
 	resultChannelBuffer = 64
-	// maxResultBatchSize is the maximum number of results flushed in a single
+	// maxBatchSize is the maximum number of messages flushed in a single
 	// Redis pipeline call.
-	maxResultBatchSize = 32
+	maxBatchSize = 32
 )
 
 var (
@@ -63,6 +63,20 @@ if #items > 0 then
 end
 return items
 `)
+
+func drainBatch[T any](first T, channel <-chan T, maxBatchSize int) []T {
+	batch := make([]T, 1, maxBatchSize)
+	batch[0] = first
+	for len(batch) < maxBatchSize {
+		select {
+		case item := <-channel:
+			batch = append(batch, item)
+		default:
+			return batch
+		}
+	}
+	return batch
+}
 
 type QueueConfig struct {
 	QueueName          string `json:"queue_name"`
@@ -159,7 +173,7 @@ func (r *RedisMQFlow) ResultChannel() chan api.ResultMessage {
 // Batches multiple results into a single Redis pipeline call to reduce round-trips.
 func (r *RedisMQFlow) resultWorker(ctx context.Context, resultsQueueName string) {
 	processMsg := func(flushCtx context.Context, msg api.ResultMessage) {
-		batch := r.collectResultBatch(msg)
+		batch := drainBatch(msg, r.resultChannel, maxBatchSize)
 		r.flushResultBatch(flushCtx, batch, resultsQueueName)
 	}
 
@@ -178,20 +192,6 @@ func (r *RedisMQFlow) resultWorker(ctx context.Context, resultsQueueName string)
 			processMsg(ctx, msg)
 		}
 	}
-}
-
-func (r *RedisMQFlow) collectResultBatch(first api.ResultMessage) []api.ResultMessage {
-	batch := make([]api.ResultMessage, 1, maxResultBatchSize)
-	batch[0] = first
-	for len(batch) < maxResultBatchSize {
-		select {
-		case result := <-r.resultChannel:
-			batch = append(batch, result)
-		default:
-			return batch
-		}
-	}
-	return batch
 }
 
 func (r *RedisMQFlow) flushResultBatch(ctx context.Context, batch []api.ResultMessage, resultsQueueName string) {
@@ -319,7 +319,7 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 					break
 				}
 
-				for _, msg := range results {
+				for i, msg := range results {
 					var message api.RequestMessage
 					err := json.Unmarshal([]byte(msg), &message)
 					if err != nil {
@@ -333,11 +333,10 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 						continue
 					}
 
-					// TODO: We probably want to write here back to the request queue/channel in Redis. Adding the msg to the
-					// golang channel directly is not that wise as this might be blocking.
 					select {
 					case msgChannel <- message:
 					case <-ctx.Done():
+						r.requeueRetryMessages(rdb, results[i:])
 						return
 					}
 				}
@@ -345,7 +344,32 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 			time.Sleep(time.Second)
 		}
 	}
+}
 
+// requeueRetryMessages puts undelivered messages back into the retry sorted set.
+// Called only after ctx is cancelled, so context.Background() is used for Redis calls.
+func (r *RedisMQFlow) requeueRetryMessages(rdb *redis.Client, messages []string) {
+	if len(messages) == 0 {
+		return
+	}
+	logger := log.FromContext(context.Background())
+	score := float64(time.Now().Unix())
+	const maxRetries = 3
+	for attempt := range maxRetries {
+		pipe := rdb.Pipeline()
+		for _, msg := range messages {
+			pipe.ZAdd(context.Background(), *retryQueueName, redis.Z{Score: score, Member: msg})
+		}
+		if _, err := pipe.Exec(context.Background()); err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to requeue retry messages on shutdown",
+				"count", len(messages), "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * 100 * time.Millisecond)
+			}
+		} else {
+			return
+		}
+	}
 }
 
 // popDueRetryMessages atomically pops up to limit retry messages whose score is <= nowUnixSec.

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -163,9 +163,9 @@ func TestPubsubResultWorker_BatchSizeCap(t *testing.T) {
 	defer sub.Close() // nolint:errcheck
 	pubsubCh := sub.Channel()
 
-	// Send more than maxResultBatchSize messages. The worker should still
+	// Send more than maxBatchSize messages. The worker should still
 	// deliver all of them across multiple pipeline flushes.
-	totalMessages := maxResultBatchSize + 10
+	totalMessages := maxBatchSize + 10
 	for i := 0; i < totalMessages; i++ {
 		flow.resultChannel <- api.ResultMessage{
 			Id:      "cap-" + strconv.Itoa(i),
@@ -288,6 +288,73 @@ func TestPubsubResultWorker_RetryAfterFailure(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Timeout waiting for retried message")
+	}
+}
+
+func TestMQRetryWorker_RequeuesOnShutdown(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	retryQueue := *retryQueueName
+	queueName := "req-queue"
+
+	// Use a blocking (unbuffered) request channel so the worker blocks on send.
+	reqCh := make(chan api.RequestMessage)
+	flow := &RedisMQFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+		retryChannel:  make(chan api.RetryMessage),
+		requestChannels: []RequestChannelData{{
+			requestChannel: api.RequestChannel{Channel: reqCh},
+			queueName:      queueName,
+		}},
+	}
+
+	// Seed the retry sorted set with 3 messages that are immediately due.
+	for i := 0; i < 3; i++ {
+		msg := api.RequestMessage{
+			Id:       "retry-" + strconv.Itoa(i),
+			Metadata: map[string]string{QUEUE_NAME_KEY: queueName},
+		}
+		bytes, _ := json.Marshal(msg)
+		rdb.ZAdd(ctx, retryQueue, redis.Z{Score: float64(time.Now().Unix() - 1), Member: string(bytes)})
+	}
+
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		flow.retryWorker(workerCtx, rdb)
+		close(done)
+	}()
+
+	// Consume exactly one message so the worker can pop all three from Redis.
+	select {
+	case <-reqCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for first message")
+	}
+
+	// Cancel while the worker is blocked sending the second message.
+	workerCancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retryWorker did not stop after context cancellation")
+	}
+
+	// The remaining messages should have been requeued to the retry sorted set.
+	count, err := rdb.ZCard(ctx, retryQueue).Result()
+	if err != nil {
+		t.Fatalf("ZCard error: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("Expected requeued retry messages, got 0")
 	}
 }
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -283,29 +283,81 @@ func (r *RedisSortedSetFlow) parseMessage(z redis.Z, logger logr.Logger) (api.Re
 
 // Re-queues failed messages with exponential backoff
 func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
-	logger := log.FromContext(ctx)
+	processMsg := func(processCtx context.Context, msg api.RetryMessage) {
+		batch := drainBatch(msg, r.retryChannel, maxBatchSize)
+		r.flushRetryBatch(processCtx, batch)
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			for {
+				select {
+				case msg := <-r.retryChannel:
+					processMsg(context.Background(), msg)
+				default:
+					return
+				}
+			}
 		case msg := <-r.retryChannel:
-			queueName := msg.Metadata[SORTEDSET_QUEUE_NAME_KEY]
-			if queueName == "" {
-				queueName = *ssRequestQueueName
-			}
-
-			bytes, err := json.Marshal(msg.RequestMessage)
-			if err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to marshal retry")
-				continue
-			}
-
-			retryScore := float64(time.Now().Unix()) + msg.BackoffDurationSeconds
-			if err := r.rdb.ZAdd(ctx, queueName, redis.Z{Score: retryScore, Member: string(bytes)}).Err(); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to add retry")
-			}
+			processMsg(ctx, msg)
 		}
+	}
+}
+
+func (r *RedisSortedSetFlow) flushRetryBatch(ctx context.Context, batch []api.RetryMessage) {
+	if len(batch) == 0 {
+		return
+	}
+
+	logger := log.FromContext(ctx)
+	type retryEntry struct {
+		queue string
+		value redis.Z
+	}
+
+	entries := make([]retryEntry, 0, len(batch))
+	for _, msg := range batch {
+		queueName := msg.Metadata[SORTEDSET_QUEUE_NAME_KEY]
+		if queueName == "" {
+			queueName = *ssRequestQueueName
+		}
+
+		bytes, err := json.Marshal(msg.RequestMessage)
+		if err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to marshal retry")
+			continue
+		}
+
+		retryScore := float64(time.Now().Unix()) + msg.BackoffDurationSeconds
+		entries = append(entries, retryEntry{
+			queue: queueName,
+			value: redis.Z{Score: retryScore, Member: string(bytes)},
+		})
+	}
+
+	const maxRetries = 3
+	for attempt := range maxRetries {
+		execCtx := ctx
+		if execCtx.Err() != nil {
+			execCtx = context.Background()
+		}
+
+		pipe := r.rdb.Pipeline()
+		for _, entry := range entries {
+			pipe.ZAdd(execCtx, entry.queue, entry.value)
+		}
+		if _, err := pipe.Exec(execCtx); err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to add retry batch",
+				"batchSize", len(entries), "attempt", attempt+1)
+			if attempt < maxRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * 100 * time.Millisecond)
+			}
+		} else {
+			logger.V(logutil.DEBUG).Info("Pushed retry batch", "batchSize", len(batch))
+			return
+		}
+
 	}
 }
 
@@ -314,7 +366,7 @@ func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
 // Batches multiple results into a single Redis pipeline call to reduce round-trips.
 func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 	processMsg := func(flushCtx context.Context, msg api.ResultMessage) {
-		batch := r.collectResultBatch(msg)
+		batch := drainBatch(msg, r.resultChannel, maxBatchSize)
 		r.flushResultBatch(flushCtx, batch)
 	}
 
@@ -335,20 +387,6 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 	}
 }
 
-func (r *RedisSortedSetFlow) collectResultBatch(first api.ResultMessage) []api.ResultMessage {
-	batch := make([]api.ResultMessage, 1, maxResultBatchSize)
-	batch[0] = first
-	for len(batch) < maxResultBatchSize {
-		select {
-		case result := <-r.resultChannel:
-			batch = append(batch, result)
-		default:
-			return batch
-		}
-	}
-	return batch
-}
-
 func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.ResultMessage) {
 	logger := log.FromContext(ctx)
 	defaultQueue := *ssResultQueueName
@@ -363,13 +401,18 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 
 	const maxRetries = 3
 	for attempt := range maxRetries {
+		execCtx := ctx
+		if execCtx.Err() != nil {
+			execCtx = context.Background()
+		}
+
 		pipe := r.rdb.Pipeline()
 		for queue, msgs := range queued {
 			for _, msgStr := range msgs {
-				pipe.LPush(ctx, queue, msgStr)
+				pipe.LPush(execCtx, queue, msgStr)
 			}
 		}
-		if _, err := pipe.Exec(ctx); err != nil {
+		if _, err := pipe.Exec(execCtx); err != nil {
 			logger.V(logutil.DEFAULT).Error(err, "Failed to push result batch to Redis",
 				"batchSize", len(batch), "attempt", attempt+1)
 			if attempt < maxRetries-1 {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -646,6 +646,109 @@ func TestSortedSetFlow_ResultRetryAfterFailure(t *testing.T) {
 	}
 }
 
+func TestSortedSetFlow_RetryWorkerDrainsOnShutdown(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "retry-drain-queue"
+	const totalMessages = maxBatchSize + 10
+	flow := &RedisSortedSetFlow{
+		rdb:          rdb,
+		retryChannel: make(chan api.RetryMessage, totalMessages),
+		pollInterval: 50 * time.Millisecond,
+		batchSize:    10,
+		gate:         noopGate(),
+	}
+
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		flow.retryWorker(workerCtx)
+		close(done)
+	}()
+
+	// Buffer more messages than maxBatchSize so the drain path
+	// exercises multiple pipeline flushes.
+	for i := 0; i < totalMessages; i++ {
+		flow.retryChannel <- api.RetryMessage{
+			EmbelishedRequestMessage: api.EmbelishedRequestMessage{
+				RequestMessage: api.RequestMessage{
+					Id:              "drain-" + strconv.Itoa(i),
+					CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
+					DeadlineUnixSec: "9999999999",
+				},
+				Metadata: map[string]string{SORTEDSET_QUEUE_NAME_KEY: queue},
+			},
+			BackoffDurationSeconds: 0,
+		}
+	}
+	workerCancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retryWorker did not stop after context cancellation")
+	}
+
+	count, err := rdb.ZCard(ctx, queue).Result()
+	if err != nil {
+		t.Fatalf("ZCard error: %v", err)
+	}
+	if int(count) != totalMessages {
+		t.Fatalf("Expected %d retry messages flushed on shutdown, got %d", totalMessages, count)
+	}
+}
+
+func TestSortedSetFlow_RetryBatchAfterFailure(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "retry-batch-queue"
+	flow := &RedisSortedSetFlow{
+		rdb:          rdb,
+		retryChannel: make(chan api.RetryMessage, 10),
+		pollInterval: 50 * time.Millisecond,
+		batchSize:    10,
+		gate:         noopGate(),
+	}
+
+	// Inject an error so the first pipeline flush fails.
+	s.SetError("READONLY simulated failure")
+	go flow.retryWorker(ctx)
+
+	flow.retryChannel <- api.RetryMessage{
+		EmbelishedRequestMessage: api.EmbelishedRequestMessage{
+			RequestMessage: api.RequestMessage{
+				Id:              "retry-batch-msg",
+				CreatedUnixSec:  strconv.FormatInt(time.Now().Unix(), 10),
+				DeadlineUnixSec: "9999999999",
+			},
+			Metadata: map[string]string{SORTEDSET_QUEUE_NAME_KEY: queue},
+		},
+		BackoffDurationSeconds: 0,
+	}
+
+	// Keep Redis failing long enough for early attempts to fail.
+	time.Sleep(150 * time.Millisecond)
+
+	// Clear the error so the next retry attempt succeeds.
+	s.SetError("")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		count, err := rdb.ZCard(ctx, queue).Result()
+		if err == nil && count == 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("Expected retry message to be enqueued after transient Redis failure")
+}
+
 func TestSortedSetFlow_PartialBudget(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()


### PR DESCRIPTION
## What does this PR do?

- Drains `retryChannel` on graceful shutdown in `RedisSortedSetFlow.retryWorker`, flushing remaining messages to Redis with `context.Background()`
- Requeues undelivered messages back to the retry sorted set in `RedisMQFlow.retryWorker` when `ctx.Done()` fires during channel send

## Why is this change needed?

Messages destructively popped from Redis (or buffered in `retryChannel`) were silently dropped when context cancellation won the select race during shutdown.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes https://github.com/llm-d-incubation/llm-d-async/issues/129