### PR TITLE
fix: handle metrics server creation error to prevent nil pointer panic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -142,7 +142,11 @@ func main() {
 	}
 	restConfig := ctrl.GetConfigOrDie()
 
-	msrv, _ := metricsserver.NewServer(metricsServerOptions, restConfig, http.DefaultClient)
+	msrv, err := metricsserver.NewServer(metricsServerOptions, restConfig, http.DefaultClient)
+	if err != nil {
+		setupLog.Error(err, "Failed to create metrics server")
+		os.Exit(1)
+	}
 	go msrv.Start(ctx) // nolint:errcheck
 
 	tlsConfig, err := buildTLSConfig(tlsCACert, tlsCert, tlsKey, tlsInsecureSkipVerify)


### PR DESCRIPTION
## What does this PR do?

Handle the error return from `metricsserver.NewServer` instead of discarding it. Previously `msrv` could be `nil` on failure, causing a nil pointer panic on `msrv.Start(ctx)`.

## Why is this change needed?

`metricsserver.NewServer` error was silently ignored. If creation failed, the next line `go msrv.Start(ctx)` would panic on nil pointer.

## How was this tested?

- [x] `go build` passes
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

N/A