### PR TITLE
feat: add per-message Endpoint field to Request interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The async processor expects request messages to have the following format:
 | `deadline` | int64 | Deadline in Unix seconds (required, must be positive) |
 | `payload` | object | Inference request payload |
 | `metadata` | map[string]string | Optional caller-supplied pass-through data (e.g. tracing IDs, user labels) |
+| `endpoint` | string | Optional per-request dispatch path; overrides the queue-level default when set |
 
 **Example:**
 

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ type Request interface {
 	ReqDeadline() int64
 	ReqPayload() map[string]any
 	ReqMetadata() map[string]string
+	ReqEndpoint() string
 }
 
 // RequestMessage contains the caller-visible fields of a request. Metadata is reserved
@@ -22,13 +23,15 @@ type RequestMessage struct {
 	Deadline int64             `json:"deadline"` // Unix seconds
 	Payload  map[string]any    `json:"payload"`
 	Metadata map[string]string `json:"metadata,omitempty"`
+	Endpoint string            `json:"endpoint,omitempty"`
 }
 
-func (r *RequestMessage) ReqID() string                { return r.ID }
-func (r *RequestMessage) ReqCreated() int64            { return r.Created }
-func (r *RequestMessage) ReqDeadline() int64           { return r.Deadline }
-func (r *RequestMessage) ReqPayload() map[string]any   { return r.Payload }
+func (r *RequestMessage) ReqID() string                  { return r.ID }
+func (r *RequestMessage) ReqCreated() int64              { return r.Created }
+func (r *RequestMessage) ReqDeadline() int64             { return r.Deadline }
+func (r *RequestMessage) ReqPayload() map[string]any     { return r.Payload }
 func (r *RequestMessage) ReqMetadata() map[string]string { return r.Metadata }
+func (r *RequestMessage) ReqEndpoint() string            { return r.Endpoint }
 
 // RedisRequest is the concrete Request implementation for Redis-based flows.
 // Per-message queue fields here override producer defaults; producers merge them

--- a/api/internal_api_test.go
+++ b/api/internal_api_test.go
@@ -199,6 +199,61 @@ func TestRoundTrip_PublicRequestInterface(t *testing.T) {
 	}
 }
 
+func TestRoundTrip_EndpointField(t *testing.T) {
+	ir := NewInternalRequest(
+		InternalRouting{RequestQueueName: "rq"},
+		&RequestMessage{
+			ID: "ep-test", Created: 1, Deadline: 2,
+			Payload:  map[string]any{"model": "m"},
+			Endpoint: "/v1/custom",
+		},
+	)
+	b, err := json.Marshal(ir)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got InternalRequest
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	rm, ok := got.PublicRequest.(*RequestMessage)
+	if !ok {
+		t.Fatalf("expected *RequestMessage, got %T", got.PublicRequest)
+	}
+	if rm.Endpoint != "/v1/custom" {
+		t.Errorf("Endpoint = %q, want /v1/custom", rm.Endpoint)
+	}
+	if rm.ReqEndpoint() != "/v1/custom" {
+		t.Errorf("ReqEndpoint() = %q, want /v1/custom", rm.ReqEndpoint())
+	}
+}
+
+func TestRoundTrip_EndpointOmittedWhenEmpty(t *testing.T) {
+	ir := NewInternalRequest(
+		InternalRouting{},
+		&RequestMessage{ID: "no-ep", Created: 1, Deadline: 2, Payload: map[string]any{}},
+	)
+	b, err := json.Marshal(ir)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != "" && json.Valid(b) {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(b, &raw); err != nil {
+			t.Fatalf("unmarshal envelope: %v", err)
+		}
+		var data map[string]json.RawMessage
+		if err := json.Unmarshal(raw["data"], &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if _, exists := data["endpoint"]; exists {
+			t.Error("endpoint should be omitted from JSON when empty")
+		}
+	}
+}
+
 func assertRouting(t *testing.T, got, want InternalRouting) {
 	t.Helper()
 	if got.RetryCount != want.RetryCount {

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -49,13 +49,17 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 				if !ok || ir == nil {
 					continue
 				}
+				requestURL := meta[i1].IGWBaseURl + meta[i1].RequestPathURL
+				if ep := ir.PublicRequest.ReqEndpoint(); ep != "" {
+					requestURL = meta[i1].IGWBaseURl + ep
+				}
 				erm := pipeline.EmbelishedRequestMessage{
 					InternalRequest: ir,
 					HttpHeaders: map[string]string{
 						"Content-Type":                  "application/json",
 						"x-gateway-inference-objective": meta[i1].InferenceObjective,
 					},
-					RequestURL: meta[i1].IGWBaseURl + meta[i1].RequestPathURL,
+					RequestURL: requestURL,
 				}
 				mergedChannel <- erm
 			}

--- a/pkg/async/random_robin_policy_test.go
+++ b/pkg/async/random_robin_policy_test.go
@@ -16,6 +16,15 @@ func irID(id string) *api.InternalRequest {
 	})
 }
 
+func irWithEndpoint(id, endpoint string) *api.InternalRequest {
+	return api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{
+		ID:       id,
+		Created:  1,
+		Deadline: 9999999999,
+		Endpoint: endpoint,
+	})
+}
+
 func TestProcessAllChannels(t *testing.T) {
 	msgsPerChannel := 5
 	channels := []pipeline.RequestChannel{
@@ -140,6 +149,41 @@ func TestMetaAlignmentAfterChannelClosure(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timed out waiting for messages")
 		}
+	}
+}
+
+func TestPerMessageEndpointOverridesChannelURL(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:            make(chan *api.InternalRequest, 2),
+		IGWBaseURl:         "http://gateway",
+		InferenceObjective: "obj",
+		RequestPathURL:     "/default/path",
+	}
+	policy := NewRandomRobinPolicy()
+
+	// One message with endpoint, one without.
+	ch.Channel <- irWithEndpoint("with-ep", "/v1/custom")
+	ch.Channel <- irID("without-ep")
+	close(ch.Channel)
+
+	merged := policy.MergeRequestChannels([]pipeline.RequestChannel{ch})
+
+	deadline := time.After(2 * time.Second)
+	results := map[string]string{}
+	for range 2 {
+		select {
+		case msg := <-merged.Channel:
+			results[msg.PublicRequest.ReqID()] = msg.RequestURL
+		case <-deadline:
+			t.Fatal("timed out waiting for messages")
+		}
+	}
+
+	if url := results["with-ep"]; url != "http://gateway/v1/custom" {
+		t.Errorf("expected http://gateway/v1/custom, got %s", url)
+	}
+	if url := results["without-ep"]; url != "http://gateway/default/path" {
+		t.Errorf("expected http://gateway/default/path, got %s", url)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional per-message `Endpoint` field to `api.RequestMessage` (and the `Request` interface) that allows callers to specify a dispatch path per request. When set, the merge policy uses `IGWBaseURL + Endpoint` instead of the queue-level `RequestPathURL` to build the worker's target URL.

## Why is this change needed?

Callers like [batch-gateway](https://github.com/llm-d-incubation/batch-gateway) need per-message endpoint routing because a single batch can contain requests targeting different OpenAI-compatible paths (`/v1/chat/completions`, `/v1/embeddings`, etc.). Without this, the workaround is either one queue per endpoint (operationally complex) or smuggling the URL through `Metadata` (violates the separation established in #142).

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Related to #143 
