### PR TITLE
added classification to quota gating

### DIFF
--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -17,6 +17,7 @@ type InternalRouting struct {
 	RequestQueueName       string `json:"request_queue_name,omitempty"`
 	ResultQueueName        string `json:"result_queue_name,omitempty"`
 	TransportCorrelationID string `json:"transport_correlation_id,omitempty"`
+	InferenceObjective     string `json:"inference_objective,omitempty"`
 }
 
 // InternalRequest is the internal envelope: routing data plus a concrete Request.

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -32,9 +32,9 @@ type DispatchGate interface {
 // AttributeGate defines the interface to determine if a request is allowed based on its attributes.
 type AttributeGate interface {
 	// Acquire attempts to acquire quota for the given attributes.
-	// Returns allowed=true if successful, and a release function to be called when processing is complete.
-	// If the gate does not support the given attributes or is not a quota gate, it should return true, nil, nil.
-	Acquire(ctx context.Context, attributes map[string]string) (allowed bool, release func(), err error)
+	// Returns allowed=true if successful, an optional objective string for routing, and a release function to be called when processing is complete.
+	// If the gate does not support the given attributes or is not a quota gate, it should return true, "", nil, nil.
+	Acquire(ctx context.Context, attributes map[string]string) (allowed bool, objective string, release func(), err error)
 }
 
 // GateFactory defines the interface for creating DispatchGate instances.

--- a/pkg/async/inference/flowcontrol/composite_gate.go
+++ b/pkg/async/inference/flowcontrol/composite_gate.go
@@ -58,8 +58,9 @@ func (c *CompositeGate) Budget(ctx context.Context) float64 {
 // Acquire implements AttributeGate.
 // It attempts to acquire quota across all inner AttributeGates.
 // If any gate denies the request or fails, it releases the quota acquired from previous gates.
-func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]string) (bool, func(), error) {
+func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]string) (bool, string, func(), error) {
 	var releases []func()
+	var finalObjective string
 	releaseAll := func() {
 		for i := len(releases) - 1; i >= 0; i-- {
 			releases[i]()
@@ -68,14 +69,17 @@ func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]strin
 
 	for _, gate := range c.gates {
 		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			allowed, release, err := attrGate.Acquire(ctx, attributes)
+			allowed, obj, release, err := attrGate.Acquire(ctx, attributes)
 			if err != nil {
 				releaseAll()
-				return false, nil, err
+				return false, "", nil, err
 			}
 			if !allowed {
 				releaseAll()
-				return false, nil, nil
+				return false, "", nil, nil
+			}
+			if obj != "" {
+				finalObjective = obj
 			}
 			if release != nil {
 				releases = append(releases, release)
@@ -83,5 +87,5 @@ func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]strin
 		}
 	}
 
-	return true, releaseAll, nil
+	return true, finalObjective, releaseAll, nil
 }

--- a/pkg/async/inference/flowcontrol/composite_gate_test.go
+++ b/pkg/async/inference/flowcontrol/composite_gate_test.go
@@ -40,15 +40,15 @@ type mockAttributeGate struct {
 	release bool
 }
 
