### PR TITLE
fix: reconnect redis subscription on channel close

### DIFF
--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -243,8 +243,31 @@ func marshalResultMessage(msg api.ResultMessage) string {
 	return string(fallbackBytes)
 }
 
-// pulls from Redis channel and put in the request channel
+// pulls from Redis channel and put in the request channel.
+const (
+	reconnectDelay = 10 * time.Second
+)
+
+// Automatically reconnects when the subscription channel closes.
 func requestWorker(ctx context.Context, rdb *redis.Client, msgChannel chan *api.InternalRequest, queueName string) {
+	logger := log.FromContext(ctx)
+	for ctx.Err() == nil {
+		shouldReconnect := consumeSubscription(ctx, rdb, msgChannel, queueName)
+		if ctx.Err() != nil {
+			return
+		}
+		if shouldReconnect {
+			logger.V(logutil.DEFAULT).Info("Redis subscription interrupted, reconnecting", "delay", reconnectDelay)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(reconnectDelay):
+			}
+		}
+	}
+}
+
+func consumeSubscription(ctx context.Context, rdb *redis.Client, msgChannel chan *api.InternalRequest, queueName string) bool {
 	logger := log.FromContext(ctx)
 	sub := rdb.Subscribe(ctx, queueName)
 	defer sub.Close() // nolint:errcheck
@@ -253,15 +276,12 @@ func requestWorker(ctx context.Context, rdb *redis.Client, msgChannel chan *api.
 	for {
 		select {
 		case <-ctx.Done():
-			return
-
+			return false
 		case rmsg, ok := <-ch:
 			if !ok {
-				logger.V(logutil.DEFAULT).Info("Redis subscription channel closed, exiting request worker")
-				return
+				return true
 			}
 			var ir api.InternalRequest
-
 			err := json.Unmarshal([]byte(rmsg.Payload), &ir)
 			if err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to unmarshal message from request channel")
@@ -274,7 +294,6 @@ func requestWorker(ctx context.Context, rdb *redis.Client, msgChannel chan *api.
 			msgChannel <- &ir
 		}
 	}
-
 }
 
 func (r *RedisMQFlow) Characteristics() pipeline.Characteristics {

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -525,3 +525,50 @@ func TestPopDueRetryMessages_ConcurrentCallers_NoDuplicatePops(t *testing.T) {
 		t.Fatalf("expected queue to be empty after concurrent pops, got %d", remaining)
 	}
 }
+
+func TestRequestWorker_ReconnectsAfterChannelClose(t *testing.T) {
+	s := miniredis.RunT(t)
+	addr := s.Addr()
+	rdb := redis.NewClient(&redis.Options{Addr: addr})
+	defer rdb.Close() // nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	queueName := "reconnect-test-queue"
+	msgChannel := make(chan *api.InternalRequest, 10)
+
+	go requestWorker(ctx, rdb, msgChannel, queueName)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Restart miniredis on the same address to force subscription channel close and reconnect
+	s.Close()
+	s2 := miniredis.NewMiniRedis()
+	if err := s2.StartAddr(addr); err != nil {
+		t.Fatalf("failed to restart miniredis on same addr: %v", err)
+	}
+	defer s2.Close()
+
+	// Wait for reconnectDelay (10s) + subscribe time
+	time.Sleep(reconnectDelay + time.Second)
+
+	now := time.Now().Unix()
+	ir := api.NewInternalRequest(
+		api.InternalRouting{},
+		&api.RequestMessage{ID: "after-reconnect", Created: now, Deadline: now + 3600},
+	)
+	bytes, _ := json.Marshal(ir)
+	rdb2 := redis.NewClient(&redis.Options{Addr: addr})
+	defer rdb2.Close() // nolint:errcheck
+	rdb2.Publish(ctx, queueName, string(bytes))
+
+	select {
+	case msg := <-msgChannel:
+		if msg.PublicRequest == nil || msg.PublicRequest.ReqID() != "after-reconnect" {
+			t.Fatalf("expected after-reconnect, got %v", msg)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: requestWorker did not recover after reconnect")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds automatic reconnection to `requestWorker` when the Redis Pub/Sub subscription channel closes. Previously, a closed channel caused either a nil pointer panic or a silent permanent exit. Now the worker retries with a fixed 10s delay.

## Why is this change needed?

If the Redis connection drops, `sub.Channel()` closes and a receive yields nil, causing a panic on `rmsg.Payload`. Even with the nil check, the worker would exit permanently and stop consuming from that queue with no way to recover.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)