### PR TITLE
feat: support per-request custom HTTP headers in async dispatch

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ type Request interface {
 	ReqDeadline() int64
 	ReqPayload() map[string]any
 	ReqMetadata() map[string]string
+	ReqHeaders() map[string]string
 	ReqEndpoint() string
 }
 
@@ -23,6 +24,7 @@ type RequestMessage struct {
 	Deadline int64             `json:"deadline"` // Unix seconds
 	Payload  map[string]any    `json:"payload"`
 	Metadata map[string]string `json:"metadata,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
 	Endpoint string            `json:"endpoint,omitempty"`
 }
 
@@ -31,6 +33,7 @@ func (r *RequestMessage) ReqCreated() int64              { return r.Created }
 func (r *RequestMessage) ReqDeadline() int64             { return r.Deadline }
 func (r *RequestMessage) ReqPayload() map[string]any     { return r.Payload }
 func (r *RequestMessage) ReqMetadata() map[string]string { return r.Metadata }
+func (r *RequestMessage) ReqHeaders() map[string]string  { return r.Headers }
 func (r *RequestMessage) ReqEndpoint() string            { return r.Endpoint }
 
 // RedisRequest is the concrete Request implementation for Redis-based flows.

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -53,13 +53,17 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 				if ep := ir.PublicRequest.ReqEndpoint(); ep != "" {
 					requestURL = meta[i1].IGWBaseURl + ep
 				}
+				headers := map[string]string{
+					"Content-Type":                  "application/json",
+					"x-gateway-inference-objective": meta[i1].InferenceObjective,
+				}
+				for k, v := range ir.PublicRequest.ReqHeaders() {
+					headers[k] = v
+				}
 				erm := pipeline.EmbelishedRequestMessage{
 					InternalRequest: ir,
-					HttpHeaders: map[string]string{
-						"Content-Type":                  "application/json",
-						"x-gateway-inference-objective": meta[i1].InferenceObjective,
-					},
-					RequestURL: requestURL,
+					HttpHeaders:     headers,
+					RequestURL:      requestURL,
 				}
 				mergedChannel <- erm
 			}

--- a/pkg/async/random_robin_policy_test.go
+++ b/pkg/async/random_robin_policy_test.go
@@ -187,6 +187,67 @@ func TestPerMessageEndpointOverridesChannelURL(t *testing.T) {
 	}
 }
 
+func irWithHeaders(id string, headers map[string]string) *api.InternalRequest {
+	return api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{
+		ID:       id,
+		Created:  1,
+		Deadline: 9999999999,
+		Headers:  headers,
+	})
+}
+
+func TestPerRequestHeadersMerged(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:            make(chan *api.InternalRequest, 3),
+		IGWBaseURl:         "http://gw",
+		InferenceObjective: "obj",
+		RequestPathURL:     "/v1/completions",
+	}
+	policy := NewRandomRobinPolicy()
+
+	ch.Channel <- irWithHeaders("custom", map[string]string{
+		"Authorization": "Bearer tok",
+		"X-Trace-ID":    "abc",
+	})
+	ch.Channel <- irWithHeaders("override-objective", map[string]string{
+		"x-gateway-inference-objective": "my-obj",
+	})
+	ch.Channel <- irID("no-headers")
+	close(ch.Channel)
+
+	merged := policy.MergeRequestChannels([]pipeline.RequestChannel{ch})
+
+	deadline := time.After(2 * time.Second)
+	results := map[string]map[string]string{}
+	for range 3 {
+		select {
+		case msg := <-merged.Channel:
+			results[msg.PublicRequest.ReqID()] = msg.HttpHeaders
+		case <-deadline:
+			t.Fatal("timed out")
+		}
+	}
+
+	// Custom headers are merged in.
+	if h := results["custom"]; h["Authorization"] != "Bearer tok" || h["X-Trace-ID"] != "abc" {
+		t.Errorf("custom headers not merged: %v", h)
+	}
+	// Default headers still present.
+	if h := results["custom"]; h["Content-Type"] != "application/json" {
+		t.Errorf("Content-Type missing: %v", h)
+	}
+
+	// User can override inference objective.
+	if h := results["override-objective"]; h["x-gateway-inference-objective"] != "my-obj" {
+		t.Errorf("expected overridden objective, got %v", h)
+	}
+
+	// No headers: defaults only.
+	if h := results["no-headers"]; h["Content-Type"] != "application/json" || h["x-gateway-inference-objective"] != "obj" {
+		t.Errorf("default headers wrong: %v", h)
+	}
+}
+
 func TestMergedChannelIsBuffered(t *testing.T) {
 	numChannels := 3
 	channels := make([]pipeline.RequestChannel, numChannels)

--- a/pkg/pubsub/gating_e2e_test.go
+++ b/pkg/pubsub/gating_e2e_test.go
@@ -19,7 +19,7 @@ func TestGating_EndToEnd(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
 	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
-	defer rdb.Close()
+	defer func() { _ = rdb.Close() }()
 
 	flow := &PubSubMQFlow{}
 	ch := make(chan *api.InternalRequest, 10)

--- a/pkg/redis/quota_gate_test.go
+++ b/pkg/redis/quota_gate_test.go
@@ -13,7 +13,7 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
 	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
-	defer rdb.Close()
+	defer func() { _ = rdb.Close() }()
 
 	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeConcurrency, 2, 10*time.Second, "quota:")
 
@@ -54,7 +54,7 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
 	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
-	defer rdb.Close()
+	defer func() { _ = rdb.Close() }()
 
 	// 2 requests per 1 second
 	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, 2, 1*time.Second, "quota:")
@@ -94,7 +94,7 @@ func TestRedisQuotaGate_MissingAttribute(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
 	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
-	defer rdb.Close()
+	defer func() { _ = rdb.Close() }()
 
 	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, 1, 1*time.Second, "quota:")
 

--- a/scalability_report.md
+++ b/scalability_report.md
@@ -34,7 +34,7 @@ The Async Processor is built as a concurrent pipeline designed to handle high-th
 ## 4. Back-pressure Bottlenecks & Scalability Risks
 
 ### High Risk: PubSub Result Pipeline
-The PubSub implementation lacks the buffering and batching present in the Redis implementation. 
+The PubSub implementation lacks the buffering and batching present in the Redis implementation.
 - **Impact:** Under heavy load, the single `resultWorker` becomes a serial bottleneck. Because the worker channel is unbuffered, the inference workers (which are expensive resources) spend idle time waiting for the PubSub publisher.
 
 ### Moderate Risk: Single-threaded Retry Logic
@@ -42,7 +42,7 @@ The `retryWorker` and `addMsgToRetryQueue` are single goroutines handling all qu
 - **Impact:** While retries are generally a smaller fraction of traffic, a "storm" of retryable errors (e.g., inference service 503s) could overwhelm these single goroutines, causing back-pressure to propagate back to the workers and further slowing down the system.
 
 ### Moderate Risk: Unbuffered Request Channels
-While unbuffered channels provide excellent back-pressure, they offer zero "smoothing" for bursts. 
+While unbuffered channels provide excellent back-pressure, they offer zero "smoothing" for bursts.
 - **Impact:** Any jitter in the worker processing time immediately reflects back to the ingestion layer. Small buffers (e.g., equal to `concurrency`) could improve throughput by allowing the next batch of messages to be pre-fetched while workers are finishing.
 
 ## 5. Summary of Redis vs. PubSub Scalability

--- a/test/e2e/igw-mock/main.go
+++ b/test/e2e/igw-mock/main.go
@@ -80,9 +80,9 @@ func (s *server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Lock()
 	s.requestLog = append(s.requestLog, reqID)
-	
+
 	delayMs := s.delay.DelayMs
-	
+
 	if s.fail.Count > 0 {
 		status := s.fail.Status
 		s.fail.Count--

--- a/test/e2e/yaml/async-processor-quota.yaml
+++ b/test/e2e/yaml/async-processor-quota.yaml
@@ -54,4 +54,3 @@ spec:
       - name: config-volume
         configMap:
           name: async-processor-quota-config
-


### PR DESCRIPTION
## What does this PR do?

Add `Headers` field to `RequestMessage` and merge them into HTTP headers during async dispatch.

## Why is this change needed?

HTTP headers are currently hardcoded — callers cannot pass auth tokens, routing hints, or tracing headers per request.

## How was this tested?

- [x] Unit tests added/updated

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)

## Related Issues

Fixes #168