### PR TITLE
feat: simplified config in Helm

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -26,26 +26,34 @@ spec:
           {{- if .Values.ap.redis.enabled }}
           {{- if eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset" }}
           - --message-queue-impl=redis-sortedset
+          {{- if .Values.ap.redis.queuesConfig }}
+          - --redis.ss.queues-config={{ .Values.ap.redis.queuesConfig | toJson }}
+          {{- else }}
           - --redis.ss.igw-base-url={{ .Values.ap.igwBaseURL }}
           - --redis.ss.request-path-url
           - "{{ .Values.ap.redis.requestPathURL }}"
           - --redis.ss.request-queue-name
           - "{{ .Values.ap.redis.requestQueueName | default "request-sortedset" }}"
+          {{- if .Values.ap.redis.gateType }}
+          - --redis.ss.gate-type={{ .Values.ap.redis.gateType }}
+          - --redis.ss.gate-params={{ include "async-processor.gateParamsJson" . }}
+          {{- end }}
+          {{- end }}
           - --redis.ss.result-queue-name
           - "{{ .Values.ap.redis.resultQueueName | default "result-list" }}"
           - --redis.ss.poll-interval-ms
           - "{{ .Values.ap.redis.pollIntervalMs | default 1000 }}"
           - --redis.ss.batch-size
           - "{{ .Values.ap.redis.batchSize | default 10 }}"
-          {{- if .Values.ap.redis.gateType }}
-          - --redis.ss.gate-type={{ .Values.ap.redis.gateType }}
-          - --redis.ss.gate-params={{ include "async-processor.gateParamsJson" . }}
-          {{- end }}
           {{- else }}
           - --message-queue-impl=redis-pubsub
+          {{- if .Values.ap.redis.queuesConfig }}
+          - --redis.queues-config={{ .Values.ap.redis.queuesConfig | toJson }}
+          {{- else }}
           - --redis.igw-base-url={{ .Values.ap.igwBaseURL }}
           - --redis.request-path-url
           - "{{ .Values.ap.redis.requestPathURL }}"
+          {{- end }}
           {{- end }}
           {{- else if .Values.ap.gcpPubSub.enabled }}
           - --message-queue-impl=gcp-pubsub

--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -26,8 +26,12 @@ spec:
           {{- if .Values.ap.redis.enabled }}
           {{- if eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset" }}
           - --message-queue-impl=redis-sortedset
+          {{- if and .Values.ap.redis.queuesConfig .Values.ap.redis.gateType }}
+          {{- fail "Cannot set both queuesConfig and gateType. Use queuesConfig with per-queue gate_type instead." }}
+          {{- end }}
           {{- if .Values.ap.redis.queuesConfig }}
-          - --redis.ss.queues-config={{ .Values.ap.redis.queuesConfig | toJson }}
+          - --redis.ss.queues-config
+          - {{ .Values.ap.redis.queuesConfig | toJson | quote }}
           {{- else }}
           - --redis.ss.igw-base-url={{ .Values.ap.igwBaseURL }}
           - --redis.ss.request-path-url
@@ -48,7 +52,8 @@ spec:
           {{- else }}
           - --message-queue-impl=redis-pubsub
           {{- if .Values.ap.redis.queuesConfig }}
-          - --redis.queues-config={{ .Values.ap.redis.queuesConfig | toJson }}
+          - --redis.queues-config
+          - {{ .Values.ap.redis.queuesConfig | toJson | quote }}
           {{- else }}
           - --redis.igw-base-url={{ .Values.ap.igwBaseURL }}
           - --redis.request-path-url

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -51,7 +51,7 @@ ap:
     #     gate_type: "prometheus-saturation"
     #     gate_params:
     #       pool: "pool-1"
-    #       threshold: "0.7"
+    #       threshold: 0.7
     #   - queue_name: "queue-2"
     #     request_path_url: "/v1/completions"
     #     igw_base_url: "http://igw:80"

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -40,6 +40,26 @@ ap:
     batchSize: 10
     gateType: ""
     gateParams: {}
+    # Full multi-queue configuration (overrides single-queue fields above).
+    # For redis-sortedset, each entry supports its own gate_type and gate_params.
+    # For redis-pubsub, only queue_name, inference_objective, request_path_url, igw_base_url are used.
+    # queuesConfig:
+    #   - queue_name: "queue-1"
+    #     inference_objective: ""
+    #     request_path_url: "/v1/completions"
+    #     igw_base_url: "http://igw:80"
+    #     gate_type: "prometheus-saturation"
+    #     gate_params:
+    #       pool: "pool-1"
+    #       threshold: "0.7"
+    #   - queue_name: "queue-2"
+    #     request_path_url: "/v1/completions"
+    #     igw_base_url: "http://igw:80"
+    #     gate_type: "redis-quota"
+    #     gate_params:
+    #       address: "redis:6379"
+    #       limit: "5"
+    queuesConfig: []
   # PodMonitor for model server metrics relabeling.
   # Creates a PodMonitor that scrapes vLLM metrics and relabels
   # the inference_pool pod label into scraped metrics.

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -132,8 +132,8 @@ helm install async-processor ${ASYNC_REPO}/charts/async-processor/ \
 
 The values file (`docs/guides/e2e-deploy/async-processor-values.yaml`) configures:
 - Image: `ghcr.io/llm-d-incubation/llm-d-async:4a1b0a4`
-- Queue: Redis sorted-set with `redis.url` set directly (chart creates the Secret)
-- Gate: `prometheus-budget` with pool=`optimized-baseline`, max_concurrency=100, baseline=0.05
+- Queue: Redis sorted-set with `redis.url` set directly (chart creates the Secret), configured via `queuesConfig`
+- Gate: `prometheus-budget` with pool=`optimized-baseline`, max_concurrency=100, baseline=0.05 (per-queue)
 - Prometheus URL pointing to the cluster's `llmd-kube-prometheus-stack-prometheus` service
 - `modelServerMonitor.enabled: true` — creates a PodMonitor that relabels the `inference_pool`
   pod label into vLLM metrics (required for the dispatch budget gate fallback)

--- a/docs/guides/e2e-deploy/async-processor-values.yaml
+++ b/docs/guides/e2e-deploy/async-processor-values.yaml
@@ -14,16 +14,18 @@ ap:
   redis:
     enabled: true
     url: "redis://redis-master.redis.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "request-sortedset"
     resultQueueName: "result-list"
     pollIntervalMs: 1000
     batchSize: 10
-    gateType: "prometheus-budget"
-    gateParams:
-      pool: "optimized-baseline"
-      max_concurrency: "100"
-      baseline: "0.05"
+    queuesConfig:
+      - queue_name: "request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://llm-d-inference-gateway-istio:80"
+        gate_type: "prometheus-budget"
+        gate_params:
+          pool: "optimized-baseline"
+          max_concurrency: "100"
+          baseline: "0.05"
   modelServerMonitor:
     enabled: true
     selector:

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -35,6 +35,7 @@ var (
 	retryQueueName  = flag.String("redis.retry-queue-name", "retry-sortedset", "name of the Redis sorted set for retry messages")
 	resultQueueName = flag.String("redis.result-queue-name", "result-queue", "name of the Redis channel for result messages")
 
+	queuesConfig     = flag.String("redis.queues-config", "", "Inline JSON queues configuration. Mutually exclusive with redis.queues-config-file and redis.igw-base-url flags.")
 	queuesConfigFile = flag.String("redis.queues-config-file", "", "Queues Configuration file. Mutually exclusive with redis.igw-base-url, redis.request-queue-name, redis.request-path-url and redis.inference-objective flags. See documentation about syntax")
 )
 
@@ -132,12 +133,15 @@ func NewRedisMQFlow() (*RedisMQFlow, error) {
 	}
 	rdb := redis.NewClient(opts)
 	var configs []QueueConfig
-	if *queuesConfigFile != "" {
+	if *queuesConfig != "" {
+		if err := json.Unmarshal([]byte(*queuesConfig), &configs); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal inline queues config: %w", err)
+		}
+	} else if *queuesConfigFile != "" {
 		data, err := os.ReadFile(*queuesConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read queues config file: %w", err)
 		}
-
 		if err := json.Unmarshal(data, &configs); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal queues config: %w", err)
 		}

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -35,7 +35,7 @@ var (
 	retryQueueName  = flag.String("redis.retry-queue-name", "retry-sortedset", "name of the Redis sorted set for retry messages")
 	resultQueueName = flag.String("redis.result-queue-name", "result-queue", "name of the Redis channel for result messages")
 
-	queuesConfig     = flag.String("redis.queues-config", "", "Inline JSON queues configuration. Mutually exclusive with redis.queues-config-file and redis.igw-base-url flags.")
+	queuesConfig     = flag.String("redis.queues-config", "", "Inline JSON queues configuration. Takes precedence over redis.queues-config-file and single-queue flags.")
 	queuesConfigFile = flag.String("redis.queues-config-file", "", "Queues Configuration file. Mutually exclusive with redis.igw-base-url, redis.request-queue-name, redis.request-path-url and redis.inference-objective flags. See documentation about syntax")
 )
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -57,7 +58,18 @@ func (m *StringMap) UnmarshalJSON(data []byte) error {
 	}
 	result := make(map[string]string, len(raw))
 	for k, v := range raw {
-		result[k] = fmt.Sprintf("%v", v)
+		switch val := v.(type) {
+		case string:
+			result[k] = val
+		case float64:
+			result[k] = strconv.FormatFloat(val, 'f', -1, 64)
+		case bool:
+			result[k] = strconv.FormatBool(val)
+		case nil:
+			result[k] = ""
+		default:
+			return fmt.Errorf("gate_params key %q: unsupported value type %T (only strings, numbers, and booleans are allowed)", k, v)
+		}
 	}
 	*m = result
 	return nil

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -26,6 +26,7 @@ var (
 	ssInferenceObjective = flag.String("redis.ss.inference-objective", "", "Inference objective header")
 	ssRequestQueueName   = flag.String("redis.ss.request-queue-name", "request-sortedset", "Request sorted set name")
 	ssResultQueueName    = flag.String("redis.ss.result-queue-name", "result-list", "Result list name")
+	ssQueuesConfig       = flag.String("redis.ss.queues-config", "", "Inline JSON queues configuration")
 	ssQueuesConfigFile   = flag.String("redis.ss.queues-config-file", "", "Multiple queues config file")
 	ssPollIntervalMs     = flag.Int("redis.ss.poll-interval-ms", 1000, "Poll interval in milliseconds")
 	ssBatchSize          = flag.Int("redis.ss.batch-size", 10, "Number of messages to process per poll")
@@ -45,13 +46,30 @@ func parseGateParams(s string) map[string]string {
 	return m
 }
 
+// StringMap is a map[string]string that tolerates non-string JSON values
+// by converting them to their string representation during unmarshaling.
+type StringMap map[string]string
+
+func (m *StringMap) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	*m = result
+	return nil
+}
+
 type queueConfig struct {
-	QueueName          string            `json:"queue_name"`
-	InferenceObjective string            `json:"inference_objective"`
-	RequestPathURL     string            `json:"request_path_url"`
-	IGWBaseURL         string            `json:"igw_base_url"`
-	GateType           string            `json:"gate_type"`
-	GateParams         map[string]string `json:"gate_params,omitempty"`
+	QueueName          string    `json:"queue_name"`
+	InferenceObjective string    `json:"inference_objective"`
+	RequestPathURL     string    `json:"request_path_url"`
+	IGWBaseURL         string    `json:"igw_base_url"`
+	GateType           string    `json:"gate_type"`
+	GateParams         StringMap `json:"gate_params,omitempty"`
 }
 
 type requestChannelData struct {
@@ -142,17 +160,24 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) (*RedisSortedSetFlow, error)
 	return r, nil
 }
 
+func parseQueueConfigs(data []byte) ([]queueConfig, error) {
+	var configs []queueConfig
+	if err := json.Unmarshal(data, &configs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal queues config: %w", err)
+	}
+	return configs, nil
+}
+
 func loadQueueConfigs() ([]queueConfig, error) {
+	if *ssQueuesConfig != "" {
+		return parseQueueConfigs([]byte(*ssQueuesConfig))
+	}
 	if *ssQueuesConfigFile != "" {
 		data, err := os.ReadFile(*ssQueuesConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}
-		var configs []queueConfig
-		if err := json.Unmarshal(data, &configs); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal config file: %w", err)
-		}
-		return configs, nil
+		return parseQueueConfigs(data)
 	}
 	return []queueConfig{{
 		QueueName:          *ssRequestQueueName,

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -36,6 +36,137 @@ func envelopeJSON(rm api.RequestMessage) string {
 	return string(b)
 }
 
+func TestParseQueueConfigs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantErr  bool
+		validate func(t *testing.T, configs []queueConfig)
+	}{
+		{
+			name:    "single queue with string gate params",
+			input:   `[{"queue_name":"q1","gate_type":"redis","gate_params":{"address":"localhost:6379"}}]`,
+			wantLen: 1,
+			validate: func(t *testing.T, configs []queueConfig) {
+				if configs[0].QueueName != "q1" {
+					t.Errorf("expected q1, got %s", configs[0].QueueName)
+				}
+				if configs[0].GateParams["address"] != "localhost:6379" {
+					t.Errorf("expected localhost:6379, got %s", configs[0].GateParams["address"])
+				}
+			},
+		},
+		{
+			name:    "numeric gate params coerced to strings",
+			input:   `[{"queue_name":"q1","gate_type":"prometheus-saturation","gate_params":{"threshold":0.7,"pool":"p1"}}]`,
+			wantLen: 1,
+			validate: func(t *testing.T, configs []queueConfig) {
+				if configs[0].GateParams["threshold"] != "0.7" {
+					t.Errorf("expected '0.7', got '%s'", configs[0].GateParams["threshold"])
+				}
+				if configs[0].GateParams["pool"] != "p1" {
+					t.Errorf("expected 'p1', got '%s'", configs[0].GateParams["pool"])
+				}
+			},
+		},
+		{
+			name:    "multiple queues",
+			input:   `[{"queue_name":"q1","igw_base_url":"http://igw:80"},{"queue_name":"q2","gate_type":"redis","gate_params":{"address":"redis:6379"}}]`,
+			wantLen: 2,
+			validate: func(t *testing.T, configs []queueConfig) {
+				if configs[0].QueueName != "q1" {
+					t.Errorf("expected q1, got %s", configs[0].QueueName)
+				}
+				if configs[1].QueueName != "q2" {
+					t.Errorf("expected q2, got %s", configs[1].QueueName)
+				}
+			},
+		},
+		{
+			name:    "no gate params",
+			input:   `[{"queue_name":"q1","request_path_url":"/v1/completions"}]`,
+			wantLen: 1,
+			validate: func(t *testing.T, configs []queueConfig) {
+				if len(configs[0].GateParams) != 0 {
+					t.Errorf("expected empty gate params, got %v", configs[0].GateParams)
+				}
+			},
+		},
+		{
+			name:    "invalid json",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configs, err := parseQueueConfigs([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseQueueConfigs() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(configs) != tt.wantLen {
+				t.Fatalf("expected %d configs, got %d", tt.wantLen, len(configs))
+			}
+			if tt.validate != nil {
+				tt.validate(t, configs)
+			}
+		})
+	}
+}
+
+func TestStringMapUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:     "string values",
+			input:    `{"key":"value"}`,
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name:     "numeric float",
+			input:    `{"threshold":0.7}`,
+			expected: map[string]string{"threshold": "0.7"},
+		},
+		{
+			name:     "integer",
+			input:    `{"limit":5}`,
+			expected: map[string]string{"limit": "5"},
+		},
+		{
+			name:     "boolean",
+			input:    `{"enabled":true}`,
+			expected: map[string]string{"enabled": "true"},
+		},
+		{
+			name:     "mixed types",
+			input:    `{"pool":"p1","threshold":0.8,"limit":100,"active":true}`,
+			expected: map[string]string{"pool": "p1", "threshold": "0.8", "limit": "100", "active": "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m StringMap
+			if err := json.Unmarshal([]byte(tt.input), &m); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			for k, want := range tt.expected {
+				if got := m[k]; got != want {
+					t.Errorf("key %q: expected %q, got %q", k, want, got)
+				}
+			}
+		})
+	}
+}
+
 func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -150,6 +150,11 @@ func TestStringMapUnmarshal(t *testing.T) {
 			input:    `{"pool":"p1","threshold":0.8,"limit":100,"active":true}`,
 			expected: map[string]string{"pool": "p1", "threshold": "0.8", "limit": "100", "active": "true"},
 		},
+		{
+			name:     "null becomes empty string",
+			input:    `{"key":null}`,
+			expected: map[string]string{"key": ""},
+		},
 	}
 
 	for _, tt := range tests {
@@ -162,6 +167,24 @@ func TestStringMapUnmarshal(t *testing.T) {
 				if got := m[k]; got != want {
 					t.Errorf("key %q: expected %q, got %q", k, want, got)
 				}
+			}
+		})
+	}
+}
+
+func TestStringMapRejectsNonScalar(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"nested object", `{"key":{"nested":"value"}}`},
+		{"array", `{"key":[1,2,3]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m StringMap
+			if err := json.Unmarshal([]byte(tt.input), &m); err == nil {
+				t.Error("expected error for non-scalar value, got nil")
 			}
 		})
 	}

--- a/test/e2e/helm/budget.yaml
+++ b/test/e2e/helm/budget.yaml
@@ -12,15 +12,17 @@ ap:
   redis:
     enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "budget-request-sortedset"
     resultQueueName: "budget-result-list"
     pollIntervalMs: 500
     batchSize: 10
-    gateType: "prometheus-budget"
-    gateParams:
-      pool: "e2e-pool"
-      max_concurrency: "1"
-      baseline: "0.05"
+    queuesConfig:
+      - queue_name: "budget-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "prometheus-budget"
+        gate_params:
+          pool: "e2e-pool"
+          max_concurrency: "1"
+          baseline: "0.05"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/composite.yaml
+++ b/test/e2e/helm/composite.yaml
@@ -12,13 +12,15 @@ ap:
   redis:
     enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "composite-request-sortedset"
     resultQueueName: "composite-result-list"
     pollIntervalMs: 500
     batchSize: 10
-    gateType: "composite"
-    gateParams:
-      gates: '[{"gate_type":"prometheus-saturation","gate_params":{"pool":"e2e-pool","threshold":"0.8"}},{"gate_type":"redis-quota","gate_params":{"address":"redis.e2e-integration.svc.cluster.local:6379","attribute":"userid","mode":"concurrency","limit":"1","prefix":"test-composite-quota:"}}]'
+    queuesConfig:
+      - queue_name: "composite-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "composite"
+        gate_params:
+          gates: '[{"gate_type":"prometheus-saturation","gate_params":{"pool":"e2e-pool","threshold":"0.8"}},{"gate_type":"redis-quota","gate_params":{"address":"redis.e2e-integration.svc.cluster.local:6379","attribute":"userid","mode":"concurrency","limit":"1","prefix":"test-composite-quota:"}}]'
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/integration.yaml
+++ b/test/e2e/helm/integration.yaml
@@ -11,10 +11,12 @@ ap:
   redis:
     enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "integration-request-sortedset"
     resultQueueName: "integration-result-list"
     pollIntervalMs: 500
     batchSize: 10
+    queuesConfig:
+      - queue_name: "integration-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/quota.yaml
+++ b/test/e2e/helm/quota.yaml
@@ -11,16 +11,18 @@ ap:
   redis:
     enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "quota-request-sortedset"
     resultQueueName: "quota-result-list"
     pollIntervalMs: 500
     batchSize: 10
-    gateType: "redis-quota"
-    gateParams:
-      address: "redis.e2e-integration.svc.cluster.local:6379"
-      attribute: "userid"
-      mode: "concurrency"
-      limit: "1"
+    queuesConfig:
+      - queue_name: "quota-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "redis-quota"
+        gate_params:
+          address: "redis.e2e-integration.svc.cluster.local:6379"
+          attribute: "userid"
+          mode: "concurrency"
+          limit: "1"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/redis-gate.yaml
+++ b/test/e2e/helm/redis-gate.yaml
@@ -11,13 +11,15 @@ ap:
   redis:
     enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "redis-gate-request-sortedset"
     resultQueueName: "redis-gate-result-list"
     pollIntervalMs: 500
     batchSize: 10
-    gateType: "redis"
-    gateParams:
-      address: "redis.e2e-integration.svc.cluster.local:6379"
+    queuesConfig:
+      - queue_name: "redis-gate-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "redis"
+        gate_params:
+          address: "redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/saturation.yaml
+++ b/test/e2e/helm/saturation.yaml
@@ -12,14 +12,16 @@ ap:
   redis:
     enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "saturation-request-sortedset"
     resultQueueName: "saturation-result-list"
     pollIntervalMs: 500
     batchSize: 10
-    gateType: "prometheus-saturation"
-    gateParams:
-      pool: "e2e-pool"
-      threshold: "0.7"
+    queuesConfig:
+      - queue_name: "saturation-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "prometheus-saturation"
+        gate_params:
+          pool: "e2e-pool"
+          threshold: "0.7"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/yaml/async-processor-composite.yaml
+++ b/test/e2e/yaml/async-processor-composite.yaml
@@ -1,22 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: async-processor-composite-config
-  namespace: e2e-test
-data:
-  queues.json: |
-    [
-      {
-        "queue_name": "composite-request-sortedset",
-        "igw_base_url": "http://igw-mock.e2e-test.svc.cluster.local:80",
-        "request_path_url": "/v1/completions",
-        "gate_type": "composite",
-        "gate_params": {
-          "gates": "[{\"gate_type\":\"prometheus-saturation\",\"gate_params\":{\"pool\":\"e2e-pool\",\"threshold\":\"0.8\"}},{\"gate_type\":\"redis-quota\",\"gate_params\":{\"address\":\"redis.e2e-test.svc.cluster.local:6379\",\"attribute\":\"userid\",\"mode\":\"concurrency\",\"limit\":\"1\",\"prefix\":\"test-composite-quota:\"}}]"
-        }
-      }
-    ]
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,15 +23,8 @@ spec:
         args:
         - --message-queue-impl=redis-sortedset
         - --redis.url=redis://redis.e2e-test.svc.cluster.local:6379
-        - --redis.ss.queues-config-file=/etc/config/queues.json
+        - --redis.ss.queues-config=[{"queue_name":"composite-request-sortedset","igw_base_url":"http://igw-mock.e2e-test.svc.cluster.local:80","request_path_url":"/v1/completions","gate_type":"composite","gate_params":{"gates":"[{\"gate_type\":\"prometheus-saturation\",\"gate_params\":{\"pool\":\"e2e-pool\",\"threshold\":\"0.8\"}},{\"gate_type\":\"redis-quota\",\"gate_params\":{\"address\":\"redis.e2e-test.svc.cluster.local:6379\",\"attribute\":\"userid\",\"mode\":\"concurrency\",\"limit\":\"1\",\"prefix\":\"test-composite-quota:\"}}]"}}]
         - --prometheus-url=http://prom-mock.e2e-test.svc.cluster.local:9090
         - --prometheus-cache-ttl=0s
         - --redis.ss.poll-interval-ms=500
         - --metrics-endpoint-auth=false
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/config
-      volumes:
-      - name: config-volume
-        configMap:
-          name: async-processor-composite-config

--- a/test/e2e/yaml/async-processor-quota.yaml
+++ b/test/e2e/yaml/async-processor-quota.yaml
@@ -1,25 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: async-processor-quota-config
-  namespace: e2e-test
-data:
-  queues.json: |
-    [
-      {
-        "queue_name": "quota-request-sortedset",
-        "igw_base_url": "http://igw-mock.e2e-test.svc.cluster.local:80",
-        "request_path_url": "/v1/completions",
-        "gate_type": "redis-quota",
-        "gate_params": {
-          "address": "redis.e2e-test.svc.cluster.local:6379",
-          "attribute": "userid",
-          "mode": "concurrency",
-          "limit": "1"
-        }
-      }
-    ]
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,12 +23,5 @@ spec:
         args:
         - --message-queue-impl=redis-sortedset
         - --redis.url=redis://redis.e2e-test.svc.cluster.local:6379
-        - --redis.ss.queues-config-file=/etc/config/queues.json
+        - --redis.ss.queues-config=[{"queue_name":"quota-request-sortedset","igw_base_url":"http://igw-mock.e2e-test.svc.cluster.local:80","request_path_url":"/v1/completions","gate_type":"redis-quota","gate_params":{"address":"redis.e2e-test.svc.cluster.local:6379","attribute":"userid","mode":"concurrency","limit":"1"}}]
         - --metrics-endpoint-auth=false
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/config
-      volumes:
-      - name: config-volume
-        configMap:
-          name: async-processor-quota-config


### PR DESCRIPTION
## What does this PR do?

Adds support for full multi-queue JSON configuration in the Helm chart via a new queuesConfig values field. Previously the chart only supported a single queue with a single dispatch gate through individual CLI flags.

### Go changes:
- Adds --redis.ss.queues-config and --redis.queues-config inline CLI flags that accept the full queues JSON directly (priority: inline > file > single-queue fallback)
- Adds a StringMap type that coerces non-string JSON values (e.g. threshold: 0.7) by coercing them to strings during unmarshaling, so Helm's toJson works without a custom helper
   - Note: this is a stopgap measure because GateParams is `map[string]string`, we should follow-up with a proper refactor to take at least `map[string]any`.

### Helm changes:
- Adds queuesConfig array to values.yaml: when set, the chart passes the full config inline via --redis.ss.queues-config (sorted-set) or --redis.queues-config (pubsub), bypassing the single-queue CLI flags
- remove usages of ConfigMap or volume mount, the JSON is passed directly as a CLI argument

## Why is this change needed?

The Helm chart was limited to a single queue and single dispatch gate. Users who needed multiple queues with per-queue gates had to create ConfigMaps and manage volume mounts manually outside the chart. This change exposes the full configuration surface that the Go code  already supports.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
