### PR TITLE
fix: replace panic with error returns, remove redis.url from CLI args, update deploy/install.sh

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -24,7 +24,6 @@ spec:
         - /async-processor
         args:
           {{- if .Values.ap.redis.enabled }}
-          - --redis.url=$(REDIS_URL)
           {{- if eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset" }}
           - --message-queue-impl=redis-sortedset
           - --redis.ss.igw-base-url={{ .Values.ap.igwBaseURL }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,9 +95,19 @@ func main() {
 	var impl pipeline.Flow
 	switch messageQueueImpl {
 	case "redis-pubsub":
-		impl = redis.NewRedisMQFlow()
+		flow, err := redis.NewRedisMQFlow()
+		if err != nil {
+			setupLog.Error(err, "Failed to create Redis pub/sub flow")
+			os.Exit(1)
+		}
+		impl = flow
 	case "redis-sortedset":
-		impl = redis.NewRedisSortedSetFlow(redis.WithGateFactory(gateFactory))
+		flow, err := redis.NewRedisSortedSetFlow(redis.WithGateFactory(gateFactory))
+		if err != nil {
+			setupLog.Error(err, "Failed to create Redis sorted-set flow")
+			os.Exit(1)
+		}
+		impl = flow
 		setupLog.Info("Using Redis sorted-set flow with per-queue gating")
 	case "gcp-pubsub":
 		impl = pubsub.NewGCPPubSubMQFlow()

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -407,7 +407,10 @@ deploy_ap_controller() {
         --set ap.image.tag=$AP_IMAGE_TAG \
         --set ap.imagePullPolicy=$AP_IMAGE_PULL_POLICY \
         --set ap.baseName=$WELL_LIT_PATH_NAME \
-        --set ap.logging.level=$AP_LOG_LEVEL 
+        --set ap.logging.level=$AP_LOG_LEVEL \
+        --set ap.redis.enabled=true \
+        --set ap.redis.secretName=redis-creds \
+        --set ap.redis.secretKey=url
         
     
     # Wait for AP to be ready
@@ -420,11 +423,17 @@ deploy_ap_controller() {
 
 deploy_redis() {
     log_info "Deploying Redis..."
-    # Add helm repo
     helm repo add bitnami https://charts.bitnami.com/bitnami
     helm repo update
 
     helm upgrade -i "$REDIS_RELEASE_NAME" bitnami/redis -n $REDIS_NS --set auth.enabled=false
+
+    # Create a secret with the Redis URL in the AP namespace so the async-processor can connect
+    local redis_url="redis://${REDIS_RELEASE_NAME}-master.${REDIS_NS}.svc.cluster.local:6379"
+    log_info "Creating Redis URL secret in $AP_NS namespace"
+    kubectl create secret generic redis-creds \
+        --from-literal=url="$redis_url" \
+        -n "$AP_NS" --dry-run=client -o yaml | kubectl apply -f -
 }
 
 deploy_llm_d_infrastructure() {

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -125,21 +125,21 @@ type RedisMQFlow struct {
 	resultChannel   chan api.ResultMessage
 }
 
-func NewRedisMQFlow() *RedisMQFlow {
+func NewRedisMQFlow() (*RedisMQFlow, error) {
 	opts, err := RedisOptions()
 	if err != nil {
-		panic(fmt.Sprintf("invalid Redis connection config: %v", err))
+		return nil, fmt.Errorf("invalid Redis connection config: %w", err)
 	}
 	rdb := redis.NewClient(opts)
 	var configs []QueueConfig
 	if *queuesConfigFile != "" {
 		data, err := os.ReadFile(*queuesConfigFile)
 		if err != nil {
-			panic(fmt.Sprintf("failed to read queues config file: %v", err))
+			return nil, fmt.Errorf("failed to read queues config file: %w", err)
 		}
 
 		if err := json.Unmarshal(data, &configs); err != nil {
-			panic(fmt.Sprintf("failed to unmarshal queues config: %v", err))
+			return nil, fmt.Errorf("failed to unmarshal queues config: %w", err)
 		}
 	} else {
 		configs = []QueueConfig{{QueueName: *requestQueueName, IGWBaseURl: *igwBaseURL, InferenceObjective: *inferenceObjective, RequestPathURL: *requestPathURL}}
@@ -162,7 +162,7 @@ func NewRedisMQFlow() *RedisMQFlow {
 		requestChannels: channels,
 		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
-	}
+	}, nil
 }
 
 func (r *RedisMQFlow) Start(ctx context.Context) {

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -83,11 +83,14 @@ func WithGateFactory(factory pipeline.GateFactory) SortedSetOption {
 	}
 }
 
-func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
-	configs := loadQueueConfigs()
+func NewRedisSortedSetFlow(opts ...SortedSetOption) (*RedisSortedSetFlow, error) {
+	configs, err := loadQueueConfigs()
+	if err != nil {
+		return nil, err
+	}
 	redisOpts, err := RedisOptions()
 	if err != nil {
-		panic(fmt.Sprintf("invalid Redis connection config: %v", err))
+		return nil, fmt.Errorf("invalid Redis connection config: %w", err)
 	}
 	r := &RedisSortedSetFlow{
 		rdb:             redis.NewClient(redisOpts),
@@ -98,27 +101,20 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 		batchSize:       *ssBatchSize,
 	}
 
-	// Apply functional options
 	for _, opt := range opts {
 		opt(r)
 	}
 
-	// Create per-queue channels with gates
 	for _, cfg := range configs {
-		// Determine gate for this queue
 		var gate pipeline.DispatchGate
 		if r.gateFactory != nil && cfg.GateType != "" {
-			// Use factory to create per-queue gate
-			var err error
 			gate, err = r.gateFactory.CreateGate(cfg.GateType, cfg.GateParams)
 			if err != nil {
-				panic(fmt.Sprintf("failed to create gate for queue %q (gate_type=%q): %v", cfg.QueueName, cfg.GateType, err))
+				return nil, fmt.Errorf("failed to create gate for queue %q (gate_type=%q): %w", cfg.QueueName, cfg.GateType, err)
 			}
 		} else if r.gate != nil {
-			// Fall back to global gate if provided
 			gate = r.gate
 		} else {
-			// Default to always-open gate
 			gate = pipeline.ConstOpenGate()
 		}
 
@@ -137,27 +133,25 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) *RedisSortedSetFlow {
 		})
 	}
 
-	// Set default gate if not already set
 	if r.gate == nil {
 		r.gate = pipeline.ConstOpenGate()
 	}
 
-	return r
+	return r, nil
 }
 
-func loadQueueConfigs() []queueConfig {
+func loadQueueConfigs() ([]queueConfig, error) {
 	if *ssQueuesConfigFile != "" {
 		data, err := os.ReadFile(*ssQueuesConfigFile)
 		if err != nil {
-			panic(fmt.Sprintf("failed to read config file: %v", err))
+			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}
 		var configs []queueConfig
 		if err := json.Unmarshal(data, &configs); err != nil {
-			panic(fmt.Sprintf("failed to unmarshal config file: %v", err))
+			return nil, fmt.Errorf("failed to unmarshal config file: %w", err)
 		}
-		return configs
+		return configs, nil
 	}
-	// Single-queue mode
 	return []queueConfig{{
 		QueueName:          *ssRequestQueueName,
 		InferenceObjective: *ssInferenceObjective,
@@ -165,7 +159,7 @@ func loadQueueConfigs() []queueConfig {
 		IGWBaseURl:         *ssIGWBaseURL,
 		GateType:           *ssGateType,
 		GateParams:         parseGateParams(*ssGateParamsJSON),
-	}}
+	}}, nil
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -511,7 +511,10 @@ func TestSortedSetFlow_Integration(t *testing.T) {
 	*RedisURL = "redis://" + s.Addr()
 	defer func() { *RedisURL = origURL }()
 
-	flow := NewRedisSortedSetFlow()
+	flow, err := NewRedisSortedSetFlow()
+	if err != nil {
+		t.Fatal(err)
+	}
 	flow.rdb = rdb
 	flow.pollInterval = 50 * time.Millisecond
 

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -25,7 +25,10 @@ func TestRedisImpl(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	flow := redis.NewRedisMQFlow()
+	flow, err := redis.NewRedisMQFlow()
+	if err != nil {
+		t.Fatal(err)
+	}
 	flow.Start(ctx)
 
 	flow.RetryChannel() <- pipeline.RetryMessage{
@@ -80,7 +83,10 @@ func TestRedisImplWithAuth(t *testing.T) {
 	ctx := context.Background()
 	_ = flag.Set("redis.url", redisURL)
 
-	flow := redis.NewRedisSortedSetFlow()
+	flow, err := redis.NewRedisSortedSetFlow()
+	if err != nil {
+		t.Fatal(err)
+	}
 	flow.Start(ctx)
 
 	flow.ResultChannel() <- api.ResultMessage{


### PR DESCRIPTION
## What does this PR do?

Addresses review feedback from #158:
- **Replace `panic` with error returns**: `NewRedisMQFlow()` and `NewRedisSortedSetFlow()` now return `(*Flow, error)` instead of panicking. `cmd/main.go` handles errors via `setupLog.Error() + os.Exit(1)`.
- **Remove `--redis.url` from CLI args**: The `REDIS_URL` env var (injected via `secretKeyRef`) is picked up by the flag default, so credentials never appear in `/proc/<pid>/cmdline`.
- **Update `deploy/install.sh`**: `deploy_redis()` creates a `redis-creds` secret with the Redis URL. `deploy_ap_controller()` passes the secret reference to the Helm chart.

## Why is this change needed?

- `panic` dumps the full stack trace on misconfiguration — `setupLog.Error() + os.Exit(1)` gives a clean error message.
- Passing `--redis.url=$(REDIS_URL)` in pod args expands the secret value into the podspec, exposing credentials. Reading from the env var directly avoids this.
- `deploy/install.sh` was not updated for the new `redis.url` secret-based config introduced in #158.


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Follows up on #158
