### PR TITLE
fix: add WithRedisClient option to allow injecting custom Redis Client in Producer

### DIFF
--- a/producer/redis_sortedset_producer.go
+++ b/producer/redis_sortedset_producer.go
@@ -22,6 +22,18 @@ type RedisSortedSetProducer struct {
 	resultQueueName  string
 }
 
+// ProducerOption is a functional option for NewRedisSortedSetProducer.
+type ProducerOption func(*RedisSortedSetProducer)
+
+// WithRedisClient injects a pre-configured *redis.Client, allowing callers to
+// instrument it (e.g. with OpenTelemetry tracing/metrics hooks) before use.
+// When provided, RedisURL in the config is not required.
+func WithRedisClient(client *redis.Client) ProducerOption {
+	return func(p *RedisSortedSetProducer) {
+		p.client = client
+	}
+}
+
 // RedisSortedSetConfig contains configuration for the Redis sorted set producer.
 type RedisSortedSetConfig struct {
 	// RedisURL is a Redis URL (e.g. "redis://user:pass@host:port/db" or "rediss://..." for TLS).
@@ -47,11 +59,8 @@ type RedisSortedSetConfig struct {
 
 // NewRedisSortedSetProducer creates a new producer using Redis sorted set.
 // Multi-tenant safe: TenantID ensures result queue isolation between tenants.
-func NewRedisSortedSetProducer(config RedisSortedSetConfig) (*RedisSortedSetProducer, error) {
-	if config.RedisURL == "" {
-		return nil, errors.New("RedisURL is required")
-	}
-
+// Use WithRedisClient to inject a pre-configured client (e.g. with tracing hooks).
+func NewRedisSortedSetProducer(config RedisSortedSetConfig, opts ...ProducerOption) (*RedisSortedSetProducer, error) {
 	if config.TenantID == "" {
 		return nil, errors.New("TenantID is required for multi-tenant isolation")
 	}
@@ -70,26 +79,35 @@ func NewRedisSortedSetProducer(config RedisSortedSetConfig) (*RedisSortedSetProd
 
 	namespacedResultQueue := fmt.Sprintf("results:%s:%s", config.TenantID, config.ResultQueueName)
 
-	opts, err := redis.ParseURL(config.RedisURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse RedisURL: %w", err)
+	p := &RedisSortedSetProducer{
+		requestQueueName: config.RequestQueueName,
+		resultQueueName:  namespacedResultQueue,
 	}
 
-	client := redis.NewClient(opts)
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.client == nil {
+		if config.RedisURL == "" {
+			return nil, errors.New("RedisURL is required when no RedisClient is provided via WithRedisClient")
+		}
+		redisOpts, err := redis.ParseURL(config.RedisURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse RedisURL: %w", err)
+		}
+		p.client = redis.NewClient(redisOpts)
+	}
 
 	// Test connection
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Ping(ctx).Err(); err != nil {
+	if err := p.client.Ping(ctx).Err(); err != nil {
 		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 	}
 
-	return &RedisSortedSetProducer{
-		client:           client,
-		requestQueueName: config.RequestQueueName,
-		resultQueueName:  namespacedResultQueue,
-	}, nil
+	return p, nil
 }
 
 // toInternalRequest builds an InternalRequest with routing merged from the concrete

--- a/producer/redis_sortedset_producer.go
+++ b/producer/redis_sortedset_producer.go
@@ -18,6 +18,7 @@ var _ Producer = (*RedisSortedSetProducer)(nil)
 // and Redis list for results.
 type RedisSortedSetProducer struct {
 	client           *redis.Client
+	managedClient    bool
 	requestQueueName string
 	resultQueueName  string
 }
@@ -97,6 +98,7 @@ func NewRedisSortedSetProducer(config RedisSortedSetConfig, opts ...ProducerOpti
 			return nil, fmt.Errorf("failed to parse RedisURL: %w", err)
 		}
 		p.client = redis.NewClient(redisOpts)
+		p.managedClient = true
 	}
 
 	// Test connection
@@ -230,9 +232,13 @@ func (p *RedisSortedSetProducer) parseResult(data string) (*api.ResultMessage, e
 	return &result, nil
 }
 
-// Close closes the Redis connection.
+// Close closes the Redis connection if the client was created internally.
+// Externally injected clients (via WithRedisClient) are not closed.
 func (p *RedisSortedSetProducer) Close() error {
-	return p.client.Close()
+	if p.managedClient {
+		return p.client.Close()
+	}
+	return nil
 }
 
 // RequestQueueDepth returns the number of pending requests in the queue.

--- a/producer/redis_sortedset_producer_test.go
+++ b/producer/redis_sortedset_producer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -405,6 +406,34 @@ func TestMalformedResultHandling(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "missing 'id' field")
+	})
+}
+
+func TestWithRedisClient(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close() //nolint:errcheck
+
+	t.Run("injected client is used, RedisURL not required", func(t *testing.T) {
+		p, err := NewRedisSortedSetProducer(
+			RedisSortedSetConfig{TenantID: "test-tenant"},
+			WithRedisClient(client),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "results:test-tenant:default", p.resultQueueName)
+
+		ctx := context.Background()
+		err = p.client.Ping(ctx).Err()
+		assert.NoError(t, err)
+	})
+
+	t.Run("fails without RedisURL and without WithRedisClient", func(t *testing.T) {
+		_, err := NewRedisSortedSetProducer(RedisSortedSetConfig{TenantID: "test-tenant"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "RedisURL is required when no RedisClient is provided")
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

- Adds a `WithRedisClient(*redis.Client)` functional option to `NewRedisSortedSetProducer`, allowing callers to inject a pre-configured Redis client instead of having one created internally
- When a client is provided via `WithRedisClient`, `RedisURL` is no longer required in the config
- When no client is injected, existing behaviour is fully preserved (backward compatible)

## Why is this change needed?

`NewRedisSortedSetProducer` creates its Redis client internally, making it impossible to add hooks like OpenTelemetry tracing (`redisotel.InstrumentTracing`) or custom metrics before the client is used. This change enables distributed tracing and observability instrumentation by letting callers bring their own instrumented client (#157).

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #157
