### PR TITLE
enhancement: move internal pipeline types from api to pipeline pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# Root go.mod replace ./api must exist before go mod download.
+# Local replace directives (./api, ./pipeline) must exist before go mod download.
 COPY api/ api/
+COPY pipeline/ pipeline/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -1,83 +1,9 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 )
-
-type Flow interface {
-	Characteristics() Characteristics
-	Start(ctx context.Context)
-	RequestChannels() []RequestChannel
-	RetryChannel() chan RetryMessage
-	ResultChannel() chan ResultMessage
-}
-
-type Characteristics struct {
-	HasExternalBackoff     bool
-	SupportsMessageLatency bool
-}
-
-// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
-type DispatchGate interface {
-	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
-	// the fraction of system capacity available for new requests.
-	// A value of 0.0 indicates no available capacity (system at max allowed).
-	// A value of 1.0 indicates full capacity available (system is idle).
-	// The system always returns a valid value, even in case of internal error.
-	Budget(ctx context.Context) float64
-}
-
-// GateFactory defines the interface for creating DispatchGate instances.
-type GateFactory interface {
-	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
-}
-
-var _ DispatchGate = DispatchGateFunc(nil)
-
-// DispatchGateFunc is a function type that implements DispatchGate.
-type DispatchGateFunc func(context.Context) float64
-
-func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
-	return f(ctx)
-}
-
-func ConstOpenGate() DispatchGate {
-	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
-}
-
-type RequestMergePolicy interface {
-	MergeRequestChannels(channels []RequestChannel) EmbelishedRequestChannel
-}
-
-type RequestChannel struct {
-	Channel            chan *InternalRequest
-	IGWBaseURl         string
-	InferenceObjective string
-	RequestPathURL     string
-	Gate               DispatchGate
-}
-
-type EmbelishedRequestChannel struct {
-	Channel chan EmbelishedRequestMessage
-}
-
-// EmbelishedRequestMessage decorates an InternalRequest with HTTP dispatch context.
-// The embedded InternalRequest must be non-nil in normal use.
-// Caller-supplied metadata lives on the embedded Request (via ReqMetadata());
-// there is no separate Metadata field here to avoid ambiguity.
-type EmbelishedRequestMessage struct {
-	*InternalRequest
-	HttpHeaders map[string]string
-	RequestURL  string
-}
-
-// RetryMessage carries an embellished request and backoff for re-queueing.
-type RetryMessage struct {
-	EmbelishedRequestMessage
-	BackoffDurationSeconds float64
-}
 
 // InternalRouting holds the resolved, authoritative routing fields used by
 // infrastructure (producers, workers, retry logic). These are not part of the

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/internal/logging"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker"
@@ -71,7 +71,7 @@ func main() {
 	// Create Gate Factory for per-queue gate instantiation
 	gateFactory := flowcontrol.NewGateFactoryWithCacheTTL(*prometheusURL, *prometheusCacheTTL)
 
-	var policy api.RequestMergePolicy
+	var policy pipeline.RequestMergePolicy
 	switch requestMergePolicy {
 	case "random-robin":
 		policy = async.NewRandomRobinPolicy()
@@ -80,7 +80,7 @@ func main() {
 			requestMergePolicy)
 		os.Exit(1)
 	}
-	var impl api.Flow
+	var impl pipeline.Flow
 	switch messageQueueImpl {
 	case "redis-pubsub":
 		impl = redis.NewRedisMQFlow()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,11 @@ go 1.25.0
 // from v0.0.0 to that semver (e.g. v0.1.0). Keep the replace line for in-repo development.
 require github.com/llm-d-incubation/llm-d-async/api v0.0.0
 
+require github.com/llm-d-incubation/llm-d-async/pipeline v0.0.0
+
 replace github.com/llm-d-incubation/llm-d-async/api => ./api
+
+replace github.com/llm-d-incubation/llm-d-async/pipeline => ./pipeline
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.6.0

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -1,0 +1,7 @@
+module github.com/llm-d-incubation/llm-d-async/pipeline
+
+go 1.25.0
+
+require github.com/llm-d-incubation/llm-d-async/api v0.0.0
+
+replace github.com/llm-d-incubation/llm-d-async/api => ../api

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+)
+
+type Flow interface {
+	Characteristics() Characteristics
+	Start(ctx context.Context)
+	RequestChannels() []RequestChannel
+	RetryChannel() chan RetryMessage
+	ResultChannel() chan api.ResultMessage
+}
+
+type Characteristics struct {
+	HasExternalBackoff     bool
+	SupportsMessageLatency bool
+}
+
+// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
+type DispatchGate interface {
+	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
+	// the fraction of system capacity available for new requests.
+	// A value of 0.0 indicates no available capacity (system at max allowed).
+	// A value of 1.0 indicates full capacity available (system is idle).
+	// The system always returns a valid value, even in case of internal error.
+	Budget(ctx context.Context) float64
+}
+
+// GateFactory defines the interface for creating DispatchGate instances.
+type GateFactory interface {
+	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
+}
+
+var _ DispatchGate = DispatchGateFunc(nil)
+
+// DispatchGateFunc is a function type that implements DispatchGate.
+type DispatchGateFunc func(context.Context) float64
+
+func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
+	return f(ctx)
+}
+
+func ConstOpenGate() DispatchGate {
+	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
+}
+
+type RequestMergePolicy interface {
+	MergeRequestChannels(channels []RequestChannel) EmbelishedRequestChannel
+}
+
+type RequestChannel struct {
+	Channel            chan *api.InternalRequest
+	IGWBaseURl         string
+	InferenceObjective string
+	RequestPathURL     string
+	Gate               DispatchGate
+}
+
+type EmbelishedRequestChannel struct {
+	Channel chan EmbelishedRequestMessage
+}
+
+// EmbelishedRequestMessage decorates an InternalRequest with HTTP dispatch context.
+// The embedded InternalRequest must be non-nil in normal use.
+// Caller-supplied metadata lives on the embedded Request (via ReqMetadata());
+// there is no separate Metadata field here to avoid ambiguity.
+type EmbelishedRequestMessage struct {
+	*api.InternalRequest
+	HttpHeaders map[string]string
+	RequestURL  string
+}
+
+// RetryMessage carries an embellished request and backoff for re-queueing.
+type RetryMessage struct {
+	EmbelishedRequestMessage
+	BackoffDurationSeconds float64
+}

