### PR TITLE
fix: store quota release before channel send to prevent race condition

### DIFF
--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -278,13 +278,14 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			release = func() {}
 		}
 
-		select {
+		if release != nil {
+			r.activeReleases.Store(rview.ReqID(), release)
+		}
 
+		select {
 		case msgChannel <- ir:
-			if release != nil {
-				r.activeReleases.Store(rview.ReqID(), release)
-			}
 		case <-ctx.Done():
+			r.activeReleases.Delete(rview.ReqID())
 			if err := retryRedisOp(context.Background(), func(ctx context.Context) error {
 				return r.rdb.ZAdd(ctx, queueName, redis.Z{
 					Score:  results[0].Score,


### PR DESCRIPTION
## What does this PR do?

Moves `activeReleases.Store()` before the channel send and adds `activeReleases.Delete()` in the `ctx.Done` branch.

## Why is this change needed?

There is a race window where `resultWorker` calls `LoadAndDelete` before `Store` completes. if a worker processes a request faster than the store, the quota release function is lost and quota leaks.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

`go test ./pkg/redis/...` passes.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)