### PR TITLE
fix: prevent nil pointer panic when redis channel closes

### DIFF
--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -255,7 +255,11 @@ func requestWorker(ctx context.Context, rdb *redis.Client, msgChannel chan *api.
 		case <-ctx.Done():
 			return
 
-		case rmsg := <-ch:
+		case rmsg, ok := <-ch:
+			if !ok {
+				logger.V(logutil.DEFAULT).Info("Redis subscription channel closed, exiting request worker")
+				return
+			}
 			var ir api.InternalRequest
 
 			err := json.Unmarshal([]byte(rmsg.Payload), &ir)


### PR DESCRIPTION
## What does this PR do?

Adds a channel closed check in `requestWorker`

When the Redis Pub/Sub channel closes (e.g. due to a connection drop), the worker now detects `ok == false` from the channel receive and exits gracefully with a log message, instead of dereferencing a nil `*redis.Message`.

## Why is this change needed?

If the Redis connection drops or the subscription is terminated, `sub.Channel()` returns a channel that gets closed. A receive on a closed channel yields a zero-value (nil `*redis.Message`). The existing code immediately accesses `rmsg.Payload`, which causes a nil pointer panic and crashes the worker goroutine.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #126