### PR TITLE
feat: add TLS configuration support for inference HTTP client

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -56,6 +56,16 @@ spec:
           - "{{ .Values.ap.gcpPubSub.requestPathURL }}"
           {{- end }}
           - --metrics-endpoint-auth={{ .Values.ap.metrics.secure }}
+          {{- if .Values.ap.tls.insecureSkipVerify }}
+          - --tls-insecure-skip-verify=true
+          {{- end }}
+          {{- if .Values.ap.tls.caCertKey }}
+          - --tls-ca-cert=/etc/tls/{{ .Values.ap.tls.caCertKey }}
+          {{- end }}
+          {{- if and .Values.ap.tls.certKey .Values.ap.tls.keyKey }}
+          - --tls-cert=/etc/tls/{{ .Values.ap.tls.certKey }}
+          - --tls-key=/etc/tls/{{ .Values.ap.tls.keyKey }}
+          {{- end }}
         image: "{{ .Values.ap.image.repository }}:{{ .Values.ap.image.tag }}"
         imagePullPolicy: "{{ .Values.ap.imagePullPolicy }}"
         env:
@@ -74,5 +84,17 @@ spec:
                 key: {{ .Values.ap.redis.auth.passwordKey }}
           {{- end }}
         name: async-processor
+        {{- with .Values.ap.tls.secretName }}
+        volumeMounts:
+          - name: tls-certs
+            mountPath: /etc/tls
+            readOnly: true
+        {{- end }}
       serviceAccountName: {{ include "async-processor.fullname" . }}
       terminationGracePeriodSeconds: 130
+      {{- with .Values.ap.tls.secretName }}
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: {{ . }}
+      {{- end }}

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -14,6 +14,12 @@ ap:
     requestSubscriberId: ""
     resultTopicId: ""
     requestPathURL: "/v1/completions"
+  tls:
+    secretName: ""
+    insecureSkipVerify: false
+    caCertKey: ""
+    certKey: ""
+    keyKey: ""
   redis:
     enabled: false
     port: 6379

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"net/http"
@@ -38,6 +40,11 @@ func main() {
 	var requestMergePolicy string
 	var messageQueueImpl string
 
+	var tlsCACert string
+	var tlsCert string
+	var tlsKey string
+	var tlsInsecureSkipVerify bool
+
 	flag.IntVar(&loggerVerbosity, "v", logging.DEFAULT, "number for the log level verbosity")
 
 	flag.IntVar(&metricsPort, "metrics-port", 9090, "The metrics port")
@@ -48,6 +55,11 @@ func main() {
 
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
 	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
+
+	flag.StringVar(&tlsCACert, "tls-ca-cert", "", "Path to CA certificate file (PEM) for verifying the inference gateway")
+	flag.StringVar(&tlsCert, "tls-cert", "", "Path to client certificate file (PEM) for mTLS")
+	flag.StringVar(&tlsKey, "tls-key", "", "Path to client key file (PEM) for mTLS")
+	flag.BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Skip TLS certificate verification (dev/test only)")
 
 	var prometheusURL = flag.String("prometheus-url", "", "Prometheus server URL for metric-based gates (e.g., http://localhost:9090)")
 	var prometheusCacheTTL = flag.Duration("prometheus-cache-ttl", flowcontrol.DefaultCacheTTL, "TTL for cached Prometheus metrics (e.g., 5s, 0s to disable)")
@@ -122,11 +134,18 @@ func main() {
 	msrv, _ := metricsserver.NewServer(metricsServerOptions, restConfig, http.DefaultClient)
 	go msrv.Start(ctx) // nolint:errcheck
 
+	tlsConfig, err := buildTLSConfig(tlsCACert, tlsCert, tlsKey, tlsInsecureSkipVerify)
+	if err != nil {
+		setupLog.Error(err, "Failed to build TLS configuration")
+		os.Exit(1)
+	}
+
 	// Create inference client with a connection pool sized for the worker count.
 	inferenceTransport := &http.Transport{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: concurrency,
 		IdleConnTimeout:     90 * time.Second,
+		TLSClientConfig:     tlsConfig,
 	}
 	inferenceHTTPClient := &http.Client{Transport: inferenceTransport}
 	inferenceClient := asyncworker.NewHTTPInferenceClient(inferenceHTTPClient)
@@ -139,6 +158,47 @@ func main() {
 
 	impl.Start(ctx)
 	<-ctx.Done()
+}
+
+func buildTLSConfig(caCertPath, certPath, keyPath string, insecureSkipVerify bool) (*tls.Config, error) {
+	if caCertPath == "" && certPath == "" && keyPath == "" && !insecureSkipVerify {
+		return nil, nil
+	}
+
+	if (certPath != "") != (keyPath != "") {
+		return nil, fmt.Errorf("both tls-cert and tls-key must be provided together")
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12} //nolint:gosec
+
+	if insecureSkipVerify {
+		tlsConfig.InsecureSkipVerify = true //nolint:gosec
+	}
+
+	if caCertPath != "" {
+		caCert, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file %s: %w", caCertPath, err)
+		}
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			caCertPool = x509.NewCertPool()
+		}
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("no valid certificates found in %s", caCertPath)
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	if certPath != "" && keyPath != "" {
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate key pair: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
 }
 
 func printAllFlags(setupLog logr.Logger) {


### PR DESCRIPTION
## What does this PR do?

Add TLS configuration flags (`--tls-ca-cert`, `--tls-cert`, `--tls-key`, `--tls-insecure-skip-verify`) to the inference HTTP client, enabling HTTPS connections to gateways using private CA certificates and mTLS.

Custom CA is appended to the system cert pool (not replacing it), so existing public HTTPS targets remain unaffected.

## Why is this change needed?

The inference HTTP client has no `TLSClientConfig` on its transport. When the inference gateway uses certificates signed by a private CA (e.g., cert-manager in k8s), every request fails immediately with `x509: certificate signed by unknown authority`. The error is classified as fatal (`ErrCategoryUnknown`), so messages are never retried.

Fixes #154

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #154