### PR TITLE
ci: add multi-arch image build and auto-build on merge to main

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -26,6 +26,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -48,7 +51,7 @@ runs:
           LATEST_TAG="-t ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
         fi
         docker buildx build \
-          --platform linux/amd64 \
+          --platform linux/amd64,linux/arm64 \
           --build-arg PYTHON_VERSION=${{ inputs.python-version }} \
           -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
           ${LATEST_TAG} -f ${{ inputs.docker-file }} --push .

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -2,10 +2,13 @@ name: CI - Release - Docker Container Image
 
 on:
   push:
+    branches:
+      - main  # Runs on every push to main (including PR merges)
     tags:
       - 'v*'  # Runs when a tag like v0.1.0 is pushed
   release:
     types: [published]  # Also runs when a GitHub release is published
+  workflow_dispatch:  # Allows manual trigger
 
 jobs:
   docker-build-and-push:
@@ -26,12 +29,16 @@ jobs:
       - name: Determine tag name
         id: tag
         run: |
+          COMMIT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
-          else
+          elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
             echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=dev" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
 
@@ -48,12 +55,13 @@ jobs:
         run: |
           IMAGE=ghcr.io/llm-d-incubation/${{ steps.version.outputs.project_name }}
           VERSION_TAG=${{ steps.tag.outputs.tag }}
-          echo "Building $IMAGE with tags $VERSION_TAG and latest for linux/amd64"
+          COMMIT_SHA=${{ steps.tag.outputs.commit_sha }}
+          echo "Building $IMAGE with tags $VERSION_TAG and $COMMIT_SHA for linux/amd64,linux/arm64"
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --push \
             -t $IMAGE:$VERSION_TAG \
-            -t $IMAGE:latest .
+            -t $IMAGE:$COMMIT_SHA .
 
       - name: Install dependencies for Helm publishing
         run: |


### PR DESCRIPTION
## What does this PR do?

- Build multi-arch Docker images (`linux/amd64` + `linux/arm64`) instead of `amd64`-only
- Add QEMU setup for ARM64 cross-compilation in both `ci-release.yaml` and the `docker-build-and-push` composite action
- Trigger image build automatically on every push to `main` (including PR merges), in addition to tag pushes and releases
- Add `workflow_dispatch` for manual trigger
- Tag images with both version/latest and short commit SHA for traceability

## Why is this change needed?

The CI currently only builds `linux/amd64` images, which prevents deployment on ARM64 infrastructure. Additionally, images are only built on tag push or release — there is no automatic build when PRs are merged to `main`, making it harder to test the latest code without cutting a release.

## Image build summary

**Architectures:** `linux/amd64`, `linux/arm64`

**Registry:** `ghcr.io/llm-d-incubation/llm-d-async`

| Trigger | Tag 1 | Tag 2 |
|---|---|---|
| PR merge to `main` | `latest` | `<commit-sha>` (7-char) |
| Push tag `v*` | `v0.1.0` | `<commit-sha>` (7-char) |
| Publish release | `v0.1.0` | `<commit-sha>` (7-char) |
| Manual (`workflow_dispatch` on main) | `latest` | `<commit-sha>` (7-char) |

## How was this tested?

- [x] Manual testing performed
  - Pushed a test tag (`v0.0.0-test`) to a fork and verified the workflow triggers correctly
  - Confirmed dual-arch build (`linux/amd64` + `linux/arm64`) completes successfully
  - Push to registry failed as expected (fork token lacks write access to `ghcr.io/llm-d-incubation`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A