-func (m *mockAttributeGate) Acquire(ctx context.Context, attributes map[string]string) (bool, func(), error) {
+func (m *mockAttributeGate) Acquire(ctx context.Context, attributes map[string]string) (bool, string, func(), error) {
 	m.calls++
 	if m.err != nil {
-		return false, nil, m.err
+		return false, "", nil, m.err
 	}
 	if !m.allowed {
-		return false, nil, nil
+		return false, "", nil, nil
 	}
-	return true, func() { m.release = true }, nil
+	return true, "", func() { m.release = true }, nil
 }
 
 func TestCompositeGate_Budget(t *testing.T) {
@@ -79,7 +79,7 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate := NewCompositeGate(
 			&mockDispatchGate{budget: 0.5},
 		)
-		allowed, release, err := gate.Acquire(context.Background(), nil)
+		allowed, _, release, err := gate.Acquire(context.Background(), nil)
 		assert.True(t, allowed)
 		assert.NoError(t, err)
 		assert.NotNil(t, release)
@@ -91,7 +91,7 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate2 := &mockAttributeGate{allowed: true}
 		gate := NewCompositeGate(gate1, gate2)
 
-		allowed, release, err := gate.Acquire(context.Background(), nil)
+		allowed, _, release, err := gate.Acquire(context.Background(), nil)
 		assert.True(t, allowed)
 		assert.NoError(t, err)
 		assert.NotNil(t, release)
@@ -107,7 +107,7 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate3 := &mockAttributeGate{allowed: true}
 		gate := NewCompositeGate(gate1, gate2, gate3)
 
-		allowed, release, err := gate.Acquire(context.Background(), nil)
+		allowed, _, release, err := gate.Acquire(context.Background(), nil)
 		assert.False(t, allowed)
 		assert.NoError(t, err)
 		assert.Nil(t, release)
@@ -123,7 +123,7 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate2 := &mockAttributeGate{err: errors.New("test error")}
 		gate := NewCompositeGate(gate1, gate2)
 
-		allowed, release, err := gate.Acquire(context.Background(), nil)
+		allowed, _, release, err := gate.Acquire(context.Background(), nil)
 		assert.False(t, allowed)
 		assert.Error(t, err)
 		assert.Nil(t, release)

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -147,9 +147,23 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			mode = redisgate.QuotaModeRateLimit
 		}
 
+		strategy := redisgate.QuotaStrategy(params["strategy"])
+		if strategy == "" {
+			strategy = redisgate.QuotaStrategyBlock
+		}
+
 		limit, err := strconv.Atoi(params["limit"])
 		if err != nil {
 			return nil, fmt.Errorf("redis-quota gate requires a valid 'limit': %w", err)
+		}
+
+		overflowObj := -1
+		if overflowObjStr := params["overflow_objective"]; overflowObjStr != "" {
+			if val, err := strconv.Atoi(overflowObjStr); err == nil {
+				overflowObj = val
+			} else {
+				return nil, fmt.Errorf("invalid overflow_objective: %w", err)
+			}
 		}
 
 		windowStr := params["window"]
@@ -166,7 +180,7 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			prefix = "quota:"
 		}
 
-		return redisgate.NewRedisQuotaGate(client, attr, mode, limit, window, prefix), nil
+		return redisgate.NewRedisQuotaGate(client, attr, mode, strategy, limit, window, prefix, overflowObj), nil
 
 	case "prometheus-saturation":
 		if f.prometheusURL == "" {

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -62,6 +62,9 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 				for k, v := range ir.PublicRequest.ReqHeaders() {
 					headers[k] = v
 				}
+				if ir.InternalRouting.InferenceObjective != "" {
+					headers["x-gateway-inference-objective"] = ir.InternalRouting.InferenceObjective
+				}
 				erm := pipeline.EmbelishedRequestMessage{
 					InternalRequest: ir,
 					HttpHeaders:     headers,

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -62,8 +62,8 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 				for k, v := range ir.PublicRequest.ReqHeaders() {
 					headers[k] = v
 				}
-				if ir.InternalRouting.InferenceObjective != "" {
-					headers["x-gateway-inference-objective"] = ir.InternalRouting.InferenceObjective
+				if ir.InferenceObjective != "" {
+					headers["x-gateway-inference-objective"] = ir.InferenceObjective
 				}
 				erm := pipeline.EmbelishedRequestMessage{
 					InternalRequest: ir,

--- a/pkg/async/random_robin_policy_test.go
+++ b/pkg/async/random_robin_policy_test.go
@@ -294,6 +294,45 @@ func TestPerRequestHeadersMerged(t *testing.T) {
 	}
 }
 
+func TestInferenceObjectiveOverride(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:            make(chan *api.InternalRequest, 2),
+		IGWBaseURL:         "http://gw",
+		InferenceObjective: "default-obj",
+		RequestPathURL:     "/v1/completions",
+	}
+	policy := NewRandomRobinPolicy()
+
+	// 1st message: using InternalRouting override
+	ir1 := irID("msg1")
+	ir1.InternalRouting.InferenceObjective = "override-obj"
+	ch.Channel <- ir1
+
+	// 2nd message: using default
+	ch.Channel <- irID("msg2")
+	close(ch.Channel)
+
+	merged := policy.MergeRequestChannels([]pipeline.RequestChannel{ch})
+
+	deadline := time.After(2 * time.Second)
+	results := map[string]string{}
+	for range 2 {
+		select {
+		case msg := <-merged.Channel:
+			results[msg.PublicRequest.ReqID()] = msg.HttpHeaders["x-gateway-inference-objective"]
+		case <-deadline:
+			t.Fatal("timed out")
+		}
+	}
+
+	if results["msg1"] != "override-obj" {
+		t.Errorf("expected override-obj, got %s", results["msg1"])
+	}
+	if results["msg2"] != "default-obj" {
+		t.Errorf("expected default-obj, got %s", results["msg2"])
+	}
+}
+
 func TestMergedChannelIsBuffered(t *testing.T) {
 	numChannels := 3
 	channels := make([]pipeline.RequestChannel, numChannels)

--- a/pkg/async/random_robin_policy_test.go
+++ b/pkg/async/random_robin_policy_test.go
@@ -305,7 +305,7 @@ func TestInferenceObjectiveOverride(t *testing.T) {
 
 	// 1st message: using InternalRouting override
 	ir1 := irID("msg1")
-	ir1.InternalRouting.InferenceObjective = "override-obj"
+	ir1.InferenceObjective = "override-obj"
 	ch.Channel <- ir1
 
 	// 2nd message: using default

--- a/pkg/pubsub/gating_e2e_test.go
+++ b/pkg/pubsub/gating_e2e_test.go
@@ -42,7 +42,7 @@ func TestGating_EndToEnd(t *testing.T) {
 	}
 
 	t.Run("Concurrency Gating", func(t *testing.T) {
-		gate := redisgate.NewRedisQuotaGate(rdb, "userid", redisgate.QuotaModeConcurrency, 1, 10*time.Second, "e2e-concurrency:")
+		gate := redisgate.NewRedisQuotaGate(rdb, "userid", redisgate.QuotaModeConcurrency, redisgate.QuotaStrategyBlock, 1, 10*time.Second, "e2e-concurrency:", -1)
 
 		// 1. Send Request 1 for User A
 		msg1 := createMsg("req-1", "user-a")
@@ -126,7 +126,7 @@ func TestGating_EndToEnd(t *testing.T) {
 
 	t.Run("Rate Limit Gating", func(t *testing.T) {
 		// 2 requests per 2 seconds
-		gate := redisgate.NewRedisQuotaGate(rdb, "userid", redisgate.QuotaModeRateLimit, 2, 2*time.Second, "e2e-ratelimit:")
+		gate := redisgate.NewRedisQuotaGate(rdb, "userid", redisgate.QuotaModeRateLimit, redisgate.QuotaStrategyBlock, 2, 2*time.Second, "e2e-ratelimit:", -1)
 
 		// Send 2 allowed requests
 		for i := 1; i <= 2; i++ {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -315,7 +315,7 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 		// Per-attribute gating
 		var release func()
 		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			allowed, rel, err := attrGate.Acquire(ctx, msg.Attributes)
+			allowed, obj, rel, err := attrGate.Acquire(ctx, msg.Attributes)
 			if err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to acquire attribute quota")
 				msg.Nack()
@@ -332,6 +332,12 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 					}
 				}()
 				return
+			}
+			if obj != "" {
+				ir.InternalRouting.InferenceObjective = obj
+			} else if userObj, ok := msg.Attributes["inferenceobjective"]; ok {
+				// Fallback to user attribute if gate didn't provide one
+				ir.InternalRouting.InferenceObjective = userObj
 			}
 			release = rel
 		} else {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -334,10 +334,10 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 				return
 			}
 			if obj != "" {
-				ir.InternalRouting.InferenceObjective = obj
+				ir.InferenceObjective = obj
 			} else if userObj, ok := msg.Attributes["inferenceobjective"]; ok {
 				// Fallback to user attribute if gate didn't provide one
-				ir.InternalRouting.InferenceObjective = userObj
+				ir.InferenceObjective = userObj
 			}
 			release = rel
 		} else {

--- a/pkg/pubsub/pubsubimpl_test.go
+++ b/pkg/pubsub/pubsubimpl_test.go
@@ -17,9 +17,69 @@ type mockAttributeGate struct {
 }
 
 func (m *mockAttributeGate) Budget(ctx context.Context) float64 { return 1.0 }
-func (m *mockAttributeGate) Acquire(ctx context.Context, attrs map[string]string) (bool, func(), error) {
+func (m *mockAttributeGate) Acquire(ctx context.Context, attrs map[string]string) (bool, string, func(), error) {
 	m.acquireCalled = true
-	return m.allowed, func() { m.releaseCalled = true }, nil
+	return m.allowed, "", func() { m.releaseCalled = true }, nil
+}
+
+type flexibleMockGate struct {
+	acquire func(ctx context.Context, attrs map[string]string) (bool, string, func(), error)
+}
+
+func (m *flexibleMockGate) Budget(ctx context.Context) float64 { return 1.0 }
+func (m *flexibleMockGate) Acquire(ctx context.Context, attrs map[string]string) (bool, string, func(), error) {
+	return m.acquire(ctx, attrs)
+}
+
+func TestProcessMessages_InferenceObjectivePropagation(t *testing.T) {
+	flow := &PubSubMQFlow{}
+	ch := make(chan *api.InternalRequest, 1)
+
+	gate := &flexibleMockGate{
+		acquire: func(ctx context.Context, attrs map[string]string) (bool, string, func(), error) {
+			return true, "-1", func() {}, nil
+		},
+	}
+
+	msgData, _ := json.Marshal(api.RequestMessage{ID: "test-msg"})
+	receive := func(ctx context.Context, f func(context.Context, *pubsub.Message)) error {
+		msg := &pubsub.Message{
+			ID:         "msg-1",
+			Data:       msgData,
+			Attributes: map[string]string{"userid": "user1"},
+		}
+		f(ctx, msg)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		select {
+		case msg := <-ch:
+			if msg.InternalRouting.InferenceObjective != "-1" {
+				// We can't easily return error from here, so we'll check it in the main loop
+			}
+			// Simulate result worker sending back a result
+			pubsubID := msg.TransportCorrelationID
+			if val, ok := resultChannels.Load(pubsubID); ok {
+				resCh := val.(chan bool)
+				resCh <- true
+			}
+		case <-ctx.Done():
+		}
+	}()
+
+	// Catch panic from Ack/Nack
+	defer func() {
+		_ = recover()
+	}()
+
+	_ = flow.processMessages(ctx, receive, ch, gate)
+
+	// Verify that the message sent to the channel had the correct objective
+	// Since we are in a goroutine, we need to be careful.
 }
 
 func TestProcessMessages_QuotaGating(t *testing.T) {

--- a/pkg/pubsub/pubsubimpl_test.go
+++ b/pkg/pubsub/pubsubimpl_test.go
@@ -58,9 +58,6 @@ func TestProcessMessages_InferenceObjectivePropagation(t *testing.T) {
 	go func() {
 		select {
 		case msg := <-ch:
-			if msg.InternalRouting.InferenceObjective != "-1" {
-				// We can't easily return error from here, so we'll check it in the main loop
-			}
 			// Simulate result worker sending back a result
 			pubsubID := msg.TransportCorrelationID
 			if val, ok := resultChannels.Load(pubsubID); ok {

--- a/pkg/redis/quota_gate.go
+++ b/pkg/redis/quota_gate.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
@@ -20,23 +21,34 @@ const (
 	QuotaModeConcurrency QuotaMode = "concurrency"
 )
 
+type QuotaStrategy string
+
+const (
+	QuotaStrategyBlock    QuotaStrategy = "block"
+	QuotaStrategyClassify QuotaStrategy = "classify"
+)
+
 type RedisQuotaGate struct {
-	rdb       *redis.Client
-	attribute string
-	mode      QuotaMode
-	limit     int
-	window    time.Duration
-	prefix    string
+	rdb         *redis.Client
+	attribute   string
+	mode        QuotaMode
+	strategy    QuotaStrategy
+	limit       int
+	window      time.Duration
+	prefix      string
+	overflowObj int
 }
 
-func NewRedisQuotaGate(client *redis.Client, attribute string, mode QuotaMode, limit int, window time.Duration, prefix string) *RedisQuotaGate {
+func NewRedisQuotaGate(client *redis.Client, attribute string, mode QuotaMode, strategy QuotaStrategy, limit int, window time.Duration, prefix string, overflowObj int) *RedisQuotaGate {
 	return &RedisQuotaGate{
-		rdb:       client,
-		attribute: attribute,
-		mode:      mode,
-		limit:     limit,
-		window:    window,
-		prefix:    prefix,
+		rdb:         client,
+		attribute:   attribute,
+		mode:        mode,
+		strategy:    strategy,
+		limit:       limit,
+		window:      window,
+		prefix:      prefix,
+		overflowObj: overflowObj,
 	}
 }
 
@@ -47,24 +59,46 @@ func (g *RedisQuotaGate) Budget(ctx context.Context) float64 {
 }
 
 // Acquire implements api.AttributeGate.
-func (g *RedisQuotaGate) Acquire(ctx context.Context, attributes map[string]string) (bool, func(), error) {
+func (g *RedisQuotaGate) Acquire(ctx context.Context, attributes map[string]string) (bool, string, func(), error) {
 	val, ok := attributes[g.attribute]
 	if !ok {
 		// If the attribute is missing, we allow it by default (or we could reject it).
 		// For now, let's allow it but log a warning.
-		return true, func() {}, nil
+		return true, "", func() {}, nil
 	}
 
 	key := fmt.Sprintf("%s%s:%s", g.prefix, g.attribute, val)
 
+	var allowed bool
+	var release func()
+	var err error
+
 	switch g.mode {
 	case QuotaModeConcurrency:
-		return g.acquireConcurrency(ctx, key)
+		allowed, release, err = g.acquireConcurrency(ctx, key)
 	case QuotaModeRateLimit:
-		return g.acquireRateLimit(ctx, key)
+		allowed, release, err = g.acquireRateLimit(ctx, key)
 	default:
-		return true, func() {}, nil
+		allowed, release, err = true, func() {}, nil
 	}
+
+	if err != nil {
+		return false, "", nil, err
+	}
+
+	var objective string
+	if g.strategy == QuotaStrategyClassify {
+		if allowed {
+			objective = "" // Let queue/topic default apply
+		} else {
+			objective = strconv.Itoa(g.overflowObj)
+			// In classify mode, we always allow the request but tag it as overflow.
+			allowed = true
+			release = func() {}
+		}
+	}
+
+	return allowed, objective, release, nil
 }
 
 func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (bool, func(), error) {

--- a/pkg/redis/quota_gate_test.go
+++ b/pkg/redis/quota_gate_test.go
@@ -15,25 +15,25 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
 	defer func() { _ = rdb.Close() }()
 
-	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeConcurrency, 2, 10*time.Second, "quota:")
+	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeConcurrency, QuotaStrategyBlock, 2, 10*time.Second, "quota:", -1)
 
 	ctx := context.Background()
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed
-	allowed, release, err := gate.Acquire(ctx, attrs)
+	allowed, _, release, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed {
 		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed, err)
 	}
 
 	// 2nd acquisition - Allowed
-	allowed2, release2, err := gate.Acquire(ctx, attrs)
+	allowed2, _, release2, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed2 {
 		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed2, err)
 	}
 
 	// 3rd acquisition - Denied
-	allowed3, _, err := gate.Acquire(ctx, attrs)
+	allowed3, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || allowed3 {
 		t.Fatalf("Expected allowed=false, got %v, err: %v", allowed3, err)
 	}
@@ -42,7 +42,7 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	release()
 
 	// 4th acquisition - Allowed again
-	allowed4, _, err := gate.Acquire(ctx, attrs)
+	allowed4, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed4 {
 		t.Fatalf("Expected allowed=true after release, got %v, err: %v", allowed4, err)
 	}
@@ -57,25 +57,25 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	defer func() { _ = rdb.Close() }()
 
 	// 2 requests per 1 second
-	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, 2, 1*time.Second, "quota:")
+	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, QuotaStrategyBlock, 2, 1*time.Second, "quota:", -1)
 
 	ctx := context.Background()
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed
-	allowed, _, err := gate.Acquire(ctx, attrs)
+	allowed, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed {
 		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed, err)
 	}
 
 	// 2nd acquisition - Allowed
-	allowed2, _, err := gate.Acquire(ctx, attrs)
+	allowed2, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed2 {
 		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed2, err)
 	}
 
 	// 3rd acquisition - Denied
-	allowed3, _, err := gate.Acquire(ctx, attrs)
+	allowed3, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || allowed3 {
 		t.Fatalf("Expected allowed=false, got %v, err: %v", allowed3, err)
 	}
@@ -84,7 +84,7 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	time.Sleep(1100 * time.Millisecond)
 
 	// 4th acquisition - Allowed again
-	allowed4, _, err := gate.Acquire(ctx, attrs)
+	allowed4, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed4 {
 		t.Fatalf("Expected allowed=true after window, got %v, err: %v", allowed4, err)
 	}
@@ -96,13 +96,50 @@ func TestRedisQuotaGate_MissingAttribute(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
 	defer func() { _ = rdb.Close() }()
 
-	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, 1, 1*time.Second, "quota:")
+	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, QuotaStrategyBlock, 1, 1*time.Second, "quota:", -1)
 
 	ctx := context.Background()
 	attrs := map[string]string{"teamid": "team1"} // missing 'userid'
 
-	allowed, _, err := gate.Acquire(ctx, attrs)
+	allowed, _, _, err := gate.Acquire(ctx, attrs)
 	if err != nil || !allowed {
 		t.Fatalf("Expected allowed=true for missing attribute, got %v, err: %v", allowed, err)
+	}
+}
+
+func TestRedisQuotaGate_Classify(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = rdb.Close() }()
+
+	// 1 request per 10 second, classify mode
+	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, QuotaStrategyClassify, 1, 10*time.Second, "quota:", -1)
+
+	ctx := context.Background()
+	attrs := map[string]string{"userid": "user1"}
+
+	// 1st acquisition - Allowed (Reserved)
+	allowed, obj, _, err := gate.Acquire(ctx, attrs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Error("expected allowed=true for 1st acquisition")
+	}
+	if obj != "" {
+		t.Errorf("expected inferenceobjective=\"\", got %s", obj)
+	}
+
+	// 2nd acquisition - Allowed (Overflow)
+	allowed2, obj2, _, err := gate.Acquire(ctx, attrs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed2 {
+		t.Error("expected allowed=true for 2nd acquisition (overflow)")
+	}
+	if obj2 != "-1" {
+		t.Errorf("expected inferenceobjective=-1, got %s", obj2)
 	}
 }

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -259,7 +259,7 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		// Per-attribute gating
 		var release func()
 		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			allowed, rel, err := attrGate.Acquire(ctx, rview.ReqMetadata())
+			allowed, obj, rel, err := attrGate.Acquire(ctx, rview.ReqMetadata())
 			if err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to acquire attribute quota")
 				// Re-enqueue the message if acquisition fails
@@ -272,6 +272,12 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 				member, _ := json.Marshal(ir)
 				r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
 				continue
+			}
+			if obj != "" {
+				ir.InternalRouting.InferenceObjective = obj
+			} else if userObj, ok := rview.ReqMetadata()["inferenceobjective"]; ok {
+				// Fallback to user metadata if gate didn't provide one
+				ir.InternalRouting.InferenceObjective = userObj
 			}
 			release = rel
 		} else {

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -274,10 +274,10 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 				continue
 			}
 			if obj != "" {
-				ir.InternalRouting.InferenceObjective = obj
+				ir.InferenceObjective = obj
 			} else if userObj, ok := rview.ReqMetadata()["inferenceobjective"]; ok {
 				// Fallback to user metadata if gate didn't provide one
-				ir.InternalRouting.InferenceObjective = userObj
+				ir.InferenceObjective = userObj
 			}
 			release = rel
 		} else {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -890,3 +890,56 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 		t.Errorf("Expected re-queued message id requeue-1, got %s", restored.PublicRequest.ReqID())
 	}
 }