--- a/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 
-	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	promapi "github.com/prometheus/client_golang/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -31,7 +31,7 @@ var prometheusURL = flag.String("gate.prometheus.url", "", "Prometheus URL for n
 var gmpProjectID = flag.String("gate.pmetric.gmp.project-id", "", "Project ID for Google Managed Prometheus")
 var prometheusQueryModelName = flag.String("gate.prometheus.model-name", "", "metrics name to use for avg_queue_size")
 
-var _ asyncapi.DispatchGate = (*BinaryMetricDispatchGate)(nil)
+var _ pipeline.DispatchGate = (*BinaryMetricDispatchGate)(nil)
 
 // BinaryMetricDispatchGate implements DispatchGate using a MetricSource.
 // It returns 0.0 (no capacity) if the metric value is non-zero,

--- a/pkg/async/inference/flowcontrol/dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/dispatch_gate.go
@@ -19,10 +19,10 @@ package flowcontrol
 import (
 	"context"
 
-	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
-var _ api.DispatchGate = DispatchGateFunc(nil)
+var _ pipeline.DispatchGate = DispatchGateFunc(nil)
 
 // DispatchGateFunc is a function type that implements DispatchGate.
 // This allows any function with the signature func(context.Context) float64
@@ -34,6 +34,6 @@ func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
 	return f(ctx)
 }
 
-func ConstOpenGate() api.DispatchGate {
+func ConstOpenGate() pipeline.DispatchGate {
 	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
 }

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	redisgate "github.com/llm-d-incubation/llm-d-async/pkg/redis"
 	promapi "github.com/prometheus/client_golang/api"
 	goredis "github.com/redis/go-redis/v9"
@@ -30,7 +30,7 @@ import (
 // DefaultCacheTTL is the default TTL for cached Prometheus metric sources.
 const DefaultCacheTTL = 5 * time.Second
 
-var _ asyncapi.GateFactory = (*GateFactory)(nil)
+var _ pipeline.GateFactory = (*GateFactory)(nil)
 
 // GateFactory creates DispatchGate instances based on configuration.
 type GateFactory struct {
@@ -68,7 +68,7 @@ func NewGateFactoryWithCacheTTL(prometheusURL string, cacheTTL time.Duration) *G
 //     baseline (default 0.05), fallback (default 0.0)
 //
 // For unsupported or unknown gate types, returns ConstOpenGate as a safe default.
-func (f *GateFactory) CreateGate(gateType string, params map[string]string) (asyncapi.DispatchGate, error) {
+func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pipeline.DispatchGate, error) {
 	switch gateType {
 	case "constant":
 		return ConstOpenGate(), nil

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"math"
 
-	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
-var _ asyncapi.DispatchGate = (*MetricDispatchGate)(nil)
+var _ pipeline.DispatchGate = (*MetricDispatchGate)(nil)
 
 // MetricDispatchGate implements DispatchGate by querying a MetricSource for a
 // budget value and returning it clamped to [0.0, 1.0].

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -4,29 +4,30 @@ import (
 	"reflect"
 
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
-func NewRandomRobinPolicy() api.RequestMergePolicy {
+func NewRandomRobinPolicy() pipeline.RequestMergePolicy {
 	return &RandomRobinPolicy{}
 }
 
-var _ api.RequestMergePolicy = (*RandomRobinPolicy)(nil)
+var _ pipeline.RequestMergePolicy = (*RandomRobinPolicy)(nil)
 
 type RandomRobinPolicy struct {
 }
 
-func (r *RandomRobinPolicy) MergeRequestChannels(channels []api.RequestChannel) api.EmbelishedRequestChannel {
-	mergedChannel := make(chan api.EmbelishedRequestMessage, len(channels))
+func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChannel) pipeline.EmbelishedRequestChannel {
+	mergedChannel := make(chan pipeline.EmbelishedRequestMessage, len(channels))
 
 	// reflect.Select blocks forever on an empty cases slice, so return
 	// a closed channel immediately to avoid goroutine leaks.
 	if len(channels) == 0 {
 		close(mergedChannel)
-		return api.EmbelishedRequestChannel{Channel: mergedChannel}
+		return pipeline.EmbelishedRequestChannel{Channel: mergedChannel}
 	}
 
 	cases := make([]reflect.SelectCase, len(channels)) //nolint:staticcheck
-	meta := make([]api.RequestChannel, len(channels))
+	meta := make([]pipeline.RequestChannel, len(channels))
 	for i, ch := range channels {
 		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch.Channel)}
 		meta[i] = ch
@@ -48,7 +49,7 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []api.RequestChannel) 
 				if !ok || ir == nil {
 					continue
 				}
-				erm := api.EmbelishedRequestMessage{
+				erm := pipeline.EmbelishedRequestMessage{
 					InternalRequest: ir,
 					HttpHeaders: map[string]string{
 						"Content-Type":                  "application/json",
@@ -62,7 +63,7 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []api.RequestChannel) 
 		}
 	}()
 
-	return api.EmbelishedRequestChannel{
+	return pipeline.EmbelishedRequestChannel{
 		Channel: mergedChannel,
 	}
 }

--- a/pkg/async/random_robin_policy_test.go
+++ b/pkg/async/random_robin_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
 func irID(id string) *api.InternalRequest {
@@ -17,7 +18,7 @@ func irID(id string) *api.InternalRequest {
 
 func TestProcessAllChannels(t *testing.T) {
 	msgsPerChannel := 5
-	channels := []api.RequestChannel{
+	channels := []pipeline.RequestChannel{
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURl: "", InferenceObjective: "", RequestPathURL: ""},
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURl: "", InferenceObjective: "", RequestPathURL: ""},
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURl: "", InferenceObjective: "", RequestPathURL: ""},
@@ -70,7 +71,7 @@ func TestEmptyChannelsReturnsClosed(t *testing.T) {
 
 func TestMetaAlignmentAfterChannelClosure(t *testing.T) {
 	// Three channels, each with distinct metadata.
-	channels := []api.RequestChannel{
+	channels := []pipeline.RequestChannel{
 		{Channel: make(chan *api.InternalRequest, 1), IGWBaseURl: "http://a", InferenceObjective: "obj-a", RequestPathURL: "/a"},
 		{Channel: make(chan *api.InternalRequest, 1), IGWBaseURl: "http://b", InferenceObjective: "obj-b", RequestPathURL: "/b"},
 		{Channel: make(chan *api.InternalRequest, 1), IGWBaseURl: "http://c", InferenceObjective: "obj-c", RequestPathURL: "/c"},
@@ -144,9 +145,9 @@ func TestMetaAlignmentAfterChannelClosure(t *testing.T) {
 
 func TestMergedChannelIsBuffered(t *testing.T) {
 	numChannels := 3
-	channels := make([]api.RequestChannel, numChannels)
+	channels := make([]pipeline.RequestChannel, numChannels)
 	for i := range numChannels {
-		channels[i] = api.RequestChannel{Channel: make(chan *api.InternalRequest, 1)}
+		channels[i] = pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)}
 	}
 	policy := NewRandomRobinPolicy()
 	merged := policy.MergeRequestChannels(channels)

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -20,8 +21,8 @@ const (
 	maxDelaySeconds  = 60
 )
 
-func Worker(ctx context.Context, characteristics asyncapi.Characteristics, client asyncapi.InferenceClient, requestChannel chan asyncapi.EmbelishedRequestMessage,
-	retryChannel chan asyncapi.RetryMessage, resultChannel chan asyncapi.ResultMessage, requestTimeout time.Duration) {
+func Worker(ctx context.Context, characteristics pipeline.Characteristics, client asyncapi.InferenceClient, requestChannel chan pipeline.EmbelishedRequestMessage,
+	retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, requestTimeout time.Duration) {
 
 	logger := log.FromContext(ctx)
 	for {
@@ -103,7 +104,7 @@ func Worker(ctx context.Context, characteristics asyncapi.Characteristics, clien
 }
 
 // parsing and validating payload. On failure puts an error msg on the result-channel and returns nil
-func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultMessage, msg asyncapi.EmbelishedRequestMessage) []byte {
+func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultMessage, msg pipeline.EmbelishedRequestMessage) []byte {
 	if msg.PublicRequest == nil {
 		return nil
 	}
@@ -140,7 +141,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 }
 
 // If it is not after deadline, just publish again.
-func retryMessage(ctx context.Context, msg asyncapi.EmbelishedRequestMessage, retryChannel chan asyncapi.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration) {
+func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration) {
 	if msg.PublicRequest == nil {
 		return
 	}
@@ -174,7 +175,7 @@ func retryMessage(ctx context.Context, msg asyncapi.EmbelishedRequestMessage, re
 	msg.RetryCount++
 	metrics.Retries.Inc()
 	select {
-	case retryChannel <- asyncapi.RetryMessage{
+	case retryChannel <- pipeline.RetryMessage{
 		EmbelishedRequestMessage: msg,
 		BackoffDurationSeconds:   finalDuration,
 	}:

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -12,16 +12,17 @@ import (
 	"time"
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
 const defaultRequestTimeout = 5 * time.Minute
 
 // newEmb wraps a RequestMessage in a minimal InternalRequest for tests.
-func newEmb(rm asyncapi.RequestMessage, requestURL string, h map[string]string) asyncapi.EmbelishedRequestMessage {
+func newEmb(rm asyncapi.RequestMessage, requestURL string, h map[string]string) pipeline.EmbelishedRequestMessage {
 	if h == nil {
 		h = map[string]string{}
 	}
-	return asyncapi.EmbelishedRequestMessage{
+	return pipeline.EmbelishedRequestMessage{
 		InternalRequest: asyncapi.NewInternalRequest(asyncapi.InternalRouting{}, &rm),
 		HttpHeaders:     h,
 		RequestURL:      requestURL,
@@ -29,11 +30,11 @@ func newEmb(rm asyncapi.RequestMessage, requestURL string, h map[string]string) 
 }
 
 // newEmbR uses explicit internal routing (e.g. retry count) for tests.
-func newEmbR(routing asyncapi.InternalRouting, rm asyncapi.RequestMessage, requestURL string, h map[string]string) asyncapi.EmbelishedRequestMessage {
+func newEmbR(routing asyncapi.InternalRouting, rm asyncapi.RequestMessage, requestURL string, h map[string]string) pipeline.EmbelishedRequestMessage {
 	if h == nil {
 		h = map[string]string{}
 	}
-	return asyncapi.EmbelishedRequestMessage{
+	return pipeline.EmbelishedRequestMessage{
 		InternalRequest: asyncapi.NewInternalRequest(routing, &rm),
 		HttpHeaders:     h,
 		RequestURL:      requestURL,
@@ -41,7 +42,7 @@ func newEmbR(routing asyncapi.InternalRouting, rm asyncapi.RequestMessage, reque
 }
 
 func TestRetryMessage_deadlinePassed(t *testing.T) {
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmb(asyncapi.RequestMessage{
 		ID:       "123",
@@ -68,7 +69,7 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 }
 
 func TestRetryMessage_retry(t *testing.T) {
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmb(asyncapi.RequestMessage{
 		ID:       "123",
@@ -116,12 +117,12 @@ func TestSheddedRequest(t *testing.T) {
 		}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -152,12 +153,12 @@ func TestSuccessfulRequest(t *testing.T) {
 		}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -186,12 +187,12 @@ func TestFatalError_NoRetry(t *testing.T) {
 		return nil, fmt.Errorf("network unreachable")
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -232,12 +233,12 @@ func TestRateLimitRequest(t *testing.T) {
 		}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -267,13 +268,13 @@ func TestRequestTimeout(t *testing.T) {
 		return nil, req.Context().Err()
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
 	// Use a very short request timeout to trigger the deadline.
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -364,7 +365,7 @@ func TestExpBackoffDuration(t *testing.T) {
 }
 
 func TestRetryMessage_deadlineExact(t *testing.T) {
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	now := time.Now().Unix()
 	msg := newEmb(asyncapi.RequestMessage{
@@ -423,7 +424,7 @@ func TestParseRetryAfter(t *testing.T) {
 }
 
 func TestRetryMessage_retryAfterHonored(t *testing.T) {
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmb(asyncapi.RequestMessage{
 		ID:       "retry-after-test",
@@ -444,7 +445,7 @@ func TestRetryMessage_retryAfterHonored(t *testing.T) {
 }
 
 func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmbR(asyncapi.InternalRouting{RetryCount: 5}, asyncapi.RequestMessage{
 		ID:       "retry-after-small",
@@ -465,7 +466,7 @@ func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
 }
 
 func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmb(asyncapi.RequestMessage{
 		ID:       "retry-after-exceeds-deadline",
@@ -501,12 +502,12 @@ func TestRateLimitRequest_WithRetryAfterHeader(t *testing.T) {
 		}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -563,7 +564,7 @@ func TestRetryMessage_cancelledCtxDoesNotBlock(t *testing.T) {
 	cancel()
 
 	// Unbuffered channels: sends would block without the select guard.
-	retryChannel := make(chan asyncapi.RetryMessage)
+	retryChannel := make(chan pipeline.RetryMessage)
 	resultChannel := make(chan asyncapi.ResultMessage)
 
 	msg := newEmb(asyncapi.RequestMessage{
@@ -595,16 +596,16 @@ func TestWorker_cancelledCtxExitsPromptly(t *testing.T) {
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
 
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
 	// Unbuffered result channel: the worker must not block trying to send.
-	retryChannel := make(chan asyncapi.RetryMessage)
+	retryChannel := make(chan pipeline.RetryMessage)
 	resultChannel := make(chan asyncapi.ResultMessage)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan struct{})
 	go func() {
-		Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 		close(done)
 	}()
 
@@ -639,12 +640,12 @@ func TestClientError_NoRetry(t *testing.T) {
 		}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
-	requestChannel := make(chan asyncapi.EmbelishedRequestMessage, 1)
-	retryChannel := make(chan asyncapi.RetryMessage, 1)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, asyncapi.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -42,20 +43,20 @@ type TopicConfig struct {
 	GateParams         map[string]string `json:"gate_params,omitempty"`
 }
 
-var _ api.Flow = (*PubSubMQFlow)(nil)
+var _ pipeline.Flow = (*PubSubMQFlow)(nil)
 
 type PubSubMQFlow struct {
 	resultTopicID   string
 	requestChannels []RequestChannelData
-	retryChannel    chan api.RetryMessage
+	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
-	gate            api.DispatchGate
-	gateFactory     api.GateFactory
+	gate            pipeline.DispatchGate
+	gateFactory     pipeline.GateFactory
 }
 type RequestChannelData struct {
-	requestChannel api.RequestChannel
+	requestChannel pipeline.RequestChannel
 	subscriberID   string
-	gate           api.DispatchGate
+	gate           pipeline.DispatchGate
 }
 
 // PubSubOption is a functional option for configuring PubSubMQFlow
@@ -63,7 +64,7 @@ type PubSubOption func(*PubSubMQFlow)
 
 // WithGateFactory sets a GateFactory for per-topic gate instantiation.
 // When set, gates are created per topic from config, overriding any global gate.
-func WithGateFactory(factory api.GateFactory) PubSubOption {
+func WithGateFactory(factory pipeline.GateFactory) PubSubOption {
 	return func(p *PubSubMQFlow) {
 		p.gateFactory = factory
 	}
@@ -94,7 +95,7 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 	p := &PubSubMQFlow{
 		resultTopicID:   *resultTopicID,
 		requestChannels: make([]RequestChannelData, 0, len(configs)),
-		retryChannel:    make(chan api.RetryMessage),
+		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage),
 	}
 
@@ -106,7 +107,7 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 	// Create per-topic channels with gates
 	for _, cfg := range configs {
 		// Determine gate for this topic
-		var gate api.DispatchGate
+		var gate pipeline.DispatchGate
 		if p.gateFactory != nil && cfg.GateType != "" {
 			// Use factory to create per-topic gate
 			var err error
@@ -119,12 +120,12 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 			gate = p.gate
 		} else {
 			// Default to always-open gate
-			gate = api.ConstOpenGate()
+			gate = pipeline.ConstOpenGate()
 		}
 
 		ch := make(chan *api.InternalRequest)
 		p.requestChannels = append(p.requestChannels, RequestChannelData{
-			requestChannel: api.RequestChannel{
+			requestChannel: pipeline.RequestChannel{
 				Channel:            ch,
 				IGWBaseURl:         util.NormalizeBaseURL(cfg.IGWBaseURl),
 				InferenceObjective: cfg.InferenceObjective,
@@ -138,13 +139,13 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 
 	// Set default gate if not already set
 	if p.gate == nil {
-		p.gate = api.ConstOpenGate()
+		p.gate = pipeline.ConstOpenGate()
 	}
 
 	return p
 }
 
-func (r *PubSubMQFlow) RetryChannel() chan api.RetryMessage {
+func (r *PubSubMQFlow) RetryChannel() chan pipeline.RetryMessage {
 	return r.retryChannel
 }
 
@@ -152,16 +153,16 @@ func (r *PubSubMQFlow) ResultChannel() chan api.ResultMessage {
 	return r.resultChannel
 }
 
-func (r *PubSubMQFlow) Characteristics() api.Characteristics {
-	return api.Characteristics{
+func (r *PubSubMQFlow) Characteristics() pipeline.Characteristics {
+	return pipeline.Characteristics{
 		HasExternalBackoff:     true,
 		SupportsMessageLatency: true,
 	}
 }
 
-func (r *PubSubMQFlow) RequestChannels() []api.RequestChannel {
+func (r *PubSubMQFlow) RequestChannels() []pipeline.RequestChannel {
 
-	var channels []api.RequestChannel
+	var channels []pipeline.RequestChannel
 	for _, channelData := range r.requestChannels {
 		channels = append(channels, channelData.requestChannel)
 	}
@@ -217,7 +218,7 @@ func publishPubSub(ctx context.Context, publisher *pubsub.Publisher, msg []byte,
 
 }
 
-func addMsgToRetryQueue(ctx context.Context, retryChannel chan api.RetryMessage) {
+func addMsgToRetryQueue(ctx context.Context, retryChannel chan pipeline.RetryMessage) {
 	logger := log.FromContext(ctx)
 
 	for {
@@ -243,7 +244,7 @@ func addMsgToRetryQueue(ctx context.Context, retryChannel chan api.RetryMessage)
 
 }
 
-func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID string, ch chan *api.InternalRequest, gate api.DispatchGate) {
+func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID string, ch chan *api.InternalRequest, gate pipeline.DispatchGate) {
 	logger := log.FromContext(ctx)
 
 	sub := pubSubClient.Subscriber(subscriberID)

--- a/pkg/redis/dispatch_gate.go
+++ b/pkg/redis/dispatch_gate.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"strconv"
 
-	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	goredis "github.com/redis/go-redis/v9"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
-var _ asyncapi.DispatchGate = (*RedisDispatchGate)(nil)
+var _ pipeline.DispatchGate = (*RedisDispatchGate)(nil)
 
-// RedisDispatchGate implements asyncapi.DispatchGate by reading the budget
+// RedisDispatchGate implements pipeline.DispatchGate by reading the budget
 // from a Redis key. This allows external systems to dynamically control
 // the dispatch rate. If the key does not exist or is invalid, it defaults
 // to full capacity (1.0).

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
 	"github.com/redis/go-redis/v9"
 
@@ -84,16 +85,16 @@ type QueueConfig struct {
 }
 
 type RequestChannelData struct {
-	requestChannel api.RequestChannel
+	requestChannel pipeline.RequestChannel
 	queueName      string
 }
 
-var _ api.Flow = (*RedisMQFlow)(nil)
+var _ pipeline.Flow = (*RedisMQFlow)(nil)
 
 type RedisMQFlow struct {
 	rdb             *redis.Client
 	requestChannels []RequestChannelData
-	retryChannel    chan api.RetryMessage
+	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
 }
 
@@ -122,7 +123,7 @@ func NewRedisMQFlow() *RedisMQFlow {
 	for _, cfg := range configs {
 		ch := make(chan *api.InternalRequest)
 
-		channels = append(channels, RequestChannelData{api.RequestChannel{
+		channels = append(channels, RequestChannelData{pipeline.RequestChannel{
 			Channel:            ch,
 			InferenceObjective: cfg.InferenceObjective,
 			RequestPathURL:     util.NormalizeURLPath(cfg.RequestPathURL),
@@ -132,7 +133,7 @@ func NewRedisMQFlow() *RedisMQFlow {
 	return &RedisMQFlow{
 		rdb:             rdb,
 		requestChannels: channels,
-		retryChannel:    make(chan api.RetryMessage),
+		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
 	}
 }
@@ -149,9 +150,9 @@ func (r *RedisMQFlow) Start(ctx context.Context) {
 
 	go r.resultWorker(ctx, *resultQueueName)
 }
-func (r *RedisMQFlow) RequestChannels() []api.RequestChannel {
+func (r *RedisMQFlow) RequestChannels() []pipeline.RequestChannel {
 
-	var channels []api.RequestChannel
+	var channels []pipeline.RequestChannel
 	for _, channelData := range r.requestChannels {
 		channels = append(channels, channelData.requestChannel)
 	}
@@ -159,7 +160,7 @@ func (r *RedisMQFlow) RequestChannels() []api.RequestChannel {
 
 }
 
-func (r *RedisMQFlow) RetryChannel() chan api.RetryMessage {
+func (r *RedisMQFlow) RetryChannel() chan pipeline.RetryMessage {
 	return r.retryChannel
 }
 
@@ -251,15 +252,15 @@ func requestWorker(ctx context.Context, rdb *redis.Client, msgChannel chan *api.
 
 }
 
-func (r *RedisMQFlow) Characteristics() api.Characteristics {
-	return api.Characteristics{
+func (r *RedisMQFlow) Characteristics() pipeline.Characteristics {
+	return pipeline.Characteristics{
 		HasExternalBackoff:     false,
 		SupportsMessageLatency: false,
 	}
 }
 
 // Puts msgs from the retry channel into a Redis sorted-set with a duration Score.
-func addMsgToRetryWorker(ctx context.Context, rdb *redis.Client, retryChannel chan api.RetryMessage, sortedSetName string) {
+func addMsgToRetryWorker(ctx context.Context, rdb *redis.Client, retryChannel chan pipeline.RetryMessage, sortedSetName string) {
 	logger := log.FromContext(ctx)
 	for {
 		select {

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -308,9 +309,9 @@ func TestMQRetryWorker_RequeuesOnShutdown(t *testing.T) {
 	flow := &RedisMQFlow{
 		rdb:           rdb,
 		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
-		retryChannel:  make(chan api.RetryMessage),
+		retryChannel:  make(chan pipeline.RetryMessage),
 		requestChannels: []RequestChannelData{{
-			requestChannel: api.RequestChannel{Channel: reqCh},
+			requestChannel: pipeline.RequestChannel{Channel: reqCh},
 			queueName:      queueName,
 		}},
 	}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
 
 	"github.com/redis/go-redis/v9"
@@ -53,22 +54,22 @@ type queueConfig struct {
 }
 
 type requestChannelData struct {
-	channel   api.RequestChannel
+	channel   pipeline.RequestChannel
 	queueName string
-	gate      api.DispatchGate
+	gate      pipeline.DispatchGate
 }
 
-var _ api.Flow = (*RedisSortedSetFlow)(nil)
+var _ pipeline.Flow = (*RedisSortedSetFlow)(nil)
 
 type RedisSortedSetFlow struct {
 	rdb             *redis.Client
 	requestChannels []requestChannelData
-	retryChannel    chan api.RetryMessage
+	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
 	pollInterval    time.Duration
 	batchSize       int
-	gate            api.DispatchGate
-	gateFactory     api.GateFactory
+	gate            pipeline.DispatchGate
+	gateFactory     pipeline.GateFactory
 }
 
 // SortedSetOption is a functional option for configuring RedisSortedSetFlow
@@ -76,7 +77,7 @@ type SortedSetOption func(*RedisSortedSetFlow)
 
 // WithGateFactory sets a GateFactory for per-queue gate instantiation.
 // When set, gates are created per queue from config, overriding any global gate.
-func WithGateFactory(factory api.GateFactory) SortedSetOption {
+func WithGateFactory(factory pipeline.GateFactory) SortedSetOption {
 	return func(r *RedisSortedSetFlow) {
 		r.gateFactory = factory
 	}
@@ -91,7 +92,7 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 			Password: *RedisPassword,
 		}),
 		requestChannels: make([]requestChannelData, 0, len(configs)),
-		retryChannel:    make(chan api.RetryMessage),
+		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
 		pollInterval:    time.Duration(*ssPollIntervalMs) * time.Millisecond,
 		batchSize:       *ssBatchSize,
@@ -105,7 +106,7 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 	// Create per-queue channels with gates
 	for _, cfg := range configs {
 		// Determine gate for this queue
-		var gate api.DispatchGate
+		var gate pipeline.DispatchGate
 		if r.gateFactory != nil && cfg.GateType != "" {
 			// Use factory to create per-queue gate
 			var err error
@@ -118,10 +119,10 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 			gate = r.gate
 		} else {
 			// Default to always-open gate
-			gate = api.ConstOpenGate()
+			gate = pipeline.ConstOpenGate()
 		}
 
-		ch := api.RequestChannel{
+		ch := pipeline.RequestChannel{
 			Channel:            make(chan *api.InternalRequest),
 			InferenceObjective: cfg.InferenceObjective,
 			RequestPathURL:     util.NormalizeURLPath(cfg.RequestPathURL),
@@ -138,7 +139,7 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 
 	// Set default gate if not already set
 	if r.gate == nil {
-		r.gate = api.ConstOpenGate()
+		r.gate = pipeline.ConstOpenGate()
 	}
 
 	return r
@@ -175,15 +176,15 @@ func (r *RedisSortedSetFlow) Start(ctx context.Context) {
 	go r.resultWorker(ctx)
 }
 
-func (r *RedisSortedSetFlow) RequestChannels() []api.RequestChannel {
-	channels := make([]api.RequestChannel, len(r.requestChannels))
+func (r *RedisSortedSetFlow) RequestChannels() []pipeline.RequestChannel {
+	channels := make([]pipeline.RequestChannel, len(r.requestChannels))
 	for i, ch := range r.requestChannels {
 		channels[i] = ch.channel
 	}
 	return channels
 }
 
-func (r *RedisSortedSetFlow) RetryChannel() chan api.RetryMessage {
+func (r *RedisSortedSetFlow) RetryChannel() chan pipeline.RetryMessage {
 	return r.retryChannel
 }
 
@@ -191,8 +192,8 @@ func (r *RedisSortedSetFlow) ResultChannel() chan api.ResultMessage {
 	return r.resultChannel
 }
 
-func (r *RedisSortedSetFlow) Characteristics() api.Characteristics {
-	return api.Characteristics{HasExternalBackoff: false, SupportsMessageLatency: false}
+func (r *RedisSortedSetFlow) Characteristics() pipeline.Characteristics {
+	return pipeline.Characteristics{HasExternalBackoff: false, SupportsMessageLatency: false}
 }
 
 // Polls sorted set and processes messages by deadline priority (earliest first)
@@ -202,7 +203,7 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 	defer ticker.Stop()
 
 	// Find the gate for this queue
-	var gate api.DispatchGate
+	var gate pipeline.DispatchGate
 	for _, ch := range r.requestChannels {
 		if ch.queueName == queueName {
 			gate = ch.gate
@@ -223,7 +224,7 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 	}
 }
 
-func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, gate api.DispatchGate, logger logr.Logger) {
+func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, gate pipeline.DispatchGate, logger logr.Logger) {
 	currentTime := float64(time.Now().Unix())
 
 	budget := gate.Budget(ctx)
@@ -288,7 +289,7 @@ func (r *RedisSortedSetFlow) parseMessage(z redis.Z, logger logr.Logger) (*api.I
 
 // Re-queues failed messages with exponential backoff
 func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
-	processMsg := func(processCtx context.Context, msg api.RetryMessage) {
+	processMsg := func(processCtx context.Context, msg pipeline.RetryMessage) {
 		batch := drainBatch(msg, r.retryChannel, maxBatchSize)
 		r.flushRetryBatch(processCtx, batch)
 	}
@@ -310,7 +311,7 @@ func (r *RedisSortedSetFlow) retryWorker(ctx context.Context) {
 	}
 }
 
-func (r *RedisSortedSetFlow) flushRetryBatch(ctx context.Context, batch []api.RetryMessage) {
+func (r *RedisSortedSetFlow) flushRetryBatch(ctx context.Context, batch []pipeline.RetryMessage) {
 	if len(batch) == 0 {
 		return
 	}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -12,12 +12,13 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/redis/go-redis/v9"
 )
 
 // noopGate returns a gate that always returns full budget (1.0)
-func noopGate() api.DispatchGate {
-	return api.ConstOpenGate()
+func noopGate() pipeline.DispatchGate {
+	return pipeline.ConstOpenGate()
 }
 
 // Test helper to create test flow and Redis
@@ -45,7 +46,7 @@ func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
 		requestChannels: []requestChannelData{{
-			channel:   api.RequestChannel{Channel: make(chan *api.InternalRequest)},
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
 			queueName: queue,
 		}},
 		pollInterval: 50 * time.Millisecond,
@@ -142,7 +143,7 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
 		requestChannels: []requestChannelData{{
-			channel:   api.RequestChannel{Channel: make(chan *api.InternalRequest)},
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
 			queueName: queue,
 		}},
 		pollInterval: 50 * time.Millisecond,
@@ -179,7 +180,7 @@ func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
 		requestChannels: []requestChannelData{{
-			channel:   api.RequestChannel{Channel: make(chan *api.InternalRequest)},
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
 			queueName: queue,
 		}},
 		pollInterval: 50 * time.Millisecond,
@@ -226,7 +227,7 @@ func TestSortedSetFlow_RetryBackoff(t *testing.T) {
 	queue := "retry-queue"
 	flow := &RedisSortedSetFlow{
 		rdb:          rdb,
-		retryChannel: make(chan api.RetryMessage, 1),
+		retryChannel: make(chan pipeline.RetryMessage, 1),
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -234,8 +235,8 @@ func TestSortedSetFlow_RetryBackoff(t *testing.T) {
 
 	go flow.retryWorker(ctx)
 
-	retryMsg := api.RetryMessage{
-		EmbelishedRequestMessage: api.EmbelishedRequestMessage{
+	retryMsg := pipeline.RetryMessage{
+		EmbelishedRequestMessage: pipeline.EmbelishedRequestMessage{
 			InternalRequest: api.NewInternalRequest(
 				api.InternalRouting{RetryCount: 1, RequestQueueName: queue},
 				&api.RequestMessage{
@@ -468,7 +469,7 @@ func TestSortedSetFlow_ContextCancellation(t *testing.T) {
 	queue := "cancel-queue"
 	flow := &RedisSortedSetFlow{
 		rdb:           rdb,
-		retryChannel:  make(chan api.RetryMessage),
+		retryChannel:  make(chan pipeline.RetryMessage),
 		resultChannel: make(chan api.ResultMessage),
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
@@ -539,14 +540,14 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 	var budgetValue atomic.Uint64 // Store as bits to represent float64
 
 	budgetValue.Store(math.Float64bits(0.0))
-	gate := api.DispatchGateFunc(func(ctx context.Context) float64 {
+	gate := pipeline.DispatchGateFunc(func(ctx context.Context) float64 {
 		return math.Float64frombits(budgetValue.Load())
 	})
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
 		requestChannels: []requestChannelData{{
-			channel:   api.RequestChannel{Channel: make(chan *api.InternalRequest)},
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
 			queueName: queue,
 		}},
 		pollInterval: 50 * time.Millisecond,
@@ -657,7 +658,7 @@ func TestSortedSetFlow_RetryWorkerDrainsOnShutdown(t *testing.T) {
 	const totalMessages = maxBatchSize + 10
 	flow := &RedisSortedSetFlow{
 		rdb:          rdb,
-		retryChannel: make(chan api.RetryMessage, totalMessages),
+		retryChannel: make(chan pipeline.RetryMessage, totalMessages),
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -673,8 +674,8 @@ func TestSortedSetFlow_RetryWorkerDrainsOnShutdown(t *testing.T) {
 	// Buffer more messages than maxBatchSize so the drain path
 	// exercises multiple pipeline flushes.
 	for i := 0; i < totalMessages; i++ {
-		flow.retryChannel <- api.RetryMessage{
-			EmbelishedRequestMessage: api.EmbelishedRequestMessage{
+		flow.retryChannel <- pipeline.RetryMessage{
+			EmbelishedRequestMessage: pipeline.EmbelishedRequestMessage{
 				InternalRequest: api.NewInternalRequest(
 					api.InternalRouting{RequestQueueName: queue},
 					&api.RequestMessage{
@@ -713,7 +714,7 @@ func TestSortedSetFlow_RetryBatchAfterFailure(t *testing.T) {
 	queue := "retry-batch-queue"
 	flow := &RedisSortedSetFlow{
 		rdb:          rdb,
-		retryChannel: make(chan api.RetryMessage, 10),
+		retryChannel: make(chan pipeline.RetryMessage, 10),
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -723,8 +724,8 @@ func TestSortedSetFlow_RetryBatchAfterFailure(t *testing.T) {
 	s.SetError("READONLY simulated failure")
 	go flow.retryWorker(ctx)
 
-	flow.retryChannel <- api.RetryMessage{
-		EmbelishedRequestMessage: api.EmbelishedRequestMessage{
+	flow.retryChannel <- pipeline.RetryMessage{
+		EmbelishedRequestMessage: pipeline.EmbelishedRequestMessage{
 			InternalRequest: api.NewInternalRequest(
 				api.InternalRouting{RequestQueueName: queue},
 				&api.RequestMessage{
@@ -763,14 +764,14 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 	queue := "partial-budget-queue"
 
 	// Gate with 30% budget - should process floor(10*0.3)=3 messages per cycle
-	gate := api.DispatchGateFunc(func(ctx context.Context) float64 {
+	gate := pipeline.DispatchGateFunc(func(ctx context.Context) float64 {
 		return 0.3
 	})
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
 		requestChannels: []requestChannelData{{
-			channel:   api.RequestChannel{Channel: make(chan *api.InternalRequest, 20)},
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 20)},
 			queueName: queue,
 		}},
 		pollInterval: 200 * time.Millisecond,

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/redis"
 )
 
@@ -26,8 +27,8 @@ func TestRedisImpl(t *testing.T) {
 	flow := redis.NewRedisMQFlow()
 	flow.Start(ctx)
 
-	flow.RetryChannel() <- api.RetryMessage{
-		EmbelishedRequestMessage: api.EmbelishedRequestMessage{
+	flow.RetryChannel() <- pipeline.RetryMessage{
+		EmbelishedRequestMessage: pipeline.EmbelishedRequestMessage{
 			InternalRequest: api.NewInternalRequest(
 				api.InternalRouting{RequestQueueName: "request-queue"},
 				&api.RequestMessage{


### PR DESCRIPTION
## What does this PR do?

Moves internal pipeline plumbing types (`Flow`, `Characteristics`, `DispatchGate`, `GateFactory`, `RequestMergePolicy`, `RequestChannel`, `EmbelishedRequestMessage`, `RetryMessage`) out of `api/` into a new top-level `pipeline/` module. The `api/` package now contains only user-facing types and the internal wire format. Updates Dockerfile and all consumer imports accordingly.

## Why is this change needed?

Addresses https://github.com/llm-d-incubation/llm-d-async/issues/144 — enforces the boundary between public API types and internal orchestration types at the Go module level, rather than relying on file-level separation within the same package.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
<img width="806" height="324" alt="Screenshot 2026-05-04 at 10 00 18 AM" src="https://github.com/user-attachments/assets/807a9953-de1c-4157-9ee9-6eb3b8400644" />

- [x] Integration/e2e tests added/updated
<img width="669" height="408" alt="Screenshot 2026-05-04 at 10 00 00 AM" src="https://github.com/user-attachments/assets/4f5ef7d3-f37d-4409-95c9-e590a0cbe2c7" />

- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Related to https://github.com/llm-d-incubation/llm-d-async/issues/144
