### PR TITLE
Adding a classifier mode to quota gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 
 - `constant`: Always returns budget 1.0 (fully open) - no throttling.
 - `redis`: Queries Redis for dispatch budget (managed by external system).
+- `redis-quota`: Per-attribute quota management via Redis.
 - `composite`: Combines multiple gates. Returns the minimum budget across all inner dispatch gates and acquires quota across all inner attribute gates (all or nothing).
 - `prometheus-saturation`: Queries Prometheus for pool saturation metric. The gate closes (returns `0.0`) when saturation ≥ threshold; when open it returns `(1 - saturation) - (1 - threshold)`, i.e. the margin below the threshold.
 - `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_SYS)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
@@ -166,6 +167,15 @@ For more fine-grained control, configure gates per queue in your configuration f
 - `redis`:
   - `address` (**required**): Redis server address for the dispatch gate (e.g., `localhost:6379`). Queues sharing the same address will share the same connection pool.
   - `budget_key` (optional): Redis key to read dispatch budget from. Default is `dispatch-gate-budget`.
+
+- `redis-quota`:
+  - `address` (**required**): Redis server address.
+  - `attribute` (optional): The message attribute to use for quota (e.g., `userid`). Default is `userid`.
+  - `mode` (optional): `rate-limit` or `concurrency`. Default is `rate-limit`.
+  - `limit` (**required**): The quota limit.
+  - `window` (optional): The time window for rate limiting (e.g., `1m`, `10s`). Default is `1m`.
+  - `prefix` (optional): Redis key prefix. Default is `quota:`.
+  - `gating_mode` (optional): `blocking` or `classifying`. In `classifying` mode, the gate never blocks but tags the message with its quota status ("reserved" or "overflow") in the internal metadata. Default is `blocking`.
 
 - `prometheus-saturation`:
   - `pool` (**required**): The inference pool name to filter metrics by.

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -5,6 +5,14 @@ import (
 	"fmt"
 )
 
+type QuotaClassification string
+
+const (
+	ClassificationNone     QuotaClassification = ""
+	ClassificationReserved QuotaClassification = "reserved"
+	ClassificationOverflow QuotaClassification = "overflow"
+)
+
 // InternalRouting holds the resolved, authoritative routing fields used by
 // infrastructure (producers, workers, retry logic). These are not part of the
 // caller-facing contract and should not be set by callers directly.
@@ -13,10 +21,11 @@ import (
 // values here. All internal pipeline code reads routing exclusively from this
 // struct rather than reaching back into the typed request.
 type InternalRouting struct {
-	RetryCount             int    `json:"retry_count,omitempty"`
-	RequestQueueName       string `json:"request_queue_name,omitempty"`
-	ResultQueueName        string `json:"result_queue_name,omitempty"`
-	TransportCorrelationID string `json:"transport_correlation_id,omitempty"`
+	RetryCount             int                 `json:"retry_count,omitempty"`
+	RequestQueueName       string              `json:"request_queue_name,omitempty"`
+	ResultQueueName        string              `json:"result_queue_name,omitempty"`
+	TransportCorrelationID string              `json:"transport_correlation_id,omitempty"`
+	Classification         QuotaClassification `json:"classification,omitempty"`
 }
 
 // InternalRequest is the internal envelope: routing data plus a concrete Request.

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -29,12 +29,23 @@ type DispatchGate interface {
 	Budget(ctx context.Context) float64
 }
 
+// AcquireResult contains the outcome of an AttributeGate.Acquire attempt.
+type AcquireResult struct {
+	// Allowed is true if the request should proceed.
+	Allowed bool
+	// Classification indicates the quota status of the request.
+	Classification api.QuotaClassification
+	// Release is a function to be called when processing is complete.
+	// It may be nil if no quota was acquired.
+	Release func()
+}
+
 // AttributeGate defines the interface to determine if a request is allowed based on its attributes.
 type AttributeGate interface {
 	// Acquire attempts to acquire quota for the given attributes.
-	// Returns allowed=true if successful, and a release function to be called when processing is complete.
-	// If the gate does not support the given attributes or is not a quota gate, it should return true, nil, nil.
-	Acquire(ctx context.Context, attributes map[string]string) (allowed bool, release func(), err error)
+	// If the gate does not support the given attributes or is not a quota gate,
+	// it should return Allowed=true and ClassificationNone.
+	Acquire(ctx context.Context, attributes map[string]string) (AcquireResult, error)
 }
 
 // GateFactory defines the interface for creating DispatchGate instances.

--- a/pkg/async/inference/flowcontrol/composite_gate.go
+++ b/pkg/async/inference/flowcontrol/composite_gate.go
@@ -19,6 +19,7 @@ package flowcontrol
 import (
 	"context"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
 	pipeline "github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
@@ -58,7 +59,7 @@ func (c *CompositeGate) Budget(ctx context.Context) float64 {
 // Acquire implements AttributeGate.
 // It attempts to acquire quota across all inner AttributeGates.
 // If any gate denies the request or fails, it releases the quota acquired from previous gates.
-func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]string) (bool, func(), error) {
+func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]string) (pipeline.AcquireResult, error) {
 	var releases []func()
 	releaseAll := func() {
 		for i := len(releases) - 1; i >= 0; i-- {
@@ -66,22 +67,34 @@ func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]strin
 		}
 	}
 
+	finalClassification := api.ClassificationNone
 	for _, gate := range c.gates {
 		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			allowed, release, err := attrGate.Acquire(ctx, attributes)
+			res, err := attrGate.Acquire(ctx, attributes)
 			if err != nil {
 				releaseAll()
-				return false, nil, err
+				return pipeline.AcquireResult{}, err
 			}
-			if !allowed {
+			if !res.Allowed {
 				releaseAll()
-				return false, nil, nil
+				return pipeline.AcquireResult{Allowed: false, Classification: api.ClassificationOverflow}, nil
 			}
-			if release != nil {
-				releases = append(releases, release)
+			if res.Release != nil {
+				releases = append(releases, res.Release)
+			}
+
+			// Aggregate classification: Overflow dominates.
+			if res.Classification == api.ClassificationOverflow {
+				finalClassification = api.ClassificationOverflow
+			} else if res.Classification == api.ClassificationReserved && finalClassification == api.ClassificationNone {
+				finalClassification = api.ClassificationReserved
 			}
 		}
 	}
 
-	return true, releaseAll, nil
+	return pipeline.AcquireResult{
+		Allowed:        true,
+		Classification: finalClassification,
+		Release:        releaseAll,
+	}, nil
 }

--- a/pkg/async/inference/flowcontrol/composite_gate_test.go
+++ b/pkg/async/inference/flowcontrol/composite_gate_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
+	pipeline "github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,21 +36,30 @@ func (m *mockDispatchGate) Budget(ctx context.Context) float64 {
 
 type mockAttributeGate struct {
 	mockDispatchGate
-	allowed bool
-	err     error
-	calls   int
-	release bool
+	allowed        bool
+	classification api.QuotaClassification
+	err            error
+	calls          int
+	release        bool
 }
 
-func (m *mockAttributeGate) Acquire(ctx context.Context, attributes map[string]string) (bool, func(), error) {
+func (m *mockAttributeGate) Acquire(ctx context.Context, attributes map[string]string) (pipeline.AcquireResult, error) {
 	m.calls++
 	if m.err != nil {
-		return false, nil, m.err
+		return pipeline.AcquireResult{}, m.err
 	}
 	if !m.allowed {
-		return false, nil, nil
+		return pipeline.AcquireResult{Allowed: false, Classification: api.ClassificationOverflow}, nil
 	}
-	return true, func() { m.release = true }, nil
+	class := m.classification
+	if class == "" {
+		class = api.ClassificationReserved
+	}
+	return pipeline.AcquireResult{
+		Allowed:        true,
+		Classification: class,
+		Release:        func() { m.release = true },
+	}, nil
 }
 
 func TestCompositeGate_Budget(t *testing.T) {
@@ -79,11 +90,11 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate := NewCompositeGate(
 			&mockDispatchGate{budget: 0.5},
 		)
-		allowed, release, err := gate.Acquire(context.Background(), nil)
-		assert.True(t, allowed)
+		res, err := gate.Acquire(context.Background(), nil)
+		assert.True(t, res.Allowed)
 		assert.NoError(t, err)
-		assert.NotNil(t, release)
-		release()
+		assert.NotNil(t, res.Release)
+		res.Release()
 	})
 
 	t.Run("All allowed", func(t *testing.T) {
@@ -91,12 +102,12 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate2 := &mockAttributeGate{allowed: true}
 		gate := NewCompositeGate(gate1, gate2)
 
-		allowed, release, err := gate.Acquire(context.Background(), nil)
-		assert.True(t, allowed)
+		res, err := gate.Acquire(context.Background(), nil)
+		assert.True(t, res.Allowed)
 		assert.NoError(t, err)
-		assert.NotNil(t, release)
+		assert.NotNil(t, res.Release)
 
-		release()
+		res.Release()
 		assert.True(t, gate1.release)
 		assert.True(t, gate2.release)
 	})
@@ -107,10 +118,10 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate3 := &mockAttributeGate{allowed: true}
 		gate := NewCompositeGate(gate1, gate2, gate3)
 
-		allowed, release, err := gate.Acquire(context.Background(), nil)
-		assert.False(t, allowed)
+		res, err := gate.Acquire(context.Background(), nil)
+		assert.False(t, res.Allowed)
 		assert.NoError(t, err)
-		assert.Nil(t, release)
+		assert.Nil(t, res.Release)
 
 		assert.Equal(t, 1, gate1.calls)
 		assert.Equal(t, 1, gate2.calls)
@@ -123,13 +134,35 @@ func TestCompositeGate_Acquire(t *testing.T) {
 		gate2 := &mockAttributeGate{err: errors.New("test error")}
 		gate := NewCompositeGate(gate1, gate2)
 
-		allowed, release, err := gate.Acquire(context.Background(), nil)
-		assert.False(t, allowed)
+		res, err := gate.Acquire(context.Background(), nil)
+		assert.False(t, res.Allowed)
 		assert.Error(t, err)
-		assert.Nil(t, release)
+		assert.Nil(t, res.Release)
 
 		assert.Equal(t, 1, gate1.calls)
 		assert.Equal(t, 1, gate2.calls)
 		assert.True(t, gate1.release) // gate1 was released because gate2 errored
+	})
+}
+
+func TestCompositeGate_Classification(t *testing.T) {
+	t.Run("Reserved aggregation", func(t *testing.T) {
+		gate1 := &mockAttributeGate{allowed: true, classification: api.ClassificationReserved}
+		gate2 := &mockAttributeGate{allowed: true, classification: api.ClassificationNone}
+		gate := NewCompositeGate(gate1, gate2)
+
+		res, err := gate.Acquire(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, api.ClassificationReserved, res.Classification)
+	})
+
+	t.Run("Overflow aggregation", func(t *testing.T) {
+		gate1 := &mockAttributeGate{allowed: true, classification: api.ClassificationReserved}
+		gate2 := &mockAttributeGate{allowed: true, classification: api.ClassificationOverflow}
+		gate := NewCompositeGate(gate1, gate2)
+
+		res, err := gate.Acquire(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, api.ClassificationOverflow, res.Classification)
 	})
 }

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -166,7 +166,13 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			prefix = "quota:"
 		}
 
-		return redisgate.NewRedisQuotaGate(client, attr, mode, limit, window, prefix), nil
+		gate := redisgate.NewRedisQuotaGate(client, attr, mode, limit, window, prefix)
+		gatingMode := redisgate.GatingMode(params["gating_mode"])
+		if gatingMode != "" {
+			gate.WithGatingMode(gatingMode)
+		}
+
+		return gate, nil
 
 	case "prometheus-saturation":
 		if f.prometheusURL == "" {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -315,13 +315,13 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 		// Per-attribute gating
 		var release func()
 		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			allowed, rel, err := attrGate.Acquire(ctx, msg.Attributes)
+			res, err := attrGate.Acquire(ctx, msg.Attributes)
 			if err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to acquire attribute quota")
 				msg.Nack()
 				return
 			}
-			if !allowed {
+			if !res.Allowed {
 				logger.V(logutil.DEBUG).Info("Quota exceeded, delaying Nack", "msgID", msg.ID, "delay", quotaExceededNackDelay)
 				go func() {
 					select {
@@ -333,7 +333,8 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 				}()
 				return
 			}
-			release = rel
+			release = res.Release
+			ir.Classification = res.Classification
 		} else {
 			release = func() {}
 		}

--- a/pkg/pubsub/pubsubimpl_test.go
+++ b/pkg/pubsub/pubsubimpl_test.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
 type mockAttributeGate struct {
@@ -17,9 +18,13 @@ type mockAttributeGate struct {
 }
 
 func (m *mockAttributeGate) Budget(ctx context.Context) float64 { return 1.0 }
-func (m *mockAttributeGate) Acquire(ctx context.Context, attrs map[string]string) (bool, func(), error) {
+func (m *mockAttributeGate) Acquire(ctx context.Context, attrs map[string]string) (pipeline.AcquireResult, error) {
 	m.acquireCalled = true
-	return m.allowed, func() { m.releaseCalled = true }, nil
+	return pipeline.AcquireResult{
+		Allowed:        m.allowed,
+		Classification: api.ClassificationReserved,
+		Release:        func() { m.releaseCalled = true },
+	}, nil
 }
 
 func TestProcessMessages_QuotaGating(t *testing.T) {

--- a/pkg/redis/quota_gate.go
+++ b/pkg/redis/quota_gate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/redis/go-redis/v9"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -20,24 +21,38 @@ const (
 	QuotaModeConcurrency QuotaMode = "concurrency"
 )
 
+type GatingMode string
+
+const (
+	GatingModeBlocking    GatingMode = "blocking"
+	GatingModeClassifying GatingMode = "classifying"
+)
+
 type RedisQuotaGate struct {
-	rdb       *redis.Client
-	attribute string
-	mode      QuotaMode
-	limit     int
-	window    time.Duration
-	prefix    string
+	rdb        *redis.Client
+	attribute  string
+	mode       QuotaMode
+	gatingMode GatingMode
+	limit      int
+	window     time.Duration
+	prefix     string
 }
 
 func NewRedisQuotaGate(client *redis.Client, attribute string, mode QuotaMode, limit int, window time.Duration, prefix string) *RedisQuotaGate {
 	return &RedisQuotaGate{
-		rdb:       client,
-		attribute: attribute,
-		mode:      mode,
-		limit:     limit,
-		window:    window,
-		prefix:    prefix,
+		rdb:        client,
+		attribute:  attribute,
+		mode:       mode,
+		gatingMode: GatingModeBlocking,
+		limit:      limit,
+		window:     window,
+		prefix:     prefix,
 	}
+}
+
+func (g *RedisQuotaGate) WithGatingMode(mode GatingMode) *RedisQuotaGate {
+	g.gatingMode = mode
+	return g
 }
 
 // Budget implements api.DispatchGate. For quota gates, we return 1.0 (open)
@@ -47,27 +62,45 @@ func (g *RedisQuotaGate) Budget(ctx context.Context) float64 {
 }
 
 // Acquire implements api.AttributeGate.
-func (g *RedisQuotaGate) Acquire(ctx context.Context, attributes map[string]string) (bool, func(), error) {
+func (g *RedisQuotaGate) Acquire(ctx context.Context, attributes map[string]string) (pipeline.AcquireResult, error) {
 	val, ok := attributes[g.attribute]
 	if !ok {
 		// If the attribute is missing, we allow it by default (or we could reject it).
-		// For now, let's allow it but log a warning.
-		return true, func() {}, nil
+		return pipeline.AcquireResult{Allowed: true, Classification: api.ClassificationNone}, nil
 	}
 
 	key := fmt.Sprintf("%s%s:%s", g.prefix, g.attribute, val)
 
+	var classification api.QuotaClassification
+	var release func()
+	var err error
+
 	switch g.mode {
 	case QuotaModeConcurrency:
-		return g.acquireConcurrency(ctx, key)
+		classification, release, err = g.acquireConcurrency(ctx, key)
 	case QuotaModeRateLimit:
-		return g.acquireRateLimit(ctx, key)
+		classification, release, err = g.acquireRateLimit(ctx, key)
 	default:
-		return true, func() {}, nil
+		return pipeline.AcquireResult{Allowed: true, Classification: api.ClassificationNone}, nil
 	}
+
+	if err != nil {
+		return pipeline.AcquireResult{}, err
+	}
+
+	allowed := true
+	if g.gatingMode == GatingModeBlocking {
+		allowed = (classification == api.ClassificationReserved)
+	}
+
+	return pipeline.AcquireResult{
+		Allowed:        allowed,
+		Classification: classification,
+		Release:        release,
+	}, nil
 }
 
-func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (bool, func(), error) {
+func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (api.QuotaClassification, func(), error) {
 	// Use Lua script for atomic check and increment
 	script := `
 		local current = redis.call("GET", KEYS[1])
