### PR TITLE
feat: update dispatch budget gate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 
 - `constant`: Always returns budget 1.0 (fully open) - no throttling.
 - `redis`: Queries Redis for dispatch budget (managed by external system).
-- `prometheus-saturation`: Queries Prometheus for pool saturation metric. Returns `1.0 - saturation` if below threshold, `0.0` otherwise.
+- `prometheus-saturation`: Queries Prometheus for pool saturation metric. The gate closes (returns `0.0`) when saturation ≥ threshold; when open it returns `(1 - saturation) - (1 - threshold)`, i.e. the margin below the threshold.
 - `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_SYS)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
 
 **Example Configuration with Per-Queue Gates:**

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 - `constant`: Always returns budget 1.0 (fully open) - no throttling.
 - `redis`: Queries Redis for dispatch budget (managed by external system).
 - `prometheus-saturation`: Queries Prometheus for pool saturation metric. Returns `1.0 - saturation` if below threshold, `0.0` otherwise.
-- `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_sys)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / (ready_pods × max_concurrency))`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
+- `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_SYS)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
 
 **Example Configuration with Per-Queue Gates:**
 
@@ -130,7 +130,6 @@ For more fine-grained control, configure gates per queue in your configuration f
        "gate_type": "prometheus-budget",
        "gate_params": {
           "pool": "inference_pool_1",
-          "max_sys": "100",
           "max_concurrency": "100",
           "baseline": "0.05"
        }
@@ -160,14 +159,14 @@ For more fine-grained control, configure gates per queue in your configuration f
   - `fallback` (optional): Fallback saturation value (0.0-1.0) used when the metric source returns an error or empty data. Default is `0.0`.
 
 - `prometheus-budget`: Cascades two Prometheus metric sources to compute a dispatch budget D.
-  The primary source computes D from the EPP's flow control queue size: `D = 1 − (queue_size / max_sys)`.
+  Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically from the `inference_pool_ready_pods` metric.
+  The primary source computes D from the EPP's flow control queue size: `D = 1 − (queue_size / max_SYS)`.
   If the primary metric is unavailable (e.g. EPP is down), the gate falls back to a secondary source
