### PR TITLE
refactor: replace redis.addr/user/password flags with single redis.url flag using redis.ParseURL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ A persisted implementation based on Redis SortedSets.
 ![Async Processor - Redis Sorted Set architecture](/docs/images/redis_sortedset_architecture.png "AP - Redis SortedSet")
 
 #### Redis Sorted Set Command line parameters
-- `redis.addr`: Address of the Redis server. Default is <u>localhost:6379</u>.
+- `redis.url`: Redis URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Can also be set via `REDIS_URL` env var.
 - `redis.ss.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.ss.queues-config-file` flag.
 - `redis.ss.request-path-url`: Request path url (e.g.: "/v1/completions"). <br> Mutually exclusive with `redis.ss.queues-config-file` flag.")
 - `redis.ss.inference-objective`: InferenceObjective to use for requests (set as the HTTP header x-gateway-inference-objective if not empty).  <br> Mutually exclusive with `redis.ss.queues-config-file` flag.
@@ -269,7 +269,7 @@ An example implementation based on Redis channels is provided.
 
 #### Redis Channels Command line parameters
 
-- `redis.addr`: Address of the Redis server. Default is <u>localhost:6379</u>.
+- `redis.url`: Redis URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Can also be set via `REDIS_URL` env var.
 - `redis.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.queues-config-file` flag.
 - `redis.request-path-url`: Request path url (e.g.: "/v1/completions"). <br> Mutually exclusive with `redis.queues-config-file` flag.")
 - `redis.inference-objective`: InferenceObjective to use for requests (set as the HTTP header x-gateway-inference-objective if not empty).  <br> Mutually exclusive with `redis.queues-config-file` flag.

--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -24,11 +24,10 @@ spec:
         - /async-processor
         args:
           {{- if .Values.ap.redis.enabled }}
+          - --redis.url=$(REDIS_URL)
           {{- if eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset" }}
           - --message-queue-impl=redis-sortedset
           - --redis.ss.igw-base-url={{ .Values.ap.igwBaseURL }}
-          - --redis.addr
-          - "{{ .Values.ap.redis.host }}:{{ .Values.ap.redis.port }}"
           - --redis.ss.request-path-url
           - "{{ .Values.ap.redis.requestPathURL }}"
           - --redis.ss.request-queue-name
@@ -38,14 +37,8 @@ spec:
           {{- else }}
           - --message-queue-impl=redis-pubsub
           - --redis.igw-base-url={{ .Values.ap.igwBaseURL }}
-          - --redis.request-path-url          
+          - --redis.request-path-url
           - "{{ .Values.ap.redis.requestPathURL }}"
-          - --redis.addr
-          - "{{ .Values.ap.redis.host }}:{{ .Values.ap.redis.port }}"
-          {{- end }}
-          {{- if .Values.ap.redis.auth.enabled }}
-          - --redis.user=$(REDIS_USERNAME)
-          - --redis.password=$(REDIS_PASSWORD)
           {{- end }}
           {{- else if .Values.gcpPubSub.enabled  }}
           - --message-queue-impl=gcp-pubsub
@@ -61,17 +54,12 @@ spec:
         env:
           - name: LOG_LEVEL
             value: {{ if .Values.ap.logging }}{{ .Values.ap.logging.level | default "info" | quote }}{{ else }}"info"{{ end }}
-          {{- if and .Values.ap.redis.enabled .Values.ap.redis.auth.enabled }}
-          - name: REDIS_USERNAME
+          {{- if .Values.ap.redis.enabled }}
+          - name: REDIS_URL
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.ap.redis.auth.secretName }}
-                key: {{ .Values.ap.redis.auth.usernameKey }}
-          - name: REDIS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.ap.redis.auth.secretName }}
-                key: {{ .Values.ap.redis.auth.passwordKey }}
+                name: {{ .Values.ap.redis.secretName }}
+                key: {{ .Values.ap.redis.secretKey }}
           {{- end }}
         name: async-processor
       serviceAccountName: {{ include "async-processor.fullname" . }}

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -16,14 +16,10 @@ ap:
     requestPathURL: "/v1/completions"
   redis:
     enabled: false
-    port: 6379
-    host: "redis-master.redis.svc.cluster.local"
+    # Secret containing the Redis URL (e.g. redis://user:pass@host:port/db or rediss://... for TLS)
+    secretName: "redis-creds"
+    secretKey: "url"
     requestPathURL: "/v1/completions"
     # For redis-sortedset
     requestQueueName: "request-sortedset"
     resultQueueName: "result-list"
-    auth:
-      enabled: false
-      secretName: "redis-creds"
-      usernameKey: "username"
-      passwordKey: "password"

--- a/pkg/redis/redis_conn.go
+++ b/pkg/redis/redis_conn.go
@@ -2,11 +2,25 @@ package redis
 
 import (
 	"flag"
+	"fmt"
 	"os"
+
+	"github.com/redis/go-redis/v9"
 )
 
 var (
-	RedisAddr     = flag.String("redis.addr", "localhost:6379", "address of the Redis server")
-	RedisUser     = flag.String("redis.user", os.Getenv("REDIS_USERNAME"), "username for the Redis server")
-	RedisPassword = flag.String("redis.password", os.Getenv("REDIS_PASSWORD"), "password for the Redis server")
+	RedisURL = flag.String("redis.url", os.Getenv("REDIS_URL"), "Redis URL (e.g. redis://user:pass@host:port/db or rediss://... for TLS)")
 )
+
+// RedisOptions returns *redis.Options derived from the --redis.url flag
+// (or REDIS_URL env var).
+func RedisOptions() (*redis.Options, error) {
+	if *RedisURL == "" {
+		return nil, fmt.Errorf("--redis.url (or REDIS_URL env var) is required")
+	}
+	opts, err := redis.ParseURL(*RedisURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse --redis.url: %w", err)
+	}
+	return opts, nil
+}

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -126,11 +126,11 @@ type RedisMQFlow struct {
 }
 
 func NewRedisMQFlow() *RedisMQFlow {
-	rdb := redis.NewClient(&redis.Options{
-		Addr:     *RedisAddr,
-		Username: *RedisUser,
-		Password: *RedisPassword,
-	})
+	opts, err := RedisOptions()
+	if err != nil {
+		panic(fmt.Sprintf("invalid Redis connection config: %v", err))
+	}
+	rdb := redis.NewClient(opts)
 	var configs []QueueConfig
 	if *queuesConfigFile != "" {
 		data, err := os.ReadFile(*queuesConfigFile)

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -85,12 +85,12 @@ func WithGateFactory(factory pipeline.GateFactory) SortedSetOption {
 
 func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 	configs := loadQueueConfigs()
+	redisOpts, err := RedisOptions()
+	if err != nil {
+		panic(fmt.Sprintf("invalid Redis connection config: %v", err))
+	}
 	r := &RedisSortedSetFlow{
-		rdb: redis.NewClient(&redis.Options{
-			Addr:     *RedisAddr,
-			Username: *RedisUser,
-			Password: *RedisPassword,
-		}),
+		rdb:             redis.NewClient(redisOpts),
 		requestChannels: make([]requestChannelData, 0, len(configs)),
 		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -507,8 +507,12 @@ func TestSortedSetFlow_Integration(t *testing.T) {
 	*ssRequestQueueName = queue
 	defer func() { *ssRequestQueueName = origQueue }()
 
+	origURL := *RedisURL
+	*RedisURL = "redis://" + s.Addr()
+	defer func() { *RedisURL = origURL }()
+
 	flow := NewRedisSortedSetFlow()
-	flow.rdb = rdb // Override with test Redis
+	flow.rdb = rdb
 	flow.pollInterval = 50 * time.Millisecond
 
 	flow.Start(ctx)

--- a/producer/redis_sortedset_producer.go
+++ b/producer/redis_sortedset_producer.go
@@ -23,17 +23,9 @@ type RedisSortedSetProducer struct {
 
 // RedisSortedSetConfig contains configuration for the Redis sorted set producer.
 type RedisSortedSetConfig struct {
-	// RedisAddr is the Redis server address (e.g., "localhost:6379").
+	// RedisURL is a Redis URL (e.g. "redis://user:pass@host:port/db" or "rediss://..." for TLS).
 	// Required.
-	RedisAddr string
-
-	// RedisUser is the username for the Redis server.
-	// Optional.
-	RedisUser string
-
-	// RedisPassword is the password for the Redis server.
-	// Optional.
-	RedisPassword string
+	RedisURL string
 
 	// TenantID is the unique identifier for the tenant/customer.
 	// Required for multi-tenant isolation.
@@ -55,8 +47,8 @@ type RedisSortedSetConfig struct {
 // NewRedisSortedSetProducer creates a new producer using Redis sorted set.
 // Multi-tenant safe: TenantID ensures result queue isolation between tenants.
 func NewRedisSortedSetProducer(config RedisSortedSetConfig) (*RedisSortedSetProducer, error) {
-	if config.RedisAddr == "" {
-		return nil, errors.New("RedisAddr is required")
+	if config.RedisURL == "" {
+		return nil, errors.New("RedisURL is required")
 	}
 
 	if config.TenantID == "" {
@@ -71,15 +63,14 @@ func NewRedisSortedSetProducer(config RedisSortedSetConfig) (*RedisSortedSetProd
 		config.ResultQueueName = "default"
 	}
 
-	// Namespace result queue with tenant ID to prevent collisions
-	// Format: results:{tenantID}:{customerQueueName}
 	namespacedResultQueue := fmt.Sprintf("results:%s:%s", config.TenantID, config.ResultQueueName)
 
-	client := redis.NewClient(&redis.Options{
-		Addr:     config.RedisAddr,
-		Username: config.RedisUser,
-		Password: config.RedisPassword,
-	})
+	opts, err := redis.ParseURL(config.RedisURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RedisURL: %w", err)
+	}
+
+	client := redis.NewClient(opts)
 
 	// Test connection
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/producer/redis_sortedset_producer_test.go
+++ b/producer/redis_sortedset_producer_test.go
@@ -15,13 +15,12 @@ import (
 func setupTestProducer(t *testing.T) (*RedisSortedSetProducer, *miniredis.Miniredis) {
 	t.Helper()
 
-	// Start mini Redis
 	mr, err := miniredis.Run()
 	require.NoError(t, err)
 	t.Cleanup(func() { mr.Close() })
 
 	producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-		RedisAddr:        mr.Addr(),
+		RedisURL:         "redis://" + mr.Addr(),
 		TenantID:         "test-tenant",
 		RequestQueueName: "test-request-queue",
 		ResultQueueName:  "test-result-queue",
@@ -203,12 +202,11 @@ func TestMultipleTenantsIsolation(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create producers for two different tenants
 	tenant1Producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-		RedisAddr:        mr.Addr(),
+		RedisURL:         "redis://" + mr.Addr(),
 		TenantID:         "tenant-alice",
 		RequestQueueName: "shared-request-queue",
-		ResultQueueName:  "my-results", // Same name but different tenant
+		ResultQueueName:  "my-results",
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -218,10 +216,10 @@ func TestMultipleTenantsIsolation(t *testing.T) {
 	})
 
 	tenant2Producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-		RedisAddr:        mr.Addr(),
+		RedisURL:         "redis://" + mr.Addr(),
 		TenantID:         "tenant-bob",
 		RequestQueueName: "shared-request-queue",
-		ResultQueueName:  "my-results", // Same name but different tenant
+		ResultQueueName:  "my-results",
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -307,18 +305,17 @@ func TestProducerAuth(t *testing.T) {
 
 	t.Run("fails without password", func(t *testing.T) {
 		_, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-			RedisAddr: mr.Addr(),
-			TenantID:  "test",
+			RedisURL: "redis://" + mr.Addr(),
+			TenantID: "test",
 		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "NOAUTH")
 	})
 
-	t.Run("succeeds with password", func(t *testing.T) {
+	t.Run("succeeds with password in URL", func(t *testing.T) {
 		producer, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-			RedisAddr:     mr.Addr(),
-			RedisPassword: "producer-secret",
-			TenantID:      "test",
+			RedisURL: "redis://default:producer-secret@" + mr.Addr(),
+			TenantID: "test",
 		})
 		assert.NoError(t, err)
 		defer producer.Close() // nolint:errcheck
@@ -334,9 +331,8 @@ func TestTenantIDRequired(t *testing.T) {
 	require.NoError(t, err)
 	defer mr.Close()
 
-	// Should fail without TenantID
 	_, err = NewRedisSortedSetProducer(RedisSortedSetConfig{
-		RedisAddr:        mr.Addr(),
+		RedisURL:         "redis://" + mr.Addr(),
 		RequestQueueName: "test",
 		ResultQueueName:  "test",
 	})
@@ -390,9 +386,8 @@ func TestSameTenantMultipleQueues(t *testing.T) {
 	require.NoError(t, err)
 	defer mr.Close()
 
-	// Same tenant creates two producers with different result queues
 	prod1, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-		RedisAddr:       mr.Addr(),
+		RedisURL:        "redis://" + mr.Addr(),
 		TenantID:        "alice",
 		ResultQueueName: "batch-jobs",
 	})
@@ -404,7 +399,7 @@ func TestSameTenantMultipleQueues(t *testing.T) {
 	})
 
 	prod2, err := NewRedisSortedSetProducer(RedisSortedSetConfig{
-		RedisAddr:       mr.Addr(),
+		RedisURL:        "redis://" + mr.Addr(),
 		TenantID:        "alice",
 		ResultQueueName: "realtime",
 	})

--- a/test/e2e/yaml/async-processor-budget.yaml
+++ b/test/e2e/yaml/async-processor-budget.yaml
@@ -43,7 +43,7 @@ spec:
             - "--redis.ss.gate-type=prometheus-budget"
             - "--redis.ss.gate-params={\"pool\":\"e2e-pool\",\"max_concurrency\":\"10\",\"baseline\":\"0.05\"}"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
-            - "--redis.addr=redis.e2e-test.svc.cluster.local:6379"
+            - "--redis.url=redis://redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"
             - "--redis.ss.batch-size=10"
             - "--redis.ss.request-queue-name=budget-request-sortedset"

--- a/test/e2e/yaml/async-processor-saturation.yaml
+++ b/test/e2e/yaml/async-processor-saturation.yaml
@@ -43,7 +43,7 @@ spec:
             - "--redis.ss.gate-type=prometheus-saturation"
             - "--redis.ss.gate-params={\"pool\":\"e2e-pool\",\"threshold\":\"0.8\"}"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
-            - "--redis.addr=redis.e2e-test.svc.cluster.local:6379"
+            - "--redis.url=redis://redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"
             - "--redis.ss.batch-size=10"
             - "--redis.ss.request-queue-name=saturation-request-sortedset"

--- a/test/e2e/yaml/async-processor.yaml
+++ b/test/e2e/yaml/async-processor.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - "--message-queue-impl=redis-sortedset"
             - "--redis.ss.igw-base-url=http://igw-mock.e2e-test.svc.cluster.local:80"
-            - "--redis.addr=redis.e2e-test.svc.cluster.local:6379"
+            - "--redis.url=redis://redis.e2e-test.svc.cluster.local:6379"
             - "--redis.ss.poll-interval-ms=500"
             - "--redis.ss.batch-size=10"
             - "--metrics-endpoint-auth=false"

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"context"
 	"flag"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,10 +17,10 @@ import (
 
 func TestRedisImpl(t *testing.T) {
 	s := miniredis.RunT(t)
-	rAddr := s.Host() + ":" + s.Port()
+	redisURL := fmt.Sprintf("redis://%s:%s", s.Host(), s.Port())
 
 	ctx := context.Background()
-	err := flag.Set("redis.addr", rAddr)
+	err := flag.Set("redis.url", redisURL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,24 +75,19 @@ func TestRedisImpl(t *testing.T) {
 func TestRedisImplWithAuth(t *testing.T) {
 	s := miniredis.RunT(t)
 	s.RequireAuth("test-password")
-	rAddr := s.Host() + ":" + s.Port()
+	redisURL := fmt.Sprintf("redis://default:test-password@%s:%s", s.Host(), s.Port())
 
 	ctx := context.Background()
-	_ = flag.Set("redis.addr", rAddr)
-	_ = flag.Set("redis.password", "test-password")
+	_ = flag.Set("redis.url", redisURL)
 
 	flow := redis.NewRedisSortedSetFlow()
 	flow.Start(ctx)
 
-	// Publish a result message
 	flow.ResultChannel() <- api.ResultMessage{
 		ID: "test-auth-id",
 	}
 
-	// Wait for processing
 	time.Sleep(1 * time.Second)
 
-	// Verify it was published to Redis successfully
-	// By default, the result queue is "result-list" for SortedSetFlow
 	s.CheckList(t, "result-list", `{"id":"test-auth-id","payload":""}`)
 }


### PR DESCRIPTION
## What does this PR do?

Replaces the three separate Redis connection flags (`--redis.addr`, `--redis.user`, `--redis.password`) with a single `--redis.url` flag that accepts a standard Redis URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS), parsed via `go-redis`'s `redis.ParseURL()`.
### Changes
- **`pkg/redis/redis_conn.go`** — Removed `--redis.addr`, `--redis.user`, `--redis.password` flags. Added `--redis.url` flag (defaults to `REDIS_URL` env var) and a `RedisOptions()` helper that calls `redis.ParseURL()`.
- **`pkg/redis/redisimpl.go`**, **`pkg/redis/sortedset_impl.go`** — `NewRedisMQFlow()` and `NewRedisSortedSetFlow()` now use `RedisOptions()` instead of constructing `redis.Options` manually.
- **`producer/redis_sortedset_producer.go`** — `RedisSortedSetConfig` now has a single `RedisURL` field replacing `RedisAddr`/`RedisUser`/`RedisPassword`. `NewRedisSortedSetProducer()` uses `redis.ParseURL()`.
- **Helm chart (`charts/async-processor/`)** — `REDIS_URL` is loaded from a Kubernetes secret (`secretName`/`secretKey`). Removed `host`, `port`, and `auth` values. The flag `--redis.url=$(REDIS_URL)` is passed via env var expansion so credentials never appear in `/proc/<pid>/cmdline`.
- **E2e YAMLs** — Switched from `--redis.addr=host:port` to `--redis.url=redis://host:port`.
- **E2e test suite** — Added podman support: sets `KIND_EXPERIMENTAL_PROVIDER=podman` and loads images into Kind via `podman save | ctr images import`.
- **Tests** — All integration and producer tests updated to use URL-based configuration.
- **README** — Updated CLI parameter docs from `redis.addr` to `redis.url` in both Redis Sorted Set and Redis Channels sections.


## Why is this change needed?

1. **Extensibility** — The previous approach required adding a new CLI flag for every new connection parameter (DB number, TLS, timeouts, etc.). A standard Redis URL encodes all of these in a single string that `go-redis` already knows how to parse.
2. **Security** — Credentials were previously passed as CLI flags (`--redis.password=$(REDIS_PASSWORD)`), exposing them in `/proc/<pid>/cmdline`. With `--redis.url=$(REDIS_URL)`, the URL is injected via an environment variable sourced from a Kubernetes secret, keeping credentials out of process arguments.
3. **Simplicity** — Three flags reduced to one. The standard `redis://` / `rediss://` URL format is well-known and consistent with how most Redis clients and tools accept connection strings.


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Resolves https://github.com/llm-d-incubation/llm-d-async/issues/133