@@ -88,11 +121,11 @@ func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (bo
 
 	res, err := g.rdb.Eval(ctx, script, []string{key}, g.limit, ttl).Result()
 	if err != nil {
-		return false, nil, err
+		return api.ClassificationNone, nil, err
 	}
 
 	if res.(int64) == 0 {
-		return false, nil, nil
+		return api.ClassificationOverflow, nil, nil
 	}
 
 	release := func() {
@@ -109,10 +142,10 @@ func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (bo
 		}
 	}
 
-	return true, release, nil
+	return api.ClassificationReserved, release, nil
 }
 
-func (g *RedisQuotaGate) acquireRateLimit(ctx context.Context, key string) (bool, func(), error) {
+func (g *RedisQuotaGate) acquireRateLimit(ctx context.Context, key string) (api.QuotaClassification, func(), error) {
 	// Sliding window rate limit using Sorted Set
 	now := time.Now().UnixNano()
 	windowNano := g.window.Nanoseconds()
@@ -136,12 +169,12 @@ func (g *RedisQuotaGate) acquireRateLimit(ctx context.Context, key string) (bool
 
 	res, err := g.rdb.Eval(ctx, script, []string{key}, min, g.limit, now, ttl).Result()
 	if err != nil {
-		return false, nil, err
+		return api.ClassificationNone, nil, err
 	}
 
 	if res.(int64) == 0 {
-		return false, nil, nil
+		return api.ClassificationOverflow, nil, nil
 	}
 
-	return true, func() {}, nil
+	return api.ClassificationReserved, func() {}, nil
 }

--- a/pkg/redis/quota_gate_test.go
+++ b/pkg/redis/quota_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -21,33 +22,33 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed
-	allowed, release, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed {
-		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed, err)
+	res, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res.Allowed || res.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res.Allowed, res.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed
-	allowed2, release2, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed2 {
-		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed2, err)
+	res2, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res2.Allowed || res2.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res2.Allowed, res2.Classification, err)
 	}
 
 	// 3rd acquisition - Denied
