### PR TITLE
test: support Podman as container runtime for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,8 @@ GOBIN := $(shell go env GOBIN)
 endif
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
-# Be aware that the target commands are only tested with Docker which is
-# scaffolded by default. However, you might want to replace it to use other
-# tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+# Auto-detects docker (if daemon running) or podman; override with CONTAINER_TOOL=podman.
+CONTAINER_TOOL ?= $(shell (command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 && echo docker) || (command -v podman >/dev/null 2>&1 && echo podman) || echo docker)
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -151,7 +149,7 @@ IGW_MOCK_IMG ?= e2e-igw-mock:latest
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests against a Kind cluster
 	@command -v kind >/dev/null 2>&1 || { echo "kind is not installed"; exit 1; }
-	AP_IMAGE=$(E2E_IMG) go test ./test/e2e/ -timeout 30m -v -ginkgo.v \
+	CONTAINER_TOOL=$(CONTAINER_TOOL) AP_IMAGE=$(E2E_IMG) go test ./test/e2e/ -timeout 30m -v -ginkgo.v \
 		$(if $(FOCUS),-ginkgo.focus="$(FOCUS)",) \
 		$(if $(SKIP),-ginkgo.skip="$(SKIP)",)
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -56,7 +57,7 @@ var (
 
 	testConfig *testutils.TestConfig
 
-	containerRuntime = env.GetEnvString("CONTAINER_TOOL", env.GetEnvString("CONTAINER_RUNTIME", "docker", ginkgo.GinkgoLogr), ginkgo.GinkgoLogr)
+	containerRuntime = detectContainerRuntime()
 	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d-incubation/async-processor:e2e-test", ginkgo.GinkgoLogr)
 	igwMockImage     = "e2e-igw-mock:latest"
 	promMockImage    = "e2e-prom-mock:latest"
@@ -116,8 +117,33 @@ var _ = ginkgo.AfterSuite(func() {
 	}
 })
 
+// detectContainerRuntime returns the container runtime to use.
+// Priority: CONTAINER_TOOL env > CONTAINER_RUNTIME env > docker (if daemon running) > podman.
+func detectContainerRuntime() string {
+	if tool := os.Getenv("CONTAINER_TOOL"); tool != "" {
+		return tool
+	}
+	if tool := os.Getenv("CONTAINER_RUNTIME"); tool != "" {
+		return tool
+	}
+	if _, err := exec.LookPath("docker"); err == nil {
+		if exec.Command("docker", "info").Run() == nil {
+			return "docker"
+		}
+	}
+	if _, err := exec.LookPath("podman"); err == nil {
+		return "podman"
+	}
+	return "docker"
+}
+
 // setupK8sCluster creates the Kind cluster, builds images, and loads them.
 func setupK8sCluster() {
+	if containerRuntime == "podman" {
+		ginkgo.By("Setting KIND_EXPERIMENTAL_PROVIDER=podman")
+		os.Setenv("KIND_EXPERIMENTAL_PROVIDER", "podman") //nolint:errcheck
+	}
+
 	ginkgo.By("Creating Kind cluster " + kindClusterName)
 	command := exec.Command("kind", "create", "cluster", "--name", kindClusterName, "--wait", "120s", "--config", "-")
 	stdin, err := command.StdinPipe()
@@ -171,12 +197,32 @@ func setupK8sCluster() {
 }
 
 func kindLoadImage(image string) {
-	ginkgo.By(fmt.Sprintf("Loading %s into the cluster %s", image, kindClusterName))
+	ginkgo.By(fmt.Sprintf("Loading %s into the cluster %s (runtime=%s)", image, kindClusterName, containerRuntime))
 
-	command := exec.Command("kind", "load", "docker-image", image, "--name", kindClusterName)
-	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
+	if containerRuntime == "podman" {
+		// Podman: tag unqualified images so kind can find them, then pipe via
+		// podman save | kind load image-archive.
+		qualifiedImage := image
+		if !strings.Contains(image, "/") {
+			qualifiedImage = "docker.io/library/" + image
+			cmd := exec.Command("podman", "tag", image, qualifiedImage)
+			session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(session).WithTimeout(60 * time.Second).Should(gexec.Exit(0))
+		}
+
+		shell := fmt.Sprintf("podman save --format docker-archive %s | kind load image-archive /dev/stdin --name %s",
+			qualifiedImage, kindClusterName)
+		command := exec.Command("bash", "-c", shell)
+		session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
+	} else {
+		command := exec.Command("kind", "load", "docker-image", image, "--name", kindClusterName)
+		session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
+	}
 }
 
 func setupK8sClient() {


### PR DESCRIPTION
## What does this PR do?

- Adds Podman as a supported container runtime for e2e tests alongside Docker.
- Introduces `detectContainerRuntime()` to auto-detect the available runtime (priority: `CONTAINER_TOOL` env > `CONTAINER_RUNTIME` env > Docker > Podman).
- Sets `KIND_EXPERIMENTAL_PROVIDER=podman` when using Podman so Kind creates clusters via Podman.
- Updates `kindLoadImage()` to use `podman save | kind load image-archive` for loading images into Kind with Podman.
- Auto-detects the container tool in the `Makefile` and propagates `CONTAINER_TOOL` to the e2e test environment.

## Why is this change needed?

The e2e test suite was hardcoded to use Docker, making it impossible to run locally on systems using Podman (e.g., Fedora, RHEL). Developers using Podman had to manually work around Kind's Docker dependency. This change detects the container runtime automatically and adapts cluster creation and image loading accordingly, matching the approach used in `batch-gateway`. 


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
<img width="840" height="853" alt="Screenshot 2026-05-07 at 5 09 41 PM" src="https://github.com/user-attachments/assets/a42488a0-9e4b-42c4-baa3-e1affe9295d3" />

- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #170 
