### PR TITLE
fix: close GateFactory redis clients on shutdown

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,6 +83,11 @@ func main() {
 	printAllFlags(setupLog)
 	// Create Gate Factory for per-queue gate instantiation
 	gateFactory := flowcontrol.NewGateFactoryWithCacheTTL(*prometheusURL, *prometheusCacheTTL)
+	defer func() {
+		if err := gateFactory.Close(); err != nil {
+			setupLog.Error(err, "Failed to close gate factory")
+		}
+	}()
 
 	var policy pipeline.RequestMergePolicy
 	switch requestMergePolicy {

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -58,6 +58,17 @@ func NewGateFactoryWithCacheTTL(prometheusURL string, cacheTTL time.Duration) *G
 	}
 }
 
+// Close closes all Redis clients created by this factory.
+func (f *GateFactory) Close() error {
+	var firstErr error
+	for addr, client := range f.redisClients {
+		if err := client.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("failed to close Redis client for %s: %w", addr, err)
+		}
+	}
+	return firstErr
+}
+
 // CreateGate creates a DispatchGate based on the gate type and parameters.
 // Supported gate types:
 //   - "constant": Always returns budget 1.0 (fully open)


### PR DESCRIPTION
## What does this PR do?

Add `Close()` method to `GateFactory` and defer it in `main()` so cached Redis clients are properly closed on shutdown.

## Why is this change needed?

`GateFactory` caches `go-redis` clients in a map but never closes them, leaking connections when the process exits.

## How was this tested?

- [x] Manual testing performed
- [x] Linters pass (`make lint`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)