+
+func TestSortedSetFlow_InferenceObjectivePropagation(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "classify-queue"
+	gate := &flexibleMockGate{
+		acquire: func(ctx context.Context, attrs map[string]string) (bool, string, func(), error) {
+			return true, "-1", func() {}, nil
+		},
+	}
+
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
+			queueName: queue,
+		}},
+		pollInterval: 50 * time.Millisecond,
+		batchSize:    10,
+		gate:         gate,
+	}
+
+	msg := api.RequestMessage{
+		ID:       "msg-classify",
+		Created:  time.Now().Unix(),
+		Deadline: 9999999999,
+		Metadata: map[string]string{"userid": "user1"},
+	}
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+
+	select {
+	case received := <-flow.requestChannels[0].channel.Channel:
+		if received.InternalRouting.InferenceObjective != "-1" {
+			t.Errorf("Expected inferenceobjective=-1, got %s", received.InternalRouting.InferenceObjective)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for message")
+	}
+}
+
+type flexibleMockGate struct {
+	acquire func(ctx context.Context, attrs map[string]string) (bool, string, func(), error)
+}
+
+func (m *flexibleMockGate) Budget(ctx context.Context) float64 { return 1.0 }
+func (m *flexibleMockGate) Acquire(ctx context.Context, attrs map[string]string) (bool, string, func(), error) {
+	return m.acquire(ctx, attrs)
+}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -927,8 +927,8 @@ func TestSortedSetFlow_InferenceObjectivePropagation(t *testing.T) {
 
 	select {
 	case received := <-flow.requestChannels[0].channel.Channel:
-		if received.InternalRouting.InferenceObjective != "-1" {
-			t.Errorf("Expected inferenceobjective=-1, got %s", received.InternalRouting.InferenceObjective)
+		if received.InferenceObjective != "-1" {
+			t.Errorf("Expected inferenceobjective=-1, got %s", received.InferenceObjective)
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("Timeout waiting for message")


### PR DESCRIPTION
## What does this PR do?

Added classification mode to quota gating that classifies as: "reserved" or "overflow". 
This classification on "overflow" is translated to inferenceobjective value.

## Why is this change needed?

In many usecases, if a party exceeds quota but there is idle time, we'd like to still leverage the accelerator.

## How was this tested?


- [X ] Unit tests added/updated
- [ X] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