-  that estimates saturation from vLLM and pool metrics: `D = 1 − (running_requests / (ready_pods × max_concurrency))`.
+  that estimates saturation from vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`.
   The gate closes when `D ≤ baseline`; when open it returns `D − baseline`, so callers compute `N = max_SYS × (D − B)`.
   See [docs/dispatch-budget.md](docs/dispatch-budget.md) for the full derivation.
   - `pool` (**required**): The inference pool name to filter metrics by.
-  - `max_sys` (**required**): Maximum system request capacity, used to normalize the EPP queue depth (`queue_size / max_sys`). Must be a positive number.
-  - `max_concurrency` (optional): Per-endpoint request capacity used to compute the vLLM fallback saturation. Default is `100` (matching the llm-d inference scheduler default).
+  - `max_concurrency` (optional): Per-endpoint request capacity (`MaxConcurrency` in the [inference scheduler's saturation detector](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go)). Default is `100` (matching the inference scheduler default).
   - `baseline` (optional): Reserved baseline B. The gate closes when D ≤ B. Default is `0.05`.
   - `fallback` (optional): Fallback budget value (0.0-1.0) returned when all metric sources are unavailable. Default is `0.0` (fail closed).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 - `constant`: Always returns budget 1.0 (fully open) - no throttling.
 - `redis`: Queries Redis for dispatch budget (managed by external system).
 - `prometheus-saturation`: Queries Prometheus for pool saturation metric. Returns `1.0 - saturation` if below threshold, `0.0` otherwise.
-- `prometheus-budget`: Queries Prometheus to compute a dispatch budget using the formula `D = 1 - (F_SYS + F_EPP + B)`, where `F_SYS` is pool saturation, `F_EPP` is normalized EPP queue depth, and `B` is a configurable baseline reserve.
+- `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_sys)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / (ready_pods × max_concurrency))`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
 
 **Example Configuration with Per-Queue Gates:**
 
@@ -131,6 +131,7 @@ For more fine-grained control, configure gates per queue in your configuration f
        "gate_params": {
           "pool": "inference_pool_1",
           "max_sys": "100",
+          "max_concurrency": "100",
           "baseline": "0.05"
        }
     },
@@ -158,12 +159,17 @@ For more fine-grained control, configure gates per queue in your configuration f
   - `threshold` (optional): Saturation threshold (0.0-1.0). When saturation >= threshold, budget is 0.0. Default is `0.8`.
   - `fallback` (optional): Fallback saturation value (0.0-1.0) used when the metric source returns an error or empty data. Default is `0.0`.
 
-- `prometheus-budget`: Computes a dispatch budget using the formula `D = 1 - (F_SYS + F_EPP + B)`, where `F_SYS` is pool saturation,
-  `F_EPP` is normalized EPP queue depth, and `B` is a configurable baseline reserve. This is internally translated into a single Prometheus query.
+- `prometheus-budget`: Cascades two Prometheus metric sources to compute a dispatch budget D.
+  The primary source computes D from the EPP's flow control queue size: `D = 1 − (queue_size / max_sys)`.
+  If the primary metric is unavailable (e.g. EPP is down), the gate falls back to a secondary source
+  that estimates saturation from vLLM and pool metrics: `D = 1 − (running_requests / (ready_pods × max_concurrency))`.
+  The gate closes when `D ≤ baseline`; when open it returns `D − baseline`, so callers compute `N = max_SYS × (D − B)`.
+  See [docs/dispatch-budget.md](docs/dispatch-budget.md) for the full derivation.
   - `pool` (**required**): The inference pool name to filter metrics by.
-  - `max_sys` (**required**): Maximum system request capacity, used to normalize the EPP queue depth (`F_EPP = queue_size / max_sys`). Must be a positive number.
-  - `baseline` (optional): Reserved fraction for unexpected traffic bursts. Default is `0.05`.
-  - `fallback` (optional): Fallback budget value (0.0-1.0) returned when metrics are unavailable. Default is `0.0` (fail closed).
+  - `max_sys` (**required**): Maximum system request capacity, used to normalize the EPP queue depth (`queue_size / max_sys`). Must be a positive number.
+  - `max_concurrency` (optional): Per-endpoint request capacity used to compute the vLLM fallback saturation. Default is `100` (matching the llm-d inference scheduler default).
+  - `baseline` (optional): Reserved baseline B. The gate closes when D ≤ B. Default is `0.05`.
+  - `fallback` (optional): Fallback budget value (0.0-1.0) returned when all metric sources are unavailable. Default is `0.0` (fail closed).
 
 ## Request Messages and Consumption
 

--- a/docs/dispatch-budget.md
+++ b/docs/dispatch-budget.md
@@ -1,17 +1,18 @@
-# Batch Dispatcher — Gating Logic and Flow Control
+# Dispatch Budget
 
 Related:
+- [Batch Dispatcher: Architecture](https://github.com/llm-d-incubation/batch-gateway/blob/main/docs/design/batch-dispatcher.md) (batch-gateway)
 - [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj)
 - [\[PUBLIC\] EPP Flow Controller for Priority, Fairness, and Queuing](https://docs.google.com/document/d/1VZL7opFWuwgWquvgiOzLlXAJ633qZ9U-A0ZixGjBgaI/edit?tab=t.0#heading=h.hfyow92z2d0t)
 - [\[PUBLIC\] Improved Flow Control Request Management](https://docs.google.com/document/d/1JxzJc8gNv2wKK5-a8ohb0btn78ymVKw9XMIb4-S-ncA/edit?tab=t.0#heading=h.rutawybt03nl)
 - [https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
 
 
-## Detailed Approach
+The **Async Processor** ([sometimes also called "Batch Dispatcher"](https://github.com/llm-d-incubation/batch-gateway/blob/main/docs/design/batch-dispatcher.md)) pulls requests from the Message Queue and decides whether to forward them to the IGW based on a **`DispatchGate`** — a pluggable policy component that returns a budget value in $[0, 1]$ representing current system capacity. When the gate is open, a proportional number of requests are forwarded; otherwise the Async Processor waits until the gate opens again.
 
-The **Async Processor** ([sometimes also called "Batch Dispatcher"](https://github.com/llm-d-incubation/batch-gateway/blob/main/docs/design/batch-dispatcher.md)) pulls requests from the Message Queue, reads metrics from a **Metrics Store** and decides whether to forward them to the IGW: when the metrics are within a certain interval the "gates" are open, and a certain number of requests may go through. Otherwise, the Batch Dispatcher waits until the metrics return within the acceptable range.
+Several `DispatchGate` implementations are available (see [Dispatch Gates](https://github.com/llm-d-incubation/llm-d-async/blob/main/README.md#dispatch-gates)). This document describes the **Dispatch Budget**, a metric-based strategy for gating. Metric-based gates rely on a `MetricSource` (e.g., a PromQL query against Prometheus) to read inference pool state.
 
-### Dispatch Budget
+## Dispatch Budget (`prometheus-budget`)
 
 The dispatcher computes a "**Dispatch Budget"**, to determine **the number of concurrent batch requests** allowed to enter the IGW at a given time.
 
@@ -32,7 +33,7 @@ The **Dispatch Budget** $D$ is a measure of capacity of the gateway and the infe
 
 - in general any quantity $D \in [0,1]$ that estimates the remaining capacity of the system is a valid dispatch budget
 
-#### Acceptable Range
+### Acceptable Range
 
 For a given Dispatch Budget $D$, we also define a **Reserved Baseline** $B \in [0,1]$ as a threshold, and we pose
 that when $D\leq B$ "the gate is closed", i.e., no requests can be forwarded.
@@ -42,7 +43,7 @@ The number of requests that can be forwarded is estimated by scaling the total s
 
 $$N = \mathrm{max}\_\mathrm{SYS} \times (D - B)$$
 
-#### Example
+### Example
 
 When capacity is measured in requests, a natural estimate for $\mathrm{max}\_\mathrm{SYS}$ is the aggregate pool capacity, the same value the EPP's [saturation detector](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/e7dca1b3673bf0d104595c39afcad7411e61ca0d/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go#L119-L147) uses as the denominator for saturation:
 
@@ -61,15 +62,15 @@ $$F = 0.3, \quad B = 0.1$$
 - Since 0.7 > 0.1, then we can compute $N$
 - Dispatchable Requests $N = 5 \times 10 \times (0.7 - 0.1) = 30$
 
-##### Notes
+#### Notes
 
-1. $N$ is a real-valued estimate. The rounding strategy (e.g., floor, ceiling, or ensuring a minimum of 1 when $D > 0$) is left to the implementation, as edge cases near zero require care to avoid prematurely stopping dispatch.
+1. $N$ is a real-valued estimate. The rounding strategy (e.g., floor, ceiling, or ensuring a minimum of 1 when $D > B$) is left to the implementation, as edge cases just above the baseline require care to avoid prematurely stopping dispatch.
 2. `max_concurrency` is expressed in request units here, but the same approach generalizes to other capacity units (e.g., tokens, bytes) given an equivalent per-endpoint capacity constant.
 3. We may also define system capacity in terms of number of bytes; in this case $D$ would be truncated at the boundary of a valid request; for instance, if we expect to be able to forward a maximum of 1024 KiB of data, then we may forward at most $1024 \times (0.7-0.1) = 614.4$ KiB; which means if we have $r_1, r_2, ...$ enqueued; if $r_1$ is 600 KiB and $r_2$ is 100 KiB, then we would only dispatch $r_1$
 
-#### Failure Modes
+### Failure Modes
 
-* **Queue Consumer Failures:** If the Batch Dispatcher pod crashes, the messages remain in the persistent Message Queue (Redis/PubSub), ensuring no data loss.
-* **IGW Backpressure:** If the IGW returns an HTTP error indicating overload (e.g. HTTP 429\) despite the computed budget, then the **saturation is assumed to be close to 1**, and therefore a **dispatch budget close to 0\.** The Batch Dispatcher will not retry until a subsequent update from the metrics store will bring it back within the acceptable limits.
+* **Queue Consumer Failures:** If the Async Processor pod crashes, the messages remain in the persistent Message Queue (Redis/PubSub), ensuring no data loss.
+* **IGW Backpressure:** If the IGW returns an HTTP error indicating overload (e.g. HTTP 429\) despite the computed budget, then the **saturation is assumed to be close to 1**, and therefore a **dispatch budget close to 0\.** The Async Processor will not retry until a subsequent update from the metrics store will bring it back within the acceptable limits.
   * This might happen if a sudden spike of traffic enters the gateway and the metrics did not update on-time.
-* **Unreadable Metrics:** In case of unreadable metrics, the Batch Processor cannot take informed decisions, and therefore will assume a **dispatch budget of 0\.**
+* **Unreadable Metrics:** In case of unreadable metrics, the Async Processor cannot take informed decisions, and therefore will assume a **dispatch budget of 0\.**

--- a/docs/dispatch-budget.md
+++ b/docs/dispatch-budget.md
@@ -1,0 +1,75 @@
+# Batch Dispatcher — Gating Logic and Flow Control
+
+Related:
+- [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj)
+- [\[PUBLIC\] EPP Flow Controller for Priority, Fairness, and Queuing](https://docs.google.com/document/d/1VZL7opFWuwgWquvgiOzLlXAJ633qZ9U-A0ZixGjBgaI/edit?tab=t.0#heading=h.hfyow92z2d0t)
+- [\[PUBLIC\] Improved Flow Control Request Management](https://docs.google.com/document/d/1JxzJc8gNv2wKK5-a8ohb0btn78ymVKw9XMIb4-S-ncA/edit?tab=t.0#heading=h.rutawybt03nl)
+- [https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
+
+
+## Detailed Approach
+
+The **Async Processor** ([sometimes also called "Batch Dispatcher"](https://github.com/llm-d-incubation/batch-gateway/blob/main/docs/design/batch-dispatcher.md)) pulls requests from the Message Queue, reads metrics from a **Metrics Store** and decides whether to forward them to the IGW: when the metrics are within a certain interval the "gates" are open, and a certain number of requests may go through. Otherwise, the Batch Dispatcher waits until the metrics return within the acceptable range.
+
+### Dispatch Budget
+
+The dispatcher computes a "**Dispatch Budget"**, to determine **the number of concurrent batch requests** allowed to enter the IGW at a given time.
+
+The **Dispatch Budget** $D$ is a measure of capacity of the gateway and the inference pool. In particular, depending on available metrics, $D$ could be:
+
+- the complement of the **"fullness" ($F$) of the EPP** to ingest and manage requests:
+
+  $$D = 1 - F$$
+
+  because the EPP has an up-to-date view of its corresponding inference pool at all times, $F$ is assumed to capture both the capacity of the EPP itself and the capacity of the underlying inference pool (i.e., its saturation, see below)
+
+- the complement of the **Inference Pool Saturation** ($S$)
+
+  $$D = 1 - S$$
+
+  $S$ is a measure of "fullness" of the inference backend (e.g., GPU utilization, request concurrency, KV cache pressure).
+  For instance, $S$ could be the saturation metric that the EPP's saturation detector publishes (which should be updated more frequently), or it may be computed using a Prometheus query over the inference pool.
+
+- in general any quantity $D \in [0,1]$ that estimates the remaining capacity of the system is a valid dispatch budget
+
+#### Acceptable Range
+
+For a given Dispatch Budget $D$, we also define a **Reserved Baseline** $B \in [0,1]$ as a threshold, and we pose
+that when $D\leq B$ "the gate is closed", i.e., no requests can be forwarded.
+Hence, **a dispatcher only forwards requests when $D > B$**.
+
+The number of requests that can be forwarded is estimated by scaling the total system capacity $\mathrm{max}\_\mathrm{SYS}$ by the dispatch budget, minus the baseline: $(D-B)$; depending on configuration, the unit of $\mathrm{max}\_\mathrm{SYS}$ could be bytes, tokens, or just number of requests.
+
+$$N = \mathrm{max}\_\mathrm{SYS} \times (D - B)$$
+
+#### Example
+
+When capacity is measured in requests, a natural estimate for $\mathrm{max}\_\mathrm{SYS}$ is the aggregate pool capacity, the same value the EPP's [saturation detector](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/e7dca1b3673bf0d104595c39afcad7411e61ca0d/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go#L119-L147) uses as the denominator for saturation:
+
+$$\mathrm{max}\_\mathrm{SYS} = \texttt{ready\\_model\\_servers} \times \texttt{max\\_concurrency}$$
+
+where `ready_model_servers` is the number of ready endpoints in the inference pool (available as the [`inference_pool_ready_pods` metric](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/365a1c0b61fab425e5e63141057bc83558a6c26e/site-src/guides/metrics-and-observability.md#L25-L58)) and [`max_concurrency` is the per-endpoint request capacity configured in the EPP's saturation detector (default 100)](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/e7dca1b3673bf0d104595c39afcad7411e61ca0d/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go#L32-L58). The number of dispatchable requests is then:
+
+$$N = \mathrm{max}\_\mathrm{SYS} \times (D-B) = \texttt{ready\\_model\\_servers} \times \texttt{max\\_concurrency} \times (D-B) $$
+
+For instance, if an EPP metric ($F$) is available:
+
+$$F = 0.3, \quad B = 0.1$$
+
+- $\texttt{ready\\_model\\_servers} = 5, \quad \texttt{max\\_concurrency} = 10, \quad \mathrm{max}\_\mathrm{SYS} = 50$
+- Dispatch Budget $D = (1 - 0.3) = 0.7$
+- Since 0.7 > 0.1, then we can compute $N$
+- Dispatchable Requests $N = 5 \times 10 \times (0.7 - 0.1) = 30$
+
+##### Notes
+
+1. $N$ is a real-valued estimate. The rounding strategy (e.g., floor, ceiling, or ensuring a minimum of 1 when $D > 0$) is left to the implementation, as edge cases near zero require care to avoid prematurely stopping dispatch.
+2. `max_concurrency` is expressed in request units here, but the same approach generalizes to other capacity units (e.g., tokens, bytes) given an equivalent per-endpoint capacity constant.
+3. We may also define system capacity in terms of number of bytes; in this case $D$ would be truncated at the boundary of a valid request; for instance, if we expect to be able to forward a maximum of 1024 KiB of data, then we may forward at most $1024 \times (0.7-0.1) = 614.4$ KiB; which means if we have $r_1, r_2, ...$ enqueued; if $r_1$ is 600 KiB and $r_2$ is 100 KiB, then we would only dispatch $r_1$
+
+#### Failure Modes
+
+* **Queue Consumer Failures:** If the Batch Dispatcher pod crashes, the messages remain in the persistent Message Queue (Redis/PubSub), ensuring no data loss.
+* **IGW Backpressure:** If the IGW returns an HTTP error indicating overload (e.g. HTTP 429\) despite the computed budget, then the **saturation is assumed to be close to 1**, and therefore a **dispatch budget close to 0\.** The Batch Dispatcher will not retry until a subsequent update from the metrics store will bring it back within the acceptable limits.
+  * This might happen if a sudden spike of traffic enters the gateway and the metrics did not update on-time.
+* **Unreadable Metrics:** In case of unreadable metrics, the Batch Processor cannot take informed decisions, and therefore will assume a **dispatch budget of 0\.**

--- a/docs/dispatch-budget.md
+++ b/docs/dispatch-budget.md
@@ -45,11 +45,11 @@ $$N = \mathrm{max}\_\mathrm{SYS} \times (D - B)$$
 
 ### Example
 
-When capacity is measured in requests, a natural estimate for $\mathrm{max}\_\mathrm{SYS}$ is the aggregate pool capacity, the same value the EPP's [saturation detector](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/e7dca1b3673bf0d104595c39afcad7411e61ca0d/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go#L119-L147) uses as the denominator for saturation:
+When capacity is measured in requests, a natural estimate for $\mathrm{max}\_\mathrm{SYS}$ is the aggregate pool capacity, the same value the inference scheduler's [saturation detector](https://github.com/llm-d/llm-d-inference-scheduler/blob/b9f77ee9/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go#L119-L147) uses as the denominator for saturation:
 
 $$\mathrm{max}\_\mathrm{SYS} = \texttt{ready\\_model\\_servers} \times \texttt{max\\_concurrency}$$
 
-where `ready_model_servers` is the number of ready endpoints in the inference pool (available as the [`inference_pool_ready_pods` metric](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/365a1c0b61fab425e5e63141057bc83558a6c26e/site-src/guides/metrics-and-observability.md#L25-L58)) and [`max_concurrency` is the per-endpoint request capacity configured in the EPP's saturation detector (default 100)](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/e7dca1b3673bf0d104595c39afcad7411e61ca0d/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go#L32-L58). The number of dispatchable requests is then:
+where `ready_model_servers` is the number of ready endpoints in the inference pool (available as the `inference_pool_ready_pods` metric) and `max_concurrency` is the per-endpoint request capacity, corresponding to the [`MaxConcurrency` config value in the inference scheduler's saturation detector (default 100)](https://github.com/llm-d/llm-d-inference-scheduler/blob/b9f77ee9/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go#L32-L58). The number of dispatchable requests is then:
 
 $$N = \mathrm{max}\_\mathrm{SYS} \times (D-B) = \texttt{ready\\_model\\_servers} \times \texttt{max\\_concurrency} \times (D-B) $$
 

--- a/pkg/async/inference/flowcontrol/cascade_metric_source.go
+++ b/pkg/async/inference/flowcontrol/cascade_metric_source.go
@@ -29,32 +29,37 @@ var _ MetricSource = (*CascadeMetricSource)(nil)
 
 // CascadeMetricSource tries each source in order and returns the first successful result.
 // If a source returns an error or no samples, the next source is tried. Log messages are
-// emitted only on transitions (entering/leaving fallback) to avoid noise during sustained outages.
+// emitted only on transitions (entering/leaving fallback, or switching fallback source)
+// to avoid noise during sustained outages.
 type CascadeMetricSource struct {
-	sources       []MetricSource
-	usingFallback atomic.Bool
+	sources     []MetricSource
+	activeIndex atomic.Int32 // 0 = primary, >0 = fallback index
 }
 
 // NewCascadeMetricSource creates a CascadeMetricSource from the given sources, tried in order.
-// At least two sources are required.
+// At least two sources are required; panics otherwise.
 func NewCascadeMetricSource(sources ...MetricSource) *CascadeMetricSource {
+	if len(sources) < 2 {
+		panic("CascadeMetricSource requires at least two sources")
+	}
 	return &CascadeMetricSource{sources: sources}
 }
 
-// Query implements MetricSource. It tries each source in order, logging once when
-// entering fallback and once when recovering to the primary.
+// Query implements MetricSource. It tries each source in order, logging on transitions:
+// entering fallback, switching fallback source, or recovering to the primary.
 func (c *CascadeMetricSource) Query(ctx context.Context) ([]Sample, error) {
 	logger := log.FromContext(ctx)
 	for i, s := range c.sources {
 		samples, err := s.Query(ctx)
 		if err == nil && len(samples) > 0 {
-			if i > 0 {
-				if c.usingFallback.CompareAndSwap(false, true) {
-					logger.V(logutil.DEFAULT).Info("primary metric source unavailable, using fallback",
-						"fallbackIndex", i)
+			prev := c.activeIndex.Swap(int32(i))
+			if int32(i) != prev {
+				if i == 0 {
+					logger.V(logutil.DEFAULT).Info("primary metric source recovered")
+				} else {
+					logger.V(logutil.DEFAULT).Info("using fallback metric source",
+						"fallbackIndex", i, "previousIndex", prev)
 				}
-			} else if c.usingFallback.CompareAndSwap(true, false) {
-				logger.V(logutil.DEFAULT).Info("primary metric source recovered")
 			}
 			return samples, nil
 		}

--- a/pkg/async/inference/flowcontrol/cascade_metric_source.go
+++ b/pkg/async/inference/flowcontrol/cascade_metric_source.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+var _ MetricSource = (*CascadeMetricSource)(nil)
+
+// CascadeMetricSource tries each source in order and returns the first successful result.
+// If a source returns an error or no samples, the next source is tried and a log message
+// is emitted so operators can detect when the cascade is active.
+type CascadeMetricSource struct {
+	sources []MetricSource
+}
+
+// NewCascadeMetricSource creates a CascadeMetricSource from the given sources, tried in order.
+// At least two sources are required.
+func NewCascadeMetricSource(sources ...MetricSource) *CascadeMetricSource {
+	return &CascadeMetricSource{sources: sources}
+}
+
+// Query implements MetricSource. It tries each source in order, logging a warning when
+// falling back so operators can detect degraded metric availability.
+func (c *CascadeMetricSource) Query(ctx context.Context) ([]Sample, error) {
+	logger := log.FromContext(ctx)
+	for i, s := range c.sources {
+		samples, err := s.Query(ctx)
+		if err == nil && len(samples) > 0 {
+			if i > 0 {
+				logger.V(logutil.DEFAULT).Info("primary metric source unavailable, using fallback",
+					"fallbackIndex", i)
+			}
+			return samples, nil
+		}
+		if err != nil {
+			logger.V(logutil.DEFAULT).Info("metric source unavailable, trying next",
+				"sourceIndex", i, "error", err)
+		}
+	}
+	return nil, fmt.Errorf("all metric sources unavailable")
+}

--- a/pkg/async/inference/flowcontrol/cascade_metric_source.go
+++ b/pkg/async/inference/flowcontrol/cascade_metric_source.go
@@ -19,6 +19,7 @@ package flowcontrol
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -27,10 +28,11 @@ import (
 var _ MetricSource = (*CascadeMetricSource)(nil)
 
 // CascadeMetricSource tries each source in order and returns the first successful result.
-// If a source returns an error or no samples, the next source is tried and a log message
-// is emitted so operators can detect when the cascade is active.
+// If a source returns an error or no samples, the next source is tried. Log messages are
+// emitted only on transitions (entering/leaving fallback) to avoid noise during sustained outages.
 type CascadeMetricSource struct {
-	sources []MetricSource
+	sources       []MetricSource
+	usingFallback atomic.Bool
 }
 
 // NewCascadeMetricSource creates a CascadeMetricSource from the given sources, tried in order.
@@ -39,22 +41,22 @@ func NewCascadeMetricSource(sources ...MetricSource) *CascadeMetricSource {
 	return &CascadeMetricSource{sources: sources}
 }
 
-// Query implements MetricSource. It tries each source in order, logging a warning when
-// falling back so operators can detect degraded metric availability.
+// Query implements MetricSource. It tries each source in order, logging once when
+// entering fallback and once when recovering to the primary.
 func (c *CascadeMetricSource) Query(ctx context.Context) ([]Sample, error) {
 	logger := log.FromContext(ctx)
 	for i, s := range c.sources {
 		samples, err := s.Query(ctx)
 		if err == nil && len(samples) > 0 {
 			if i > 0 {
-				logger.V(logutil.DEFAULT).Info("primary metric source unavailable, using fallback",
-					"fallbackIndex", i)
+				if c.usingFallback.CompareAndSwap(false, true) {
+					logger.V(logutil.DEFAULT).Info("primary metric source unavailable, using fallback",
+						"fallbackIndex", i)
+				}
+			} else if c.usingFallback.CompareAndSwap(true, false) {
+				logger.V(logutil.DEFAULT).Info("primary metric source recovered")
 			}
 			return samples, nil
-		}
-		if err != nil {
-			logger.V(logutil.DEFAULT).Info("metric source unavailable, trying next",
-				"sourceIndex", i, "error", err)
 		}
 	}
 	return nil, fmt.Errorf("all metric sources unavailable")

--- a/pkg/async/inference/flowcontrol/cascade_metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/cascade_metric_source_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCascadeMetricSource_RequiresAtLeastTwoSources(t *testing.T) {
+	assert.Panics(t, func() { NewCascadeMetricSource() })
+	assert.Panics(t, func() {
+		NewCascadeMetricSource(&mockMetricSource{samples: []Sample{{Value: 1}}})
+	})
+}
+
 func TestCascadeMetricSource_UsesPrimary(t *testing.T) {
 	primary := &mockMetricSource{samples: []Sample{{Value: 0.7}}}
 	secondary := &mockMetricSource{samples: []Sample{{Value: 0.3}}}
@@ -72,32 +79,40 @@ func TestCascadeMetricSource_AllUnavailable(t *testing.T) {
 func TestCascadeMetricSource_FallbackLogsOnce(t *testing.T) {
 	primary := &switchableMetricSource{err: errors.New("unavailable")}
 	secondary := &switchableMetricSource{samples: []Sample{{Value: 0.5}}}
-	cascade := NewCascadeMetricSource(primary, secondary)
+	tertiary := &switchableMetricSource{samples: []Sample{{Value: 0.2}}}
+	cascade := NewCascadeMetricSource(primary, secondary, tertiary)
 	ctx := context.Background()
 
-	// First call cascades to secondary — flag flips to true.
+	// First call cascades to secondary — activeIndex becomes 1.
 	samples, err := cascade.Query(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0.5, samples[0].Value)
-	assert.True(t, cascade.usingFallback.Load(), "should be in fallback after primary fails")
+	assert.Equal(t, int32(1), cascade.activeIndex.Load(), "should track fallback index")
 
-	// Subsequent calls stay in fallback — flag stays true (no duplicate log).
+	// Subsequent calls stay on secondary — no duplicate log.
 	samples, err = cascade.Query(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0.5, samples[0].Value)
-	assert.True(t, cascade.usingFallback.Load())
+	assert.Equal(t, int32(1), cascade.activeIndex.Load())
 
-	// Primary recovers — flag flips back to false.
+	// Secondary also fails — cascades to tertiary, activeIndex becomes 2.
+	secondary.set(nil, errors.New("also down"))
+	samples, err = cascade.Query(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0.2, samples[0].Value)
+	assert.Equal(t, int32(2), cascade.activeIndex.Load(), "should track switch to tertiary")
+
+	// Primary recovers — activeIndex back to 0.
 	primary.set([]Sample{{Value: 0.8}}, nil)
 	samples, err = cascade.Query(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0.8, samples[0].Value)
-	assert.False(t, cascade.usingFallback.Load(), "should leave fallback after primary recovers")
+	assert.Equal(t, int32(0), cascade.activeIndex.Load(), "should recover to primary")
 
-	// Primary fails again — flag flips to true (one new log).
+	// Primary fails again — activeIndex becomes 2 (secondary still down).
 	primary.set(nil, errors.New("unavailable again"))
 	samples, err = cascade.Query(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 0.5, samples[0].Value)
-	assert.True(t, cascade.usingFallback.Load(), "should re-enter fallback on new error")
+	assert.Equal(t, 0.2, samples[0].Value)
+	assert.Equal(t, int32(2), cascade.activeIndex.Load(), "should re-enter fallback")
 }

--- a/pkg/async/inference/flowcontrol/cascade_metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/cascade_metric_source_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCascadeMetricSource_UsesPrimary(t *testing.T) {
+	primary := &mockMetricSource{samples: []Sample{{Value: 0.7}}}
+	secondary := &mockMetricSource{samples: []Sample{{Value: 0.3}}}
+	cascade := NewCascadeMetricSource(primary, secondary)
+
+	samples, err := cascade.Query(context.Background())
+	require.NoError(t, err)
+	require.Len(t, samples, 1)
+	assert.Equal(t, 0.7, samples[0].Value)
+}
+
+func TestCascadeMetricSource_FallsBackOnPrimaryError(t *testing.T) {
+	primary := &mockMetricSource{err: errors.New("unavailable")}
+	secondary := &mockMetricSource{samples: []Sample{{Value: 0.3}}}
+	cascade := NewCascadeMetricSource(primary, secondary)
+
+	samples, err := cascade.Query(context.Background())
+	require.NoError(t, err)
+	require.Len(t, samples, 1)
+	assert.Equal(t, 0.3, samples[0].Value)
+}
+
+func TestCascadeMetricSource_FallsBackOnEmptySamples(t *testing.T) {
+	primary := &mockMetricSource{samples: []Sample{}}
+	secondary := &mockMetricSource{samples: []Sample{{Value: 0.5}}}
+	cascade := NewCascadeMetricSource(primary, secondary)
+
+	samples, err := cascade.Query(context.Background())
+	require.NoError(t, err)
+	require.Len(t, samples, 1)
+	assert.Equal(t, 0.5, samples[0].Value)
+}
+
+func TestCascadeMetricSource_AllUnavailable(t *testing.T) {
+	primary := &mockMetricSource{err: errors.New("primary down")}
+	secondary := &mockMetricSource{err: errors.New("secondary down")}
+	cascade := NewCascadeMetricSource(primary, secondary)
+
+	samples, err := cascade.Query(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all metric sources unavailable")
+	assert.Nil(t, samples)
+}
+
+func TestCascadeMetricSource_FallbackLogsOnce(t *testing.T) {
+	primary := &switchableMetricSource{err: errors.New("unavailable")}
+	secondary := &switchableMetricSource{samples: []Sample{{Value: 0.5}}}
+	cascade := NewCascadeMetricSource(primary, secondary)
+	ctx := context.Background()
+
+	// First call cascades to secondary — flag flips to true.
+	samples, err := cascade.Query(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, samples[0].Value)
+	assert.True(t, cascade.usingFallback.Load(), "should be in fallback after primary fails")
+
+	// Subsequent calls stay in fallback — flag stays true (no duplicate log).
+	samples, err = cascade.Query(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, samples[0].Value)
+	assert.True(t, cascade.usingFallback.Load())
+
+	// Primary recovers — flag flips back to false.
+	primary.set([]Sample{{Value: 0.8}}, nil)
+	samples, err = cascade.Query(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0.8, samples[0].Value)
+	assert.False(t, cascade.usingFallback.Load(), "should leave fallback after primary recovers")
+
+	// Primary fails again — flag flips to true (one new log).
+	primary.set(nil, errors.New("unavailable again"))
+	samples, err = cascade.Query(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, samples[0].Value)
+	assert.True(t, cascade.usingFallback.Load(), "should re-enter fallback on new error")
+}

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -138,6 +138,9 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asy
 		if err != nil {
 			return nil, err
 		}
+		if baseline < 0 || baseline >= 1 {
+			return nil, fmt.Errorf("baseline must be in [0, 1), got %g", baseline)
+		}
 		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
 		if err != nil {
 			return nil, err

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -63,9 +63,12 @@ func NewGateFactoryWithCacheTTL(prometheusURL string, cacheTTL time.Duration) *G
 //   - "redis": Queries Redis for dispatch budget
 //   - "prometheus-saturation": Queries Prometheus for pool saturation metric.
 //     Params: pool (required), threshold (default 0.8), fallback (default 0.0)
-//   - "prometheus-budget": Queries Prometheus for dispatch budget using
-//     D = (1 - F_SYS) * (1 - F_EPP) * (1 - B). Params: pool, max_sys (required),
-//     baseline (default 0.05), fallback (default 0.0)
+//   - "prometheus-budget": Cascades two Prometheus metric sources to compute dispatch budget D.
+//     Primary: D = 1 − (queue_size / max_sys) via inference_extension_flow_control_queue_size.
+//     Secondary (fallback): D = 1 − (vllm_running / (ready_pods × max_concurrency)).
+//     Gate closes when D ≤ B (baseline); returns D − B when open, so callers compute
+//     N = max_SYS × (D − B). Params: pool, max_sys (required),
+//     max_concurrency (default 100), baseline (default 0.05), fallback (default 0.0)
 //
 // For unsupported or unknown gate types, returns ConstOpenGate as a safe default.
 func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asyncapi.DispatchGate, error) {
@@ -119,21 +122,46 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asy
 			return nil, fmt.Errorf("prometheus-budget gate type requires --prometheus-url flag to be set")
 		}
 
+		pool := params["pool"]
+		if pool == "" {
+			return nil, fmt.Errorf("inference pool name is required for prometheus-budget gate")
+		}
+		maxSys, err := parsePositiveFloat("max_sys", params["max_sys"])
+		if err != nil {
+			return nil, err
+		}
+		maxConcurrency, err := parseFloat("max_concurrency", params["max_concurrency"], 100.0)
+		if err != nil {
+			return nil, err
+		}
+		if maxConcurrency <= 0 {
+			return nil, fmt.Errorf("max_concurrency must be positive, got %g", maxConcurrency)
+		}
+		baseline, err := parseFloat("baseline", params["baseline"], 0.05)
+		if err != nil {
+			return nil, err
+		}
 		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
 		if err != nil {
 			return nil, err
 		}
 
 		promConfig := promapi.Config{Address: f.prometheusURL}
-		source, err := NewBudgetPromQLSourceFromConfig(promConfig, params)
+
+		primary, err := NewFlowControlQueueSizePromQL(promConfig, pool, maxSys)
 		if err != nil {
 			return nil, err
 		}
-		var ms MetricSource = source
-		if f.cacheTTL > 0 {
-			ms = NewCachedMetricSource(source, f.cacheTTL)
+		secondary, err := NewVLLMSaturationPromQL(promConfig, pool, maxConcurrency)
+		if err != nil {
+			return nil, err
 		}
-		return NewBudgetDispatchGate(ms, fallback), nil
+
+		var ms MetricSource = NewCascadeMetricSource(
+			cachedSource(primary, f.cacheTTL),
+			cachedSource(secondary, f.cacheTTL),
+		)
+		return NewBudgetDispatchGate(ms, baseline, fallback), nil
 
 	default:
 		// Unknown gate types default to open gate
@@ -150,4 +178,25 @@ func parseFloat(name, str string, defaultValue float64) (float64, error) {
 		return 0, fmt.Errorf("invalid %s value '%s': %w", name, str, err)
 	}
 	return v, nil
+}
+
+func parsePositiveFloat(name, str string) (float64, error) {
+	if str == "" {
+		return 0, fmt.Errorf("prometheus-budget gate requires '%s' parameter", name)
+	}
+	v, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value '%s': %w", name, str, err)
+	}
+	if v <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %g", name, v)
+	}
+	return v, nil
+}
+
+func cachedSource(s MetricSource, ttl time.Duration) MetricSource {
+	if ttl > 0 {
+		return NewCachedMetricSource(s, ttl)
+	}
+	return s
 }

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -64,10 +64,11 @@ func NewGateFactoryWithCacheTTL(prometheusURL string, cacheTTL time.Duration) *G
 //   - "prometheus-saturation": Queries Prometheus for pool saturation metric.
 //     Params: pool (required), threshold (default 0.8), fallback (default 0.0)
 //   - "prometheus-budget": Cascades two Prometheus metric sources to compute dispatch budget D.
-//     Primary: D = 1 − (queue_size / max_sys) via inference_extension_flow_control_queue_size.
-//     Secondary (fallback): D = 1 − (vllm_running / (ready_pods × max_concurrency)).
+//     Both sources compute max_SYS = ready_pods × max_concurrency dynamically.
+//     Primary: D = 1 − (queue_size / max_SYS) via inference_extension_flow_control_queue_size.
+//     Secondary (fallback): D = 1 − (vllm_running / max_SYS).
 //     Gate closes when D ≤ B (baseline); returns D − B when open, so callers compute
-//     N = max_SYS × (D − B). Params: pool, max_sys (required),
+//     N = max_SYS × (D − B). Params: pool (required),
 //     max_concurrency (default 100), baseline (default 0.05), fallback (default 0.0)
 //
 // For unsupported or unknown gate types, returns ConstOpenGate as a safe default.
@@ -126,10 +127,6 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asy
 		if pool == "" {
 			return nil, fmt.Errorf("inference pool name is required for prometheus-budget gate")
 		}
-		maxSys, err := parsePositiveFloat("max_sys", params["max_sys"])
-		if err != nil {
-			return nil, err
-		}
 		maxConcurrency, err := parseFloat("max_concurrency", params["max_concurrency"], 100.0)
 		if err != nil {
 			return nil, err
@@ -148,7 +145,7 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asy
 
 		promConfig := promapi.Config{Address: f.prometheusURL}
 
-		primary, err := NewFlowControlQueueSizePromQL(promConfig, pool, maxSys)
+		primary, err := NewFlowControlQueueSizePromQL(promConfig, pool, maxConcurrency)
 		if err != nil {
 			return nil, err
 		}
@@ -176,20 +173,6 @@ func parseFloat(name, str string, defaultValue float64) (float64, error) {
 	v, err := strconv.ParseFloat(str, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid %s value '%s': %w", name, str, err)
-	}
-	return v, nil
-}
-
-func parsePositiveFloat(name, str string) (float64, error) {
-	if str == "" {
-		return 0, fmt.Errorf("prometheus-budget gate requires '%s' parameter", name)
-	}
-	v, err := strconv.ParseFloat(str, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s value '%s': %w", name, str, err)
-	}
-	if v <= 0 {
-		return 0, fmt.Errorf("%s must be positive, got %g", name, v)
 	}
 	return v, nil
 }

--- a/pkg/async/inference/flowcontrol/gate_factory_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_test.go
@@ -150,24 +150,15 @@ func TestGateFactory_RedisGateDifferentAddresses(t *testing.T) {
 
 func TestGateFactory_BudgetGateWithoutURL(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{"max_sys": "50"})
+	gate, err := factory.CreateGate("prometheus-budget", map[string]string{"pool": "my-pool"})
 	assert.Error(t, err, "should return error when Prometheus URL is not set")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "prometheus-budget gate type requires --prometheus-url flag to be set")
 }
 
-func TestGateFactory_BudgetGateMissingMaxSys(t *testing.T) {
-	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{"pool": "my-pool"})
-	assert.Error(t, err, "should return error when max_sys is not provided")
-	assert.Nil(t, gate)
-	assert.Contains(t, err.Error(), "max_sys")
-}
-
 func TestGateFactory_BudgetGateMissingPool(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"max_sys":         "50",
 		"max_concurrency": "100",
 	})
 	assert.Error(t, err, "should return error when pool is missing")
@@ -178,8 +169,7 @@ func TestGateFactory_BudgetGateMissingPool(t *testing.T) {
 func TestGateFactory_BudgetGateDefaultMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"pool":    "my-pool",
-		"max_sys": "100",
+		"pool": "my-pool",
 	})
 	assert.NoError(t, err, "should use default max_concurrency=100 when not provided")
 	assert.NotNil(t, gate)
@@ -189,7 +179,6 @@ func TestGateFactory_BudgetGateWithZeroMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
 		"pool":            "my-pool",
-		"max_sys":         "100",
 		"max_concurrency": "0",
 	})
 	assert.Error(t, err)
@@ -197,46 +186,21 @@ func TestGateFactory_BudgetGateWithZeroMaxConcurrency(t *testing.T) {
 	assert.Contains(t, err.Error(), "max_concurrency must be positive")
 }
 
-func TestGateFactory_BudgetGateWithPoolAndMaxSys(t *testing.T) {
+func TestGateFactory_BudgetGateWithPoolAndMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
 		"pool":            "my-pool",
-		"max_sys":         "100",
 		"max_concurrency": "100",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
 }
 
-func TestGateFactory_BudgetGateWithInvalidMaxSys(t *testing.T) {
-	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"pool":    "my-pool",
-		"max_sys": "not-a-number",
-	})
-	assert.Error(t, err)
-	assert.Nil(t, gate)
-	assert.Contains(t, err.Error(), "invalid max_sys value")
-}
-
-func TestGateFactory_BudgetGateWithZeroMaxSys(t *testing.T) {
-	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"pool":    "my-pool",
-		"max_sys": "0",
-	})
-	assert.Error(t, err)
-	assert.Nil(t, gate)
-	assert.Contains(t, err.Error(), "max_sys must be positive")
-}
-
 func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"pool":            "my-pool",
-		"max_sys":         "50",
-		"max_concurrency": "100",
-		"baseline":        "not-a-number",
+		"pool":     "my-pool",
+		"baseline": "not-a-number",
 	})
 	assert.Error(t, err, "should return error when baseline is not a valid float")
 	assert.Nil(t, gate)
@@ -246,10 +210,8 @@ func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 func TestGateFactory_BudgetGateWithInvalidFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"pool":            "my-pool",
-		"max_sys":         "50",
-		"max_concurrency": "100",
-		"fallback":        "not-a-number",
+		"pool":     "my-pool",
+		"fallback": "not-a-number",
 	})
 	assert.Error(t, err, "should return error when fallback is not a valid float")
 	assert.Nil(t, gate)
@@ -260,7 +222,6 @@ func TestGateFactory_BudgetGateWithAllParams(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
 		"pool":            "my-pool",
-		"max_sys":         "50",
 		"max_concurrency": "100",
 		"baseline":        "0.1",
 		"fallback":        "0.5",

--- a/pkg/async/inference/flowcontrol/gate_factory_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_test.go
@@ -158,27 +158,51 @@ func TestGateFactory_BudgetGateWithoutURL(t *testing.T) {
 
 func TestGateFactory_BudgetGateMissingMaxSys(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{})
+	gate, err := factory.CreateGate("prometheus-budget", map[string]string{"pool": "my-pool"})
 	assert.Error(t, err, "should return error when max_sys is not provided")
 	assert.Nil(t, gate)
-	assert.Contains(t, err.Error(), "prometheus-budget gate requires 'max_sys' parameter")
+	assert.Contains(t, err.Error(), "max_sys")
 }
 
 func TestGateFactory_BudgetGateMissingPool(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"max_sys": "50",
+		"max_sys":         "50",
+		"max_concurrency": "100",
 	})
 	assert.Error(t, err, "should return error when pool is missing")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "inference pool name is required")
 }
 
-func TestGateFactory_BudgetGateWithPoolAndMaxSys(t *testing.T) {
+func TestGateFactory_BudgetGateDefaultMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
 		"pool":    "my-pool",
 		"max_sys": "100",
+	})
+	assert.NoError(t, err, "should use default max_concurrency=100 when not provided")
+	assert.NotNil(t, gate)
+}
+
+func TestGateFactory_BudgetGateWithZeroMaxConcurrency(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+		"pool":            "my-pool",
+		"max_sys":         "100",
+		"max_concurrency": "0",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "max_concurrency must be positive")
+}
+
+func TestGateFactory_BudgetGateWithPoolAndMaxSys(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+		"pool":            "my-pool",
+		"max_sys":         "100",
+		"max_concurrency": "100",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
@@ -187,6 +211,7 @@ func TestGateFactory_BudgetGateWithPoolAndMaxSys(t *testing.T) {
 func TestGateFactory_BudgetGateWithInvalidMaxSys(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+		"pool":    "my-pool",
 		"max_sys": "not-a-number",
 	})
 	assert.Error(t, err)
@@ -197,6 +222,7 @@ func TestGateFactory_BudgetGateWithInvalidMaxSys(t *testing.T) {
 func TestGateFactory_BudgetGateWithZeroMaxSys(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+		"pool":    "my-pool",
 		"max_sys": "0",
 	})
 	assert.Error(t, err)
@@ -207,8 +233,10 @@ func TestGateFactory_BudgetGateWithZeroMaxSys(t *testing.T) {
 func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"max_sys":  "50",
-		"baseline": "not-a-number",
+		"pool":            "my-pool",
+		"max_sys":         "50",
+		"max_concurrency": "100",
+		"baseline":        "not-a-number",
 	})
 	assert.Error(t, err, "should return error when baseline is not a valid float")
 	assert.Nil(t, gate)
@@ -218,8 +246,10 @@ func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 func TestGateFactory_BudgetGateWithInvalidFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"max_sys":  "50",
-		"fallback": "not-a-number",
+		"pool":            "my-pool",
+		"max_sys":         "50",
+		"max_concurrency": "100",
+		"fallback":        "not-a-number",
 	})
 	assert.Error(t, err, "should return error when fallback is not a valid float")
 	assert.Nil(t, gate)
@@ -229,10 +259,11 @@ func TestGateFactory_BudgetGateWithInvalidFallback(t *testing.T) {
 func TestGateFactory_BudgetGateWithAllParams(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"pool":     "my-pool",
-		"max_sys":  "50",
-		"baseline": "0.1",
-		"fallback": "0.5",
+		"pool":            "my-pool",
+		"max_sys":         "50",
+		"max_concurrency": "100",
+		"baseline":        "0.1",
+		"fallback":        "0.5",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)

--- a/pkg/async/inference/flowcontrol/gate_factory_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_test.go
@@ -207,6 +207,26 @@ func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid baseline value")
 }
 
+func TestGateFactory_BudgetGateWithBaselineOutOfRange(t *testing.T) {
+	factory := NewGateFactory("http://localhost:9090")
+
+	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+		"pool":     "my-pool",
+		"baseline": "1.0",
+	})
+	assert.Error(t, err, "baseline=1.0 should be rejected (gate would never open)")
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "baseline must be in [0, 1)")
+
+	gate, err = factory.CreateGate("prometheus-budget", map[string]string{
+		"pool":     "my-pool",
+		"baseline": "-0.1",
+	})
+	assert.Error(t, err, "negative baseline should be rejected")
+	assert.Nil(t, gate)
+	assert.Contains(t, err.Error(), "baseline must be in [0, 1)")
+}
+
 func TestGateFactory_BudgetGateWithInvalidFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 	gate, err := factory.CreateGate("prometheus-budget", map[string]string{

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -19,11 +19,9 @@ package flowcontrol
 import (
 	"context"
 	"math"
-	"sync/atomic"
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
 var _ asyncapi.DispatchGate = (*MetricDispatchGate)(nil)
@@ -35,10 +33,9 @@ var _ asyncapi.DispatchGate = (*MetricDispatchGate)(nil)
 // formula N = max_SYS × (D − B) when threshold is set to the reserved baseline B.
 // On error or missing/invalid data, the gate returns the configured fallback budget.
 type MetricDispatchGate struct {
-	source        MetricSource
-	threshold     float64
-	fallback      float64
-	usingFallback atomic.Bool
+	source    MetricSource
+	threshold float64
+	fallback  float64
 }
 
 // NewMetricDispatchGate creates a MetricDispatchGate with the given source, threshold,
@@ -77,29 +74,19 @@ func (g *MetricDispatchGate) Budget(ctx context.Context) float64 {
 
 	samples, err := g.source.Query(ctx)
 	if err != nil {
-		if g.usingFallback.CompareAndSwap(false, true) {
-			logger.V(logutil.DEFAULT).Info("MetricSource error, using fallback value", "fallback", g.fallback, "error", err)
-		}
+		logger.Error(err, "MetricSource error, using fallback value", "fallback", g.fallback)
 		return g.fallback
 	}
 
 	if len(samples) == 0 {
-		if g.usingFallback.CompareAndSwap(false, true) {
-			logger.V(logutil.DEFAULT).Info("No metric samples found, using fallback value", "fallback", g.fallback)
-		}
+		logger.Error(nil, "No metric samples found, using fallback value", "fallback", g.fallback)
 		return g.fallback
 	}
 
 	value := samples[0].Value
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		if g.usingFallback.CompareAndSwap(false, true) {
-			logger.V(logutil.DEFAULT).Info("Invalid metric value, using fallback value", "fallback", g.fallback, "value", value)
-		}
+		logger.Error(nil, "Invalid metric value, using fallback value", "fallback", g.fallback, "value", value)
 		return g.fallback
-	}
-
-	if g.usingFallback.CompareAndSwap(true, false) {
-		logger.V(logutil.DEFAULT).Info("MetricSource recovered, no longer using fallback")
 	}
 
 	if value <= g.threshold {

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -18,6 +18,7 @@ package flowcontrol
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
@@ -79,13 +80,13 @@ func (g *MetricDispatchGate) Budget(ctx context.Context) float64 {
 	}
 
 	if len(samples) == 0 {
-		logger.Error(nil, "No metric samples found, using fallback value", "fallback", g.fallback)
+		logger.Error(fmt.Errorf("no metric samples found"), "using fallback value", "fallback", g.fallback)
 		return g.fallback
 	}
 
 	value := samples[0].Value
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		logger.Error(nil, "Invalid metric value, using fallback value", "fallback", g.fallback, "value", value)
+		logger.Error(fmt.Errorf("invalid metric value: %v", value), "using fallback value", "fallback", g.fallback)
 		return g.fallback
 	}
 

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -19,6 +19,7 @@ package flowcontrol
 import (
 	"context"
 	"math"
+	"sync/atomic"
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,14 +29,16 @@ import (
 var _ asyncapi.DispatchGate = (*MetricDispatchGate)(nil)
 
 // MetricDispatchGate implements DispatchGate by querying a MetricSource for a
-// budget value and returning it clamped to [0.0, 1.0].
+// budget value D and returning D − threshold, clamped to [0.0, 1.0].
 //
-// If the value is at or below the configured threshold, the gate returns 0.0.
+// The gate closes (returns 0.0) when D ≤ threshold. This implements the doc
+// formula N = max_SYS × (D − B) when threshold is set to the reserved baseline B.
 // On error or missing/invalid data, the gate returns the configured fallback budget.
 type MetricDispatchGate struct {
-	source    MetricSource
-	threshold float64
-	fallback  float64
+	source        MetricSource
+	threshold     float64
+	fallback      float64
+	usingFallback atomic.Bool
 }
 
 // NewMetricDispatchGate creates a MetricDispatchGate with the given source, threshold,
@@ -49,45 +52,58 @@ func NewMetricDispatchGate(source MetricSource, threshold float64, fallback floa
 }
 
 // NewSaturationDispatchGate creates a MetricDispatchGate for the saturation use case.
-// The source should return a budget value (e.g. 1 - saturation).
-// The threshold and fallback are saturation values; they are internally converted
-// to budget values via 1 - value.
+// The source should return a budget value D (e.g. 1 − saturation).
+// The threshold and fallback are given in saturation space and converted to budget
+// space via 1 − value.
 func NewSaturationDispatchGate(source MetricSource, threshold float64, fallback float64) *MetricDispatchGate {
 	return NewMetricDispatchGate(source, 1.0-threshold, 1.0-fallback)
 }
 
-// NewBudgetDispatchGate creates a MetricDispatchGate for the dispatch budget use case.
-// The source should return the budget value directly: (1 - F_SYS) * (1 - F_EPP) * (1 - B).
-// The threshold is set to 0.0 (gate closes only when budget reaches zero).
-// The fallback parameter is a direct budget value, clamped to [0.0, 1.0].
-func NewBudgetDispatchGate(source MetricSource, fallback float64) *MetricDispatchGate {
-	return NewMetricDispatchGate(source, 0.0, fallback)
+// NewBudgetDispatchGate creates a MetricDispatchGate for the prometheus-budget use case.
+// The source should return the dispatch budget D (e.g. D = 1 − F, where F is EPP
+// fullness, or D = 1 − S, where S is inference pool saturation).
+// baseline is the reserved baseline B ∈ [0, 1]: the gate closes when D ≤ B and
+// returns D − B when open, so the caller computes N = max_SYS × (D − B).
+// fallback is returned on error, clamped to [0.0, 1.0].
+func NewBudgetDispatchGate(source MetricSource, baseline float64, fallback float64) *MetricDispatchGate {
+	return NewMetricDispatchGate(source, baseline, fallback)
 }
 
 // Budget implements DispatchGate.
+// Returns 0.0 when D ≤ threshold (gate closed), otherwise D − threshold clamped to [0.0, 1.0].
 // On error or missing data the gate returns the configured fallback budget.
-// The output is always clamped to [0.0, 1.0].
 func (g *MetricDispatchGate) Budget(ctx context.Context) float64 {
 	logger := log.FromContext(ctx)
 
 	samples, err := g.source.Query(ctx)
 	if err != nil {
-		logger.V(logutil.DEFAULT).Info("MetricSource error, using fallback value", "fallback", g.fallback, "error", err)
+		if g.usingFallback.CompareAndSwap(false, true) {
+			logger.V(logutil.DEFAULT).Info("MetricSource error, using fallback value", "fallback", g.fallback, "error", err)
+		}
 		return g.fallback
 	}
 
 	if len(samples) == 0 {
-		logger.V(logutil.DEFAULT).Info("No metric samples found, using fallback value", "fallback", g.fallback)
+		if g.usingFallback.CompareAndSwap(false, true) {
+			logger.V(logutil.DEFAULT).Info("No metric samples found, using fallback value", "fallback", g.fallback)
+		}
 		return g.fallback
 	}
 
 	value := samples[0].Value
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		logger.V(logutil.DEFAULT).Info("Invalid metric value, using fallback value", "fallback", g.fallback, "value", value)
+		if g.usingFallback.CompareAndSwap(false, true) {
+			logger.V(logutil.DEFAULT).Info("Invalid metric value, using fallback value", "fallback", g.fallback, "value", value)
+		}
 		return g.fallback
 	}
+
+	if g.usingFallback.CompareAndSwap(true, false) {
+		logger.V(logutil.DEFAULT).Info("MetricSource recovered, no longer using fallback")
+	}
+
 	if value <= g.threshold {
 		return 0.0
 	}
-	return math.Min(1.0, math.Max(0.0, value))
+	return math.Min(1.0, math.Max(0.0, value-g.threshold))
 }

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -133,30 +132,6 @@ func (s *switchableMetricSource) set(samples []Sample, err error) {
 	defer s.mu.Unlock()
 	s.samples = samples
 	s.err = err
-}
-
-func TestMetricDispatchGate_FallbackLogsOnce(t *testing.T) {
-	source := &switchableMetricSource{err: errors.New("unavailable")}
-	gate := NewMetricDispatchGate(source, 0.0, 0.5)
-	ctx := context.Background()
-
-	// First call enters fallback — flag flips to true.
-	assert.Equal(t, 0.5, gate.Budget(ctx))
-	assert.True(t, gate.usingFallback.Load(), "should be in fallback after first error")
-
-	// Subsequent calls stay in fallback — flag stays true (no duplicate log).
-	assert.Equal(t, 0.5, gate.Budget(ctx))
-	assert.True(t, gate.usingFallback.Load())
-
-	// Recover: source returns valid data — flag flips back to false.
-	source.set([]Sample{{Value: 0.8}}, nil)
-	assert.InDelta(t, 0.8, gate.Budget(ctx), 1e-9)
-	assert.False(t, gate.usingFallback.Load(), "should leave fallback after recovery")
-
-	// Re-enter fallback — flag flips to true again (one new log).
-	source.set(nil, errors.New("unavailable again"))
-	assert.Equal(t, 0.5, gate.Budget(ctx))
-	assert.True(t, gate.usingFallback.Load(), "should re-enter fallback on new error")
 }
 
 func TestMetricDispatchGate(t *testing.T) {

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"math"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,15 +36,16 @@ func TestSaturationDispatchGate(t *testing.T) {
 		fallback   float64
 		expected   float64
 	}{
-		{"zero saturation", 0.0, nil, 0.8, 1.0, 1.0},
-		{"partial saturation", 0.3, nil, 0.8, 1.0, 1 - 0.3},
+		// source returns D = 1-saturation; threshold is converted to budget space as B = 1-threshold.
+		// Budget() returns D-B = (1-saturation)-(1-threshold) when D > B, else 0.
+		{"zero saturation", 0.0, nil, 0.8, 1.0, 0.8},
+		{"partial saturation", 0.3, nil, 0.8, 1.0, 0.8 - 0.3},
 		{"at threshold", 0.8, nil, 0.8, 1.0, 0.0},
 		{"above threshold", 0.95, nil, 0.8, 1.0, 0.0},
 		{"full saturation", 1.0, nil, 0.8, 1.0, 0.0},
-		{"just below threshold", 0.79, nil, 0.8, 1.0, 1 - 0.79},
-		{"threshold one", 0.99, nil, 1.0, 1.0, 1 - 0.99},
+		{"just below threshold", 0.79, nil, 0.8, 1.0, 0.8 - 0.79},
+		{"threshold one", 0.99, nil, 1.0, 1.0, 1.0 - 0.99},
 		{"saturation above one", 1.5, nil, 0.8, 1.0, 0.0},
-		{"saturation above one high threshold", 1.5, nil, 2.0, 1.0, 0.0},
 		{"negative saturation", -0.5, nil, 0.8, 1.0, 1.0},
 		{"error fail closed", 0, errors.New("conn refused"), 0.8, 1.0, 0.0},
 		{"error fail open", 0, errors.New("conn refused"), 0.8, 0.0, 1.0},
@@ -80,20 +83,22 @@ func TestBudgetDispatchGate(t *testing.T) {
 		name     string
 		budget   float64
 		err      error
+		baseline float64
 		fallback float64
 		expected float64
 	}{
-		{"core formula", 0.5 * 0.9 * 0.95, nil, 0.0, 0.5 * 0.9 * 0.95},
-		{"zero load", 1.0 * 1.0 * 0.95, nil, 0.0, 0.95},
-		{"fully saturated", 0.0, nil, 0.0, 0.0},
-		{"overloaded negative", -0.2 * 0.8 * 0.95, nil, 0.0, 0.0},
-		{"full budget", 1.0, nil, 0.0, 1.0},
-		{"near zero budget", 0.01, nil, 0.0, 0.01},
-		{"NaN", math.NaN(), nil, 0.0, 0.0},
-		{"error fail closed", 0, errors.New("conn refused"), 0.0, 0.0},
-		{"error fail open", 0, errors.New("conn refused"), 1.0, 1.0},
-		{"fallback clamped above one", 0, errors.New("error"), 2.0, 1.0},
-		{"fallback clamped below zero", 0, errors.New("error"), -1.0, 0.0},
+		// Budget() returns D-B when D > B (baseline), else 0.
+		{"D above baseline", 0.7, nil, 0.1, 0.0, 0.6},
+		{"D at baseline, gate closed", 0.1, nil, 0.1, 0.0, 0.0},
+		{"D below baseline, gate closed", 0.05, nil, 0.1, 0.0, 0.0},
+		{"zero baseline, returns D", 0.5, nil, 0.0, 0.0, 0.5},
+		{"zero baseline, full capacity", 1.0, nil, 0.0, 0.0, 1.0},
+		{"fully saturated", 0.0, nil, 0.05, 0.0, 0.0},
+		{"NaN", math.NaN(), nil, 0.05, 0.0, 0.0},
+		{"error fail closed", 0, errors.New("conn refused"), 0.05, 0.0, 0.0},
+		{"error fail open", 0, errors.New("conn refused"), 0.05, 1.0, 1.0},
+		{"fallback clamped above one", 0, errors.New("error"), 0.05, 2.0, 1.0},
+		{"fallback clamped below zero", 0, errors.New("error"), 0.05, -1.0, 0.0},
 	}
 
 	for _, tt := range tests {
@@ -104,10 +109,54 @@ func TestBudgetDispatchGate(t *testing.T) {
 			} else {
 				source = &mockMetricSource{samples: []Sample{{Value: tt.budget}}}
 			}
-			gate := NewBudgetDispatchGate(source, tt.fallback)
+			gate := NewBudgetDispatchGate(source, tt.baseline, tt.fallback)
 			require.InDelta(t, tt.expected, gate.Budget(context.Background()), 1e-9)
 		})
 	}
+}
+
+// switchableMetricSource allows changing what Query returns between calls.
+type switchableMetricSource struct {
+	mu      sync.Mutex
+	samples []Sample
+	err     error
+}
+
+func (s *switchableMetricSource) Query(_ context.Context) ([]Sample, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.samples, s.err
+}
+
+func (s *switchableMetricSource) set(samples []Sample, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.samples = samples
+	s.err = err
+}
+
+func TestMetricDispatchGate_FallbackLogsOnce(t *testing.T) {
+	source := &switchableMetricSource{err: errors.New("unavailable")}
+	gate := NewMetricDispatchGate(source, 0.0, 0.5)
+	ctx := context.Background()
+
+	// First call enters fallback — flag flips to true.
+	assert.Equal(t, 0.5, gate.Budget(ctx))
+	assert.True(t, gate.usingFallback.Load(), "should be in fallback after first error")
+
+	// Subsequent calls stay in fallback — flag stays true (no duplicate log).
+	assert.Equal(t, 0.5, gate.Budget(ctx))
+	assert.True(t, gate.usingFallback.Load())
+
+	// Recover: source returns valid data — flag flips back to false.
+	source.set([]Sample{{Value: 0.8}}, nil)
+	assert.InDelta(t, 0.8, gate.Budget(ctx), 1e-9)
+	assert.False(t, gate.usingFallback.Load(), "should leave fallback after recovery")
+
+	// Re-enter fallback — flag flips to true again (one new log).
+	source.set(nil, errors.New("unavailable again"))
+	assert.Equal(t, 0.5, gate.Budget(ctx))
+	assert.True(t, gate.usingFallback.Load(), "should re-enter fallback on new error")
 }
 
 func TestMetricDispatchGate(t *testing.T) {
@@ -119,7 +168,7 @@ func TestMetricDispatchGate(t *testing.T) {
 		fallback  float64
 		expected  float64
 	}{
-		{"above threshold", 0.5, nil, 0.3, 0.0, 0.5},
+		{"above threshold", 0.5, nil, 0.3, 0.0, 0.2},
 		{"at threshold", 0.3, nil, 0.3, 0.0, 0.0},
 		{"below threshold", 0.2, nil, 0.3, 0.0, 0.0},
 		{"fallback on error", 0, errors.New("error"), 0.8, 0.5, 0.5},

--- a/pkg/async/inference/flowcontrol/metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/metric_source_test.go
@@ -165,22 +165,40 @@ func TestNewPromQLMetricSource_InvalidAddress(t *testing.T) {
 
 // PromQL construction tests for budget and saturation source factories
 
-func TestBuildBudgetPromQL_ContainsExpectedMetrics(t *testing.T) {
-	source, err := NewBudgetPromQL(
+func TestFlowControlQueueSizePromQL_ContainsExpectedMetrics(t *testing.T) {
+	source, err := NewFlowControlQueueSizePromQL(
 		api.Config{Address: "http://localhost:9090"},
-		"my-pool", 100, 0.05,
+		"my-pool", 100,
 	)
 	require.NoError(t, err)
-	require.Contains(t, source.expr, `1 - inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
 	require.Contains(t, source.expr, `inference_extension_flow_control_queue_size{inference_pool="my-pool"}`)
 	require.Contains(t, source.expr, "/ 100")
-	require.Contains(t, source.expr, "0.95")
 }
 
-func TestBuildBudgetPromQL_RequiresPool(t *testing.T) {
-	_, err := NewBudgetPromQL(
+func TestFlowControlQueueSizePromQL_RequiresPool(t *testing.T) {
+	_, err := NewFlowControlQueueSizePromQL(
 		api.Config{Address: "http://localhost:9090"},
-		"", 100, 0.05,
+		"", 100,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "inference pool name is required")
+}
+
+func TestVLLMSaturationPromQL_ContainsExpectedMetrics(t *testing.T) {
+	source, err := NewVLLMSaturationPromQL(
+		api.Config{Address: "http://localhost:9090"},
+		"my-pool", 100,
+	)
+	require.NoError(t, err)
+	require.Contains(t, source.expr, `vllm:num_requests_running{inference_pool="my-pool"}`)
+	require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool"}`)
+	require.Contains(t, source.expr, "* 100")
+}
+
+func TestVLLMSaturationPromQL_RequiresPool(t *testing.T) {
+	_, err := NewVLLMSaturationPromQL(
+		api.Config{Address: "http://localhost:9090"},
+		"", 100,
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "inference pool name is required")
@@ -202,20 +220,4 @@ func TestNewSaturationPromQLSourceFromConfig_RequiresPool(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "inference pool name is required")
-}
-
-func TestNewBudgetPromQLSourceFromConfig_ValidatesBaseline(t *testing.T) {
-	_, err := NewBudgetPromQLSourceFromConfig(
-		api.Config{Address: "http://localhost:9090"},
-		map[string]string{"pool": "my-pool", "max_sys": "100", "baseline": "-0.1"},
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "baseline must be in [0, 1]")
-
-	_, err = NewBudgetPromQLSourceFromConfig(
-		api.Config{Address: "http://localhost:9090"},
-		map[string]string{"pool": "my-pool", "max_sys": "100", "baseline": "1.5"},
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "baseline must be in [0, 1]")
 }

--- a/pkg/async/inference/flowcontrol/metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/metric_source_test.go
@@ -172,7 +172,8 @@ func TestFlowControlQueueSizePromQL_ContainsExpectedMetrics(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Contains(t, source.expr, `inference_extension_flow_control_queue_size{inference_pool="my-pool"}`)
-	require.Contains(t, source.expr, "/ 100")
+	require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool"}`)
+	require.Contains(t, source.expr, "* 100")
 }
 
 func TestFlowControlQueueSizePromQL_RequiresPool(t *testing.T) {

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -46,59 +46,39 @@ func NewPromQLMetricSourceFromLabels(promConfig promapi.Config, metricName strin
 	return NewPromQLMetricSource(promConfig, queryExpr)
 }
 
-// NewBudgetPromQLSourceFromConfig builds a PromQLMetricSource for the dispatch budget use case,
-// parsing all budget-specific parameters.
-//
-// Params:
-//   - inferencePool: inference pool name for PromQL label selector
-//   - maxSysStr: max system capacity for normalizing F_EPP (required)
-//   - baselineStr: reserved baseline B (default "0.05")
-func NewBudgetPromQLSourceFromConfig(promConfig promapi.Config, params map[string]string) (*PromQLMetricSource, error) {
-	inferencePoolStr, maxSysStr, baselineStr := params["pool"], params["max_sys"], params["baseline"]
-
-	baseline := 0.05
-	if baselineStr != "" {
-		b, err := strconv.ParseFloat(baselineStr, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid baseline value '%s': %w", baselineStr, err)
-		}
-		if b < 0 || b > 1 {
-			return nil, fmt.Errorf("baseline must be in [0, 1], got %g", b)
-		}
-		baseline = b
-	}
-
-	if maxSysStr == "" {
-		return nil, fmt.Errorf("prometheus-budget gate requires 'max_sys' parameter")
-	}
-	maxSys, err := strconv.ParseFloat(maxSysStr, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid max_sys value '%s': %w", maxSysStr, err)
-	}
-	if maxSys <= 0 {
-		return nil, fmt.Errorf("max_sys must be positive, got %g", maxSys)
-	}
-
-	return NewBudgetPromQL(promConfig, inferencePoolStr, maxSys, baseline)
-}
-
-// NewBudgetPromQL constructs a PromQL expression for the multiplicative dispatch budget:
-//
-//	(1 - F_SYS) * (1 - F_EPP) * (1 - B)
-//
-// where:
-//   - F_SYS = inference_extension_flow_control_pool_saturation
-//   - F_EPP = sum(inference_extension_flow_control_queue_size) / maxSys
-//   - B = baseline
-func NewBudgetPromQL(promConfig promapi.Config, inferencePool string, maxSys float64, baseline float64) (*PromQLMetricSource, error) {
+// NewFlowControlQueueSizePromQL builds a PromQLMetricSource that returns the EPP queue depth
+// as a dispatch budget D = 1 − (queue_size / maxSys), where queue_size is
+// inference_extension_flow_control_queue_size and maxSys is the total system capacity.
+// inferencePool and maxSys are required.
+func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool string, maxSys float64) (*PromQLMetricSource, error) {
 	if inferencePool == "" {
-		return nil, fmt.Errorf("inference pool name is required for budget PromQL")
+		return nil, fmt.Errorf("inference pool name is required for flow control queue size PromQL")
 	}
 	label := strconv.Quote(inferencePool)
-	query := fmt.Sprintf(`(1 - inference_extension_flow_control_pool_saturation{inference_pool=%s})
-			* on(inference_pool) (1 - sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / %g)
-			* %g`, label, label, maxSys, 1-baseline)
+	query := fmt.Sprintf(
+		`1 - sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / %g`,
+		label, maxSys,
+	)
+	source, err := NewPromQLMetricSource(promConfig, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Prometheus metric source: %w", err)
+	}
+	return source, nil
+}
 
+// NewVLLMSaturationPromQL builds a PromQLMetricSource that estimates inference pool saturation
+// from vLLM and pool metrics, returning D = 1 − (running_requests / (ready_pods × maxConcurrency)).
+// This serves as a fallback when EPP flow control metrics are unavailable.
+// inferencePool and maxConcurrency are required.
+func NewVLLMSaturationPromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64) (*PromQLMetricSource, error) {
+	if inferencePool == "" {
+		return nil, fmt.Errorf("inference pool name is required for vLLM saturation PromQL")
+	}
+	label := strconv.Quote(inferencePool)
+	query := fmt.Sprintf(
+		`1 - (sum(vllm:num_requests_running{inference_pool=%s}) / on() (inference_pool_ready_pods{name=%s} * %g))`,
+		label, label, maxConcurrency,
+	)
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus metric source: %w", err)

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -47,17 +47,18 @@ func NewPromQLMetricSourceFromLabels(promConfig promapi.Config, metricName strin
 }
 
 // NewFlowControlQueueSizePromQL builds a PromQLMetricSource that returns the EPP queue depth
-// as a dispatch budget D = 1 − (queue_size / maxSys), where queue_size is
-// inference_extension_flow_control_queue_size and maxSys is the total system capacity.
-// inferencePool and maxSys are required.
-func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool string, maxSys float64) (*PromQLMetricSource, error) {
+// as a dispatch budget D = 1 − (queue_size / (ready_pods × maxConcurrency)), where queue_size is
+// inference_extension_flow_control_queue_size and max_SYS = ready_pods × maxConcurrency is
+// computed dynamically from the inference_pool_ready_pods metric.
+// inferencePool and maxConcurrency are required.
+func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64) (*PromQLMetricSource, error) {
 	if inferencePool == "" {
 		return nil, fmt.Errorf("inference pool name is required for flow control queue size PromQL")
 	}
 	label := strconv.Quote(inferencePool)
 	query := fmt.Sprintf(
-		`1 - sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / %g`,
-		label, maxSys,
+		`1 - (sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / on() (inference_pool_ready_pods{name=%s} * %g))`,
+		label, label, maxConcurrency,
 	)
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -55,6 +55,9 @@ func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool stri
 	if inferencePool == "" {
 		return nil, fmt.Errorf("inference pool name is required for flow control queue size PromQL")
 	}
+	if maxConcurrency <= 0 {
+		return nil, fmt.Errorf("maxConcurrency must be positive, got %g", maxConcurrency)
+	}
 	label := strconv.Quote(inferencePool)
 	query := fmt.Sprintf(
 		`1 - (sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / on() (inference_pool_ready_pods{name=%s} * %g))`,
@@ -74,6 +77,9 @@ func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool stri
 func NewVLLMSaturationPromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64) (*PromQLMetricSource, error) {
 	if inferencePool == "" {
 		return nil, fmt.Errorf("inference pool name is required for vLLM saturation PromQL")
+	}
+	if maxConcurrency <= 0 {
+		return nil, fmt.Errorf("maxConcurrency must be positive, got %g", maxConcurrency)
 	}
 	label := strconv.Quote(inferencePool)
 	query := fmt.Sprintf(

--- a/test/e2e/e2e_budget_gate_test.go
+++ b/test/e2e/e2e_budget_gate_test.go
@@ -22,8 +22,12 @@ var _ = ginkgo.Describe("Budget Metric Dispatch Gate E2E", func() {
 		rdb.Del(ctx, budgetRequestQueue) //nolint:errcheck
 		rdb.Del(ctx, budgetResultQueue)  //nolint:errcheck
 		resetMock(adminURL)
-		// Start with full dispatch budget (no load)
-		setPromMockBudget(promMockURL, "1.0")
+		// Reset all prom-mock metric sources (primary budget, vLLM budget,
+		// primaryDisabled flag) so cascade state doesn't leak between tests.
+		resetPromMock(promMockURL)
+		// Wait for the processor's metric cache (5s TTL) to expire and
+		// pick up the reset (gate-closed) values before each test runs.
+		time.Sleep(6 * time.Second)
 	})
 
 	ginkgo.It("processes a message when dispatch budget is positive", func() {
@@ -64,6 +68,24 @@ var _ = ginkgo.Describe("Budget Metric Dispatch Gate E2E", func() {
 		result := popResult(ctx, rdb, budgetResultQueue)
 		gomega.Expect(result).NotTo(gomega.BeNil())
 		gomega.Expect(result.ID).To(gomega.Equal("budget-zero"))
+	})
+
+	ginkgo.It("falls back to vLLM metrics when primary metric is unavailable", func() {
+		// Disable primary (EPP queue size metric) to simulate EPP being down
+		disablePromMockPrimary(promMockURL)
+		// Secondary (vLLM-based) budget is above baseline
+		setPromMockVLLMBudget(promMockURL, "0.8")
+
+		msg := makeRequestMessage("budget-cascade", 5*time.Minute)
+		enqueueMessage(ctx, rdb, budgetRequestQueue, msg)
+
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, budgetResultQueue)
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 1))
+
+		result := popResult(ctx, rdb, budgetResultQueue)
+		gomega.Expect(result).NotTo(gomega.BeNil())
+		gomega.Expect(result.ID).To(gomega.Equal("budget-cascade"))
 	})
 
 	ginkgo.It("resumes processing when dispatch budget is restored", func() {

--- a/test/e2e/e2e_budget_gate_test.go
+++ b/test/e2e/e2e_budget_gate_test.go
@@ -25,9 +25,6 @@ var _ = ginkgo.Describe("Budget Metric Dispatch Gate E2E", func() {
 		// Reset all prom-mock metric sources (primary budget, vLLM budget,
 		// primaryDisabled flag) so cascade state doesn't leak between tests.
 		resetPromMock(promMockURL)
-		// Wait for the processor's metric cache (5s TTL) to expire and
-		// pick up the reset (gate-closed) values before each test runs.
-		time.Sleep(6 * time.Second)
 	})
 
 	ginkgo.It("processes a message when dispatch budget is positive", func() {

--- a/test/e2e/e2e_saturation_gate_test.go
+++ b/test/e2e/e2e_saturation_gate_test.go
@@ -23,12 +23,9 @@ var _ = ginkgo.Describe("Saturation Metric Dispatch Gate E2E", func() {
 		rdb.Del(ctx, saturationResultQueue)  //nolint:errcheck
 		resetMock(adminURL)
 		resetPromMock(promMockURL)
-		// Set saturation to 1.0 (gate closed) so the processor's metric
-		// cache starts in a closed state before each test.
+		// Set saturation to 1.0 (gate closed) so the processor starts
+		// in a closed state before each test.
 		setPromMockSaturation(promMockURL, "1.0")
-		// Wait for the processor's metric cache (5s TTL) to expire and
-		// pick up the gate-closed values.
-		time.Sleep(6 * time.Second)
 	})
 
 	ginkgo.It("processes a message when saturation is below threshold", func() {

--- a/test/e2e/e2e_saturation_gate_test.go
+++ b/test/e2e/e2e_saturation_gate_test.go
@@ -22,8 +22,13 @@ var _ = ginkgo.Describe("Saturation Metric Dispatch Gate E2E", func() {
 		rdb.Del(ctx, saturationRequestQueue) //nolint:errcheck
 		rdb.Del(ctx, saturationResultQueue)  //nolint:errcheck
 		resetMock(adminURL)
-		// Start with zero saturation (full capacity)
-		setPromMockSaturation(promMockURL, "0")
+		resetPromMock(promMockURL)
+		// Set saturation to 1.0 (gate closed) so the processor's metric
+		// cache starts in a closed state before each test.
+		setPromMockSaturation(promMockURL, "1.0")
+		// Wait for the processor's metric cache (5s TTL) to expire and
+		// pick up the gate-closed values.
+		time.Sleep(6 * time.Second)
 	})
 
 	ginkgo.It("processes a message when saturation is below threshold", func() {

--- a/test/e2e/prom-mock/main.go
+++ b/test/e2e/prom-mock/main.go
@@ -11,18 +11,23 @@ import (
 )
 
 type server struct {
-	mu         sync.Mutex
-	saturation string
-	budget     string
+	mu              sync.Mutex
+	saturation      string
+	budget          string
+	vllmBudget      string
+	primaryDisabled bool
 }
 
 func main() {
-	s := &server{saturation: "0", budget: "0"}
+	s := &server{saturation: "0", budget: "0", vllmBudget: "0"}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/query", s.handleQuery)
 	mux.HandleFunc("/admin/saturation", s.handleSetSaturation)
 	mux.HandleFunc("/admin/budget", s.handleSetBudget)
+	mux.HandleFunc("/admin/vllm-budget", s.handleSetVLLMBudget)
+	mux.HandleFunc("/admin/disable-primary", s.handleDisablePrimary)
+	mux.HandleFunc("/admin/reset", s.handleReset)
 
 	log.Println("Starting prom-mock on :9090")
 	if err := http.ListenAndServe(":9090", mux); err != nil {
@@ -30,13 +35,13 @@ func main() {
 	}
 }
 
-// handleQuery returns a single Prometheus vector result. If the query contains
-// "queue_size" it is a budget gate query: the mock returns the dispatch budget D
-// directly. Otherwise it returns the saturation budget (1 - saturation),
-// matching what the saturation gate's PromQL source produces.
+// handleQuery returns a single Prometheus vector result.
 //
-// The Prometheus client sends queries as POST form body, so we parse both
-// URL params and form body to find the query expression.
+// Routing by query content:
+//   - "inference_extension_flow_control_queue_size" → primary budget gate metric.
+//     Returns empty result when primary is disabled (simulating EPP unavailability).
+//   - "vllm:num_requests_running" → secondary vLLM fallback metric.
+//   - anything else → saturation metric (1 - saturation).
 func (s *server) handleQuery(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "failed to parse form", http.StatusBadRequest)
@@ -45,16 +50,33 @@ func (s *server) handleQuery(w http.ResponseWriter, r *http.Request) {
 	query := r.FormValue("query")
 
 	s.mu.Lock()
-	var value string
-	if strings.Contains(query, "inference_extension_flow_control_queue_size") {
-		value = s.budget
-	} else {
-		saturation, _ := strconv.ParseFloat(s.saturation, 64)
-		value = strconv.FormatFloat(1.0-saturation, 'f', -1, 64)
-	}
+	primaryDisabled := s.primaryDisabled
+	budget := s.budget
+	vllmBudget := s.vllmBudget
+	saturation := s.saturation
 	s.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case strings.Contains(query, "inference_extension_flow_control_queue_size"):
+		if primaryDisabled {
+			// Return empty result to trigger cascade to secondary
+			fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+			return
+		}
+		writeVectorResult(w, budget)
+
+	case strings.Contains(query, "vllm:num_requests_running"):
+		writeVectorResult(w, vllmBudget)
+
+	default:
+		sat, _ := strconv.ParseFloat(saturation, 64)
+		writeVectorResult(w, strconv.FormatFloat(1.0-sat, 'f', -1, 64))
+	}
+}
+
+func writeVectorResult(w http.ResponseWriter, value string) {
 	fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"inference_pool":"e2e-pool"},"value":[1234567890,"%s"]}]}}`, value)
 }
 
@@ -64,6 +86,44 @@ func (s *server) handleSetSaturation(w http.ResponseWriter, r *http.Request) {
 
 func (s *server) handleSetBudget(w http.ResponseWriter, r *http.Request) {
 	s.handleSetValue(w, r, func(v string) { s.budget = v }, func() string { return s.budget })
+}
+
+func (s *server) handleSetVLLMBudget(w http.ResponseWriter, r *http.Request) {
+	s.handleSetValue(w, r, func(v string) { s.vllmBudget = v }, func() string { return s.vllmBudget })
+}
+
+func (s *server) handleDisablePrimary(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.mu.Lock()
+		s.primaryDisabled = true
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ok"}`)
+	case http.MethodDelete:
+		s.mu.Lock()
+		s.primaryDisabled = false
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ok"}`)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *server) handleReset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	s.saturation = "0"
+	s.budget = "0"
+	s.vllmBudget = "0"
+	s.primaryDisabled = false
+	s.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `{"status":"ok"}`)
 }
 
 func (s *server) handleSetValue(w http.ResponseWriter, r *http.Request, set func(string), get func() string) {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -116,12 +116,34 @@ func clearDispatchGateBudget(ctx context.Context, rdb *redis.Client) {
 	rdb.Del(ctx, dispatchGateBudgetKey) //nolint:errcheck
 }
 
+func resetPromMock(promMockURL string) {
+	req, err := http.NewRequest(http.MethodDelete, promMockURL+"/admin/reset", nil)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	resp, err := adminClient.Do(req)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	defer resp.Body.Close() //nolint:errcheck
+	gomega.ExpectWithOffset(1, resp.StatusCode).To(gomega.Equal(http.StatusOK))
+}
+
 func setPromMockSaturation(promMockURL string, value string) {
 	setPromMockValue(promMockURL+"/admin/saturation", value)
 }
 
 func setPromMockBudget(promMockURL string, value string) {
 	setPromMockValue(promMockURL+"/admin/budget", value)
+}
+
+func setPromMockVLLMBudget(promMockURL string, value string) {
+	setPromMockValue(promMockURL+"/admin/vllm-budget", value)
+}
+
+func disablePromMockPrimary(promMockURL string) {
+	req, err := http.NewRequest(http.MethodPost, promMockURL+"/admin/disable-primary", nil)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	resp, err := adminClient.Do(req)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	defer resp.Body.Close() //nolint:errcheck
+	gomega.ExpectWithOffset(1, resp.StatusCode).To(gomega.Equal(http.StatusOK))
 }
 
 func setPromMockValue(url string, value string) {

--- a/test/e2e/yaml/async-processor-budget.yaml
+++ b/test/e2e/yaml/async-processor-budget.yaml
@@ -41,7 +41,7 @@ spec:
             - "--message-queue-impl=redis-sortedset"
             - "--prometheus-url=http://prom-mock.e2e-test.svc.cluster.local:9090"
             - "--redis.ss.gate-type=prometheus-budget"
-            - "--redis.ss.gate-params={\"pool\":\"e2e-pool\",\"max_sys\":\"100\",\"max_concurrency\":\"10\",\"baseline\":\"0.05\"}"
+            - "--redis.ss.gate-params={\"pool\":\"e2e-pool\",\"max_concurrency\":\"10\",\"baseline\":\"0.05\"}"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
             - "--redis.addr=redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"

--- a/test/e2e/yaml/async-processor-budget.yaml
+++ b/test/e2e/yaml/async-processor-budget.yaml
@@ -41,7 +41,7 @@ spec:
             - "--message-queue-impl=redis-sortedset"
             - "--prometheus-url=http://prom-mock.e2e-test.svc.cluster.local:9090"
             - "--redis.ss.gate-type=prometheus-budget"
-            - "--redis.ss.gate-params={\"pool\":\"e2e-pool\",\"max_sys\":\"100\",\"baseline\":\"0.05\"}"
+            - "--redis.ss.gate-params={\"pool\":\"e2e-pool\",\"max_sys\":\"100\",\"max_concurrency\":\"10\",\"baseline\":\"0.05\"}"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
             - "--redis.addr=redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"


### PR DESCRIPTION
note this PR is stacked on #140 so you can ignore the docs/dispatch-budget.md change

## What does this PR do?

implements the changes detailed in #140; the dispatch budget now is computed using a metric from the EPP (queue depth or saturation. In this impl, queue depth.) and if missing (e.g. flow control is disabled) it uses a metric of _saturation_ equivalent to that of the EPP, but computed via Prometheus

## Why is this change needed?

- we implement the new formula described in #140 
- we adopt a cascade strategy in case flow control is disabled (default config) but the users deploy the batch gateway 


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

includes mock tests that will be replaced in #115 

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

related + blocked: #140