### PR TITLE
ci: add helm lint to PR workflow

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -94,6 +94,21 @@ jobs:
         if: steps.check-python.outputs.has_python == 'true'
         run: ruff format --check .
 
+  # Helm: lint chart
+  helm-lint:
+    runs-on: ubuntu-latest
+    needs: check-code-changes
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint Helm chart
+        run: helm lint charts/async-processor
+
   # Container: build (no push) to validate Dockerfile
   container-build:
     runs-on: ubuntu-latest

--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -39,7 +39,7 @@ spec:
           - --redis.request-path-url
           - "{{ .Values.ap.redis.requestPathURL }}"
           {{- end }}
-          {{- else if .Values.gcpPubSub.enabled  }}
+          {{- else if .Values.ap.gcpPubSub.enabled }}
           - --message-queue-impl=gcp-pubsub
           - --pubsub.igw-base-url={{ .Values.ap.igwBaseURL }}
           - --pubsub.request-subscriber-id={{ .Values.ap.gcpPubSub.requestSubscriberId }}


### PR DESCRIPTION
## What does this PR do?

Add a `helm-lint` job to the PR CI workflow that installs Helm and runs `helm lint` on the async-processor chart.

## Why is this change needed?

Without this, broken Helm charts can be merged undetected.

## How was this tested?

- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)