-	allowed3, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || allowed3 {
-		t.Fatalf("Expected allowed=false, got %v, err: %v", allowed3, err)
+	res3, err := gate.Acquire(ctx, attrs)
+	if err != nil || res3.Allowed || res3.Classification != api.ClassificationOverflow {
+		t.Fatalf("Expected allowed=false overflow, got %v %v, err: %v", res3.Allowed, res3.Classification, err)
 	}
 
 	// Release one
-	release()
+	res.Release()
 
 	// 4th acquisition - Allowed again
-	allowed4, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed4 {
-		t.Fatalf("Expected allowed=true after release, got %v, err: %v", allowed4, err)
+	res4, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res4.Allowed || res4.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved after release, got %v %v, err: %v", res4.Allowed, res4.Classification, err)
 	}
 
-	release2()
+	res2.Release()
 }
 
 func TestRedisQuotaGate_RateLimit(t *testing.T) {
@@ -63,30 +64,56 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed
-	allowed, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed {
-		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed, err)
+	res, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res.Allowed || res.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res.Allowed, res.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed
-	allowed2, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed2 {
-		t.Fatalf("Expected allowed=true, got %v, err: %v", allowed2, err)
+	res2, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res2.Allowed || res2.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res2.Allowed, res2.Classification, err)
 	}
 
 	// 3rd acquisition - Denied
-	allowed3, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || allowed3 {
-		t.Fatalf("Expected allowed=false, got %v, err: %v", allowed3, err)
+	res3, err := gate.Acquire(ctx, attrs)
+	if err != nil || res3.Allowed || res3.Classification != api.ClassificationOverflow {
+		t.Fatalf("Expected allowed=false overflow, got %v %v, err: %v", res3.Allowed, res3.Classification, err)
 	}
 
 	// Wait for window to pass
 	time.Sleep(1100 * time.Millisecond)
 
 	// 4th acquisition - Allowed again
-	allowed4, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed4 {
-		t.Fatalf("Expected allowed=true after window, got %v, err: %v", allowed4, err)
+	res4, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res4.Allowed || res4.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved after window, got %v %v, err: %v", res4.Allowed, res4.Classification, err)
+	}
+}
+
+func TestRedisQuotaGate_Classifying(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = rdb.Close() }()
+
+	// 1 request per 10 second, but Classifying mode
+	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeRateLimit, 1, 10*time.Second, "quota:").
+		WithGatingMode(GatingModeClassifying)
+
+	ctx := context.Background()
+	attrs := map[string]string{"userid": "user1"}
+
+	// 1st acquisition - Allowed and Reserved
+	res, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res.Allowed || res.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res.Allowed, res.Classification, err)
+	}
+
+	// 2nd acquisition - Allowed but Overflow
+	res2, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res2.Allowed || res2.Classification != api.ClassificationOverflow {
+		t.Fatalf("Expected allowed=true overflow, got %v %v, err: %v", res2.Allowed, res2.Classification, err)
 	}
 }
 
@@ -101,8 +128,8 @@ func TestRedisQuotaGate_MissingAttribute(t *testing.T) {
 	ctx := context.Background()
 	attrs := map[string]string{"teamid": "team1"} // missing 'userid'
 
-	allowed, _, err := gate.Acquire(ctx, attrs)
-	if err != nil || !allowed {
-		t.Fatalf("Expected allowed=true for missing attribute, got %v, err: %v", allowed, err)
+	res, err := gate.Acquire(ctx, attrs)
+	if err != nil || !res.Allowed || res.Classification != api.ClassificationNone {
+		t.Fatalf("Expected allowed=true none for missing attribute, got %v %v, err: %v", res.Allowed, res.Classification, err)
 	}
 }

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -259,7 +259,7 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		// Per-attribute gating
 		var release func()
 		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			allowed, rel, err := attrGate.Acquire(ctx, rview.ReqMetadata())
+			res, err := attrGate.Acquire(ctx, rview.ReqMetadata())
 			if err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to acquire attribute quota")
 				// Re-enqueue the message if acquisition fails
@@ -267,13 +267,14 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 				r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
 				continue
 			}
-			if !allowed {
+			if !res.Allowed {
 				// Re-enqueue the message (wait for quota)
 				member, _ := json.Marshal(ir)
 				r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
 				continue
 			}
-			release = rel
+			release = res.Release
+			ir.Classification = res.Classification
 		} else {
 			release = func() {}
 		}

--- a/test/integration/gate_factory_redis_test.go
+++ b/test/integration/gate_factory_redis_test.go
@@ -41,29 +41,29 @@ func TestGateFactory_RedisQuota_ConcurrencyParsing(t *testing.T) {
 	attrs := map[string]string{"model": "gpt-4"}
 
 	// Acquire twice (limit=2) — both should succeed.
-	ok1, rel1, err := attrGate.Acquire(ctx, attrs)
+	res1, err := attrGate.Acquire(ctx, attrs)
 	require.NoError(t, err)
-	assert.True(t, ok1)
+	assert.True(t, res1.Allowed)
 
-	ok2, rel2, err := attrGate.Acquire(ctx, attrs)
+	res2, err := attrGate.Acquire(ctx, attrs)
 	require.NoError(t, err)
-	assert.True(t, ok2)
+	assert.True(t, res2.Allowed)
 
 	// Third acquire — should fail.
-	ok3, _, err := attrGate.Acquire(ctx, attrs)
+	res3, err := attrGate.Acquire(ctx, attrs)
 	require.NoError(t, err)
-	assert.False(t, ok3, "Third acquire should be denied (limit=2)")
+	assert.False(t, res3.Allowed, "Third acquire should be denied (limit=2)")
 
 	// Release one and retry.
-	rel1()
-	ok4, rel4, err := attrGate.Acquire(ctx, attrs)
+	res1.Release()
+	res4, err := attrGate.Acquire(ctx, attrs)
 	require.NoError(t, err)
-	assert.True(t, ok4, "Should succeed after release")
+	assert.True(t, res4.Allowed, "Should succeed after release")
 
 	// Cleanup.
-	rel2()
-	if rel4 != nil {
-		rel4()
+	res2.Release()
+	if res4.Release != nil {
+		res4.Release()
 	}
 }
 
@@ -88,15 +88,15 @@ func TestGateFactory_RedisQuota_RateLimitParsing(t *testing.T) {
 	attrs := map[string]string{"userid": "alice"}
 
 	for i := 0; i < 3; i++ {
-		ok, _, err := attrGate.Acquire(ctx, attrs)
+		res, err := attrGate.Acquire(ctx, attrs)
 		require.NoError(t, err)
-		assert.True(t, ok, "Request %d should be allowed", i+1)
+		assert.True(t, res.Allowed, "Request %d should be allowed", i+1)
 	}
 
 	// Fourth should be rate limited.
-	ok4, _, err := attrGate.Acquire(ctx, attrs)
+	res4, err := attrGate.Acquire(ctx, attrs)
 	require.NoError(t, err)
-	assert.False(t, ok4, "Fourth request should be rate limited")
+	assert.False(t, res4.Allowed, "Fourth request should be rate limited")
 }
 
 // TestGateFactory_RedisQuota_MissingParams validates error handling for missing
@@ -133,11 +133,11 @@ func TestGateFactory_RedisQuota_DefaultParams(t *testing.T) {
 
 	// Default attribute is "userid", default mode is "rate-limit".
 	ctx := context.Background()
-	ok1, _, err := attrGate.Acquire(ctx, map[string]string{"userid": "bob"})
+	res1, err := attrGate.Acquire(ctx, map[string]string{"userid": "bob"})
 	require.NoError(t, err)
-	assert.True(t, ok1)
+	assert.True(t, res1.Allowed)
 
-	ok2, _, err := attrGate.Acquire(ctx, map[string]string{"userid": "bob"})
+	res2, err := attrGate.Acquire(ctx, map[string]string{"userid": "bob"})
 	require.NoError(t, err)
-	assert.False(t, ok2, "Second acquire should be rate limited with default params")
+	assert.False(t, res2.Allowed, "Second acquire should be rate limited with default params")
 }

--- a/test/integration/sortedset_quota_gate_test.go
+++ b/test/integration/sortedset_quota_gate_test.go
@@ -60,10 +60,10 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	var ir1 api.InternalRequest
 	require.NoError(t, json.Unmarshal([]byte(results[0].Member.(string)), &ir1))
 
-	allowed, release, err := gate.Acquire(ctx, ir1.PublicRequest.ReqMetadata())
+	res1, err := gate.Acquire(ctx, ir1.PublicRequest.ReqMetadata())
 	require.NoError(t, err)
-	assert.True(t, allowed, "First request should be allowed")
-	require.NotNil(t, release)
+	assert.True(t, res1.Allowed, "First request should be allowed")
+	require.NotNil(t, res1.Release)
 
 	// Pop second message — Acquire should be denied (concurrency limit reached).
 	results2, err := rdb.ZPopMin(ctx, queueName, 1).Result()
@@ -73,9 +73,9 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	var ir2 api.InternalRequest
 	require.NoError(t, json.Unmarshal([]byte(results2[0].Member.(string)), &ir2))
 
-	allowed2, _, err := gate.Acquire(ctx, ir2.PublicRequest.ReqMetadata())
+	res2, err := gate.Acquire(ctx, ir2.PublicRequest.ReqMetadata())
 	require.NoError(t, err)
-	assert.False(t, allowed2, "Second request should be denied while first is in-flight")
+	assert.False(t, res2.Allowed, "Second request should be denied while first is in-flight")
 
 	// Re-enqueue denied message (as sortedset_impl does).
 	err = rdb.ZAdd(ctx, queueName, goredis.Z{
@@ -84,7 +84,7 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Release the first request (simulates resultWorker calling release).
-	release()
+	res1.Release()
 
 	// Now the second message should be acquirable.
 	results3, err := rdb.ZPopMin(ctx, queueName, 1).Result()
@@ -95,11 +95,11 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(results3[0].Member.(string)), &ir3))
 	assert.Equal(t, "msg-2", ir3.PublicRequest.ReqID())
 
-	allowed3, release3, err := gate.Acquire(ctx, ir3.PublicRequest.ReqMetadata())
+	res3, err := gate.Acquire(ctx, ir3.PublicRequest.ReqMetadata())
 	require.NoError(t, err)
-	assert.True(t, allowed3, "Second request should be allowed after first was released")
-	if release3 != nil {
-		release3()
+	assert.True(t, res3.Allowed, "Second request should be allowed after first was released")
+	if res3.Release != nil {
+		res3.Release()
 	}
 }
 
@@ -127,20 +127,20 @@ func TestSortedSetQuotaGate_RateLimitRequeue(t *testing.T) {
 	)
 
 	// First acquire — allowed.
-	allowed, _, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
+	res, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
 	require.NoError(t, err)
-	assert.True(t, allowed)
+	assert.True(t, res.Allowed)
 
 	// Second acquire — denied (rate limit hit).
-	allowed2, _, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
+	res2, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
 	require.NoError(t, err)
-	assert.False(t, allowed2, "Should be rate limited")
+	assert.False(t, res2.Allowed, "Should be rate limited")
 
 	// Wait for window to reset.
 	time.Sleep(2100 * time.Millisecond)
 
 	// Third acquire — allowed again.
-	allowed3, _, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
+	res3, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
 	require.NoError(t, err)
-	assert.True(t, allowed3, "Should be allowed after rate limit window resets")
+	assert.True(t, res3.Allowed, "Should be allowed after rate limit window resets")
 }


### PR DESCRIPTION
## What does this PR do?
Adding Classifier mode to quota gating (not blocking, just marking request as "Reserved" or "Overflow"

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ X] Unit tests added/updated
- [X ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
