### PR TITLE
feat: configurable result queue on sorted set

### DIFF
--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -22,6 +22,7 @@ const (
 // struct rather than reaching back into the typed request.
 type InternalRouting struct {
 	RetryCount             int                 `json:"retry_count,omitempty"`
+	QueueID                string              `json:"queue_id,omitempty"`
 	RequestQueueName       string              `json:"request_queue_name,omitempty"`
 	ResultQueueName        string              `json:"result_queue_name,omitempty"`
 	TransportCorrelationID string              `json:"transport_correlation_id,omitempty"`

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -214,21 +214,19 @@ func loadQueueConfigs() ([]queueConfig, error) {
 			GateParams:         parseGateParams(*ssGateParamsJSON),
 		}}
 	}
+	seen := make(map[string]bool, len(configs))
 	for i := range configs {
 		applyQueueConfigDefaults(&configs[i])
+		if seen[configs[i].ID] {
+			return nil, fmt.Errorf("duplicate queue id %q", configs[i].ID)
+		}
+		seen[configs[i].ID] = true
 	}
 	return configs, nil
 }
 
 func applyQueueConfigDefaults(cfg *queueConfig) {
-	if cfg.ID != "" {
-		if cfg.QueueName == "" {
-			cfg.QueueName = "request:" + cfg.ID
-		}
-		if cfg.ResultQueueName == "" {
-			cfg.ResultQueueName = "result:" + cfg.ID
-		}
-	} else {
+	if cfg.ID == "" {
 		cfg.ID = cfg.QueueName
 	}
 }
@@ -504,6 +502,8 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 		resultQueue := defaultQueue
 		if cfg, ok := r.configMap[result.Routing.QueueID]; ok && cfg.ResultQueueName != "" {
 			resultQueue = cfg.ResultQueueName
+		} else if result.Routing.ResultQueueName != "" {
+			resultQueue = result.Routing.ResultQueueName
 		}
 		queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
 	}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -76,7 +76,9 @@ func (m *StringMap) UnmarshalJSON(data []byte) error {
 }
 
 type queueConfig struct {
-	QueueName          string    `json:"queue_name"`
+	ID                 string    `json:"id,omitempty"`
+	QueueName          string    `json:"queue_name,omitempty"`
+	ResultQueueName    string    `json:"result_queue_name,omitempty"`
 	InferenceObjective string    `json:"inference_objective"`
 	RequestPathURL     string    `json:"request_path_url"`
 	IGWBaseURL         string    `json:"igw_base_url"`
@@ -87,6 +89,7 @@ type queueConfig struct {
 type requestChannelData struct {
 	channel   pipeline.RequestChannel
 	queueName string
+	queueID   string
 	gate      pipeline.DispatchGate
 }
 
@@ -102,6 +105,7 @@ type RedisSortedSetFlow struct {
 	activeReleases  sync.Map
 	gate            pipeline.DispatchGate
 	gateFactory     pipeline.GateFactory
+	configMap       map[string]queueConfig
 }
 
 // SortedSetOption is a functional option for configuring RedisSortedSetFlow
@@ -137,6 +141,7 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) (*RedisSortedSetFlow, error)
 		opt(r)
 	}
 
+	r.configMap = make(map[string]queueConfig, len(configs))
 	for _, cfg := range configs {
 		var gate pipeline.DispatchGate
 		if r.gateFactory != nil && cfg.GateType != "" {
@@ -158,9 +163,11 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) (*RedisSortedSetFlow, error)
 			Gate:               gate,
 		}
 
+		r.configMap[cfg.ID] = cfg
 		r.requestChannels = append(r.requestChannels, requestChannelData{
 			channel:   ch,
 			queueName: cfg.QueueName,
+			queueID:   cfg.ID,
 			gate:      gate,
 		})
 	}
@@ -181,29 +188,54 @@ func parseQueueConfigs(data []byte) ([]queueConfig, error) {
 }
 
 func loadQueueConfigs() ([]queueConfig, error) {
+	var configs []queueConfig
 	if *ssQueuesConfig != "" {
-		return parseQueueConfigs([]byte(*ssQueuesConfig))
-	}
-	if *ssQueuesConfigFile != "" {
+		var err error
+		configs, err = parseQueueConfigs([]byte(*ssQueuesConfig))
+		if err != nil {
+			return nil, err
+		}
+	} else if *ssQueuesConfigFile != "" {
 		data, err := os.ReadFile(*ssQueuesConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read config file: %w", err)
 		}
-		return parseQueueConfigs(data)
+		configs, err = parseQueueConfigs(data)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		configs = []queueConfig{{
+			QueueName:          *ssRequestQueueName,
+			InferenceObjective: *ssInferenceObjective,
+			RequestPathURL:     *ssRequestPathURL,
+			IGWBaseURL:         *ssIGWBaseURL,
+			GateType:           *ssGateType,
+			GateParams:         parseGateParams(*ssGateParamsJSON),
+		}}
 	}
-	return []queueConfig{{
-		QueueName:          *ssRequestQueueName,
-		InferenceObjective: *ssInferenceObjective,
-		RequestPathURL:     *ssRequestPathURL,
-		IGWBaseURL:         *ssIGWBaseURL,
-		GateType:           *ssGateType,
-		GateParams:         parseGateParams(*ssGateParamsJSON),
-	}}, nil
+	for i := range configs {
+		applyQueueConfigDefaults(&configs[i])
+	}
+	return configs, nil
+}
+
+func applyQueueConfigDefaults(cfg *queueConfig) {
+	if cfg.ID != "" {
+		if cfg.QueueName == "" {
+			cfg.QueueName = "request:" + cfg.ID
+		}
+		if cfg.ResultQueueName == "" {
+			cfg.ResultQueueName = "result:" + cfg.ID
+		}
+	} else {
+		cfg.ID = cfg.QueueName
+	}
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {
 	for _, ch := range r.requestChannels {
-		go r.requestWorker(ctx, ch.channel.Channel, ch.queueName)
+		go r.requestWorker(ctx, ch.channel.Channel, ch.queueName, ch.queueID)
 	}
 	go r.retryWorker(ctx)  // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
 	go r.resultWorker(ctx) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
@@ -230,7 +262,7 @@ func (r *RedisSortedSetFlow) Characteristics() pipeline.Characteristics {
 }
 
 // Polls sorted set and processes messages by deadline priority (earliest first)
-func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string) {
+func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string) {
 	logger := log.FromContext(ctx)
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
@@ -252,12 +284,12 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			r.processMessages(ctx, msgChannel, queueName, gate, logger)
+			r.processMessages(ctx, msgChannel, queueName, queueID, gate, logger)
 		}
 	}
 }
 
-func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, gate pipeline.DispatchGate, logger logr.Logger) {
+func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string, gate pipeline.DispatchGate, logger logr.Logger) {
 	currentTime := float64(time.Now().Unix())
 
 	budget := gate.Budget(ctx)
@@ -291,6 +323,9 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 
 		if ir.RequestQueueName == "" {
 			ir.RequestQueueName = queueName
+		}
+		if ir.QueueID == "" {
+			ir.QueueID = queueID
 		}
 
 		// Per-attribute gating
@@ -467,8 +502,8 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 	queued := make(map[string][]string)
 	for _, result := range batch {
 		resultQueue := defaultQueue
-		if result.Routing.ResultQueueName != "" {
-			resultQueue = result.Routing.ResultQueueName
+		if cfg, ok := r.configMap[result.Routing.QueueID]; ok && cfg.ResultQueueName != "" {
+			resultQueue = cfg.ResultQueueName
 		}
 		queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
 	}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -214,13 +214,18 @@ func loadQueueConfigs() ([]queueConfig, error) {
 			GateParams:         parseGateParams(*ssGateParamsJSON),
 		}}
 	}
-	seen := make(map[string]bool, len(configs))
+	seenID := make(map[string]bool, len(configs))
+	seenQueue := make(map[string]bool, len(configs))
 	for i := range configs {
 		applyQueueConfigDefaults(&configs[i])
-		if seen[configs[i].ID] {
+		if seenID[configs[i].ID] {
 			return nil, fmt.Errorf("duplicate queue id %q", configs[i].ID)
 		}
-		seen[configs[i].ID] = true
+		seenID[configs[i].ID] = true
+		if seenQueue[configs[i].QueueName] {
+			return nil, fmt.Errorf("duplicate queue_name %q", configs[i].QueueName)
+		}
+		seenQueue[configs[i].QueueName] = true
 	}
 	return configs, nil
 }

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -217,7 +217,7 @@ func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 	}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
 
 	select {
 	case received := <-flow.requestChannels[0].channel.Channel:
@@ -267,7 +267,7 @@ func TestSortedSetFlow_DeadlineOrdering(t *testing.T) {
 	}
 
 	msgChannel := make(chan *api.InternalRequest, 10)
-	go flow.requestWorker(ctx, msgChannel, queue)
+	go flow.requestWorker(ctx, msgChannel, queue, "")
 
 	var processed []string
 	for i := 0; i < 3; i++ {
@@ -309,7 +309,7 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	msg := api.RequestMessage{ID: "expired", Created: time.Now().Unix(), Deadline: pastDeadline}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(pastDeadline), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
 
 	select {
 	case msg := <-flow.requestChannels[0].channel.Channel:
@@ -359,7 +359,7 @@ func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 	validMsg := api.RequestMessage{ID: "valid", Created: time.Now().Unix(), Deadline: 9999999999}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(validMsg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
 
 	// Should skip malformed and receive valid message
 	select {
@@ -515,7 +515,6 @@ func TestSortedSetFlow_ResultBatchMultiQueue(t *testing.T) {
 	defer cancel()
 
 	defaultQueue := "default-result-queue"
-	customQueue := "custom-result-queue"
 	origQueue := *ssResultQueueName
 	*ssResultQueueName = defaultQueue
 	defer func() { *ssResultQueueName = origQueue }()
@@ -526,35 +525,33 @@ func TestSortedSetFlow_ResultBatchMultiQueue(t *testing.T) {
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
 		gate:          noopGate(),
+		configMap: map[string]queueConfig{
+			"queue-a": {ID: "queue-a", QueueName: "request:queue-a", ResultQueueName: "result:queue-a"},
+			"queue-b": {ID: "queue-b", QueueName: "request:queue-b", ResultQueueName: "result:queue-b"},
+		},
 	}
 
-	// Send messages targeting different queues in a single batch.
-	flow.resultChannel <- api.ResultMessage{ID: "default-1", Payload: "d1"}
-	flow.resultChannel <- api.ResultMessage{
-		ID:      "custom-1",
-		Payload: "c1",
-		Routing: api.InternalRouting{ResultQueueName: customQueue},
-	}
-	flow.resultChannel <- api.ResultMessage{ID: "default-2", Payload: "d2"}
-	flow.resultChannel <- api.ResultMessage{
-		ID:      "custom-2",
-		Payload: "c2",
-		Routing: api.InternalRouting{ResultQueueName: customQueue},
-	}
+	flow.resultChannel <- api.ResultMessage{ID: "a-1", Payload: "d1", Routing: api.InternalRouting{QueueID: "queue-a"}}
+	flow.resultChannel <- api.ResultMessage{ID: "b-1", Payload: "c1", Routing: api.InternalRouting{QueueID: "queue-b"}}
+	flow.resultChannel <- api.ResultMessage{ID: "a-2", Payload: "d2", Routing: api.InternalRouting{QueueID: "queue-a"}}
+	flow.resultChannel <- api.ResultMessage{ID: "no-id", Payload: "fallback"}
 
 	go flow.resultWorker(ctx)
 	time.Sleep(200 * time.Millisecond)
 
-	// Verify default queue
-	defaultLen, _ := rdb.LLen(ctx, defaultQueue).Result()
-	if defaultLen != 2 {
-		t.Errorf("Expected 2 messages in default queue, got %d", defaultLen)
+	aLen, _ := rdb.LLen(ctx, "result:queue-a").Result()
+	if aLen != 2 {
+		t.Errorf("Expected 2 messages in result:queue-a, got %d", aLen)
 	}
 
-	// Verify custom queue
-	customLen, _ := rdb.LLen(ctx, customQueue).Result()
-	if customLen != 2 {
-		t.Errorf("Expected 2 messages in custom queue, got %d", customLen)
+	bLen, _ := rdb.LLen(ctx, "result:queue-b").Result()
+	if bLen != 1 {
+		t.Errorf("Expected 1 message in result:queue-b, got %d", bLen)
+	}
+
+	defaultLen, _ := rdb.LLen(ctx, defaultQueue).Result()
+	if defaultLen != 1 {
+		t.Errorf("Expected 1 message in default queue (no queue ID), got %d", defaultLen)
 	}
 }
 
@@ -584,7 +581,7 @@ func TestSortedSetFlow_NoRaceCondition(t *testing.T) {
 			defer wg.Done()
 			workerCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 			defer cancel()
-			go flow.requestWorker(workerCtx, msgChan, queue)
+			go flow.requestWorker(workerCtx, msgChan, queue, "")
 			for {
 				select {
 				case msg := <-msgChan:
@@ -635,7 +632,7 @@ func TestSortedSetFlow_ContextCancellation(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		flow.requestWorker(workerCtx, msgChan, queue)
+		flow.requestWorker(workerCtx, msgChan, queue, "")
 		done <- true
 	}()
 
@@ -725,7 +722,7 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 	}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
 
 	// Wait for several poll cycles - message should NOT be pulled (budget=0)
 	select {
@@ -950,7 +947,7 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 		rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix() + int64(i)), Member: envelopeJSON(msg)})
 	}
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue)
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
 
 	// Wait for one poll cycle (200ms interval + buffer)
 	time.Sleep(250 * time.Millisecond)
@@ -1000,7 +997,7 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
-		flow.requestWorker(workerCtx, msgChan, queue)
+		flow.requestWorker(workerCtx, msgChan, queue, "")
 		close(done)
 	}()
 
@@ -1042,5 +1039,128 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 	json.Unmarshal([]byte(results[0].Member.(string)), &restored) // nolint:errcheck
 	if restored.PublicRequest.ReqID() != "requeue-1" {
 		t.Errorf("Expected re-queued message id requeue-1, got %s", restored.PublicRequest.ReqID())
+	}
+}
+
+func TestApplyQueueConfigDefaults_IDDerivesNames(t *testing.T) {
+	cfg := queueConfig{ID: "my-queue"}
+	applyQueueConfigDefaults(&cfg)
+
+	if cfg.QueueName != "request:my-queue" {
+		t.Errorf("Expected QueueName 'request:my-queue', got %q", cfg.QueueName)
+	}
+	if cfg.ResultQueueName != "result:my-queue" {
+		t.Errorf("Expected ResultQueueName 'result:my-queue', got %q", cfg.ResultQueueName)
+	}
+	if cfg.ID != "my-queue" {
+		t.Errorf("Expected ID 'my-queue', got %q", cfg.ID)
+	}
+}
+
+func TestApplyQueueConfigDefaults_IDWithExplicitNames(t *testing.T) {
+	cfg := queueConfig{ID: "my-queue", QueueName: "custom-req", ResultQueueName: "custom-res"}
+	applyQueueConfigDefaults(&cfg)
+
+	if cfg.QueueName != "custom-req" {
+		t.Errorf("Expected QueueName 'custom-req', got %q", cfg.QueueName)
+	}
+	if cfg.ResultQueueName != "custom-res" {
+		t.Errorf("Expected ResultQueueName 'custom-res', got %q", cfg.ResultQueueName)
+	}
+}
+
+func TestApplyQueueConfigDefaults_InferredFromQueueName(t *testing.T) {
+	cfg := queueConfig{QueueName: "my-request-sortedset"}
+	applyQueueConfigDefaults(&cfg)
+
+	if cfg.ID != "my-request-sortedset" {
+		t.Errorf("Expected ID inferred as 'my-request-sortedset', got %q", cfg.ID)
+	}
+	if cfg.QueueName != "my-request-sortedset" {
+		t.Errorf("Expected QueueName unchanged, got %q", cfg.QueueName)
+	}
+	if cfg.ResultQueueName != "" {
+		t.Errorf("Expected empty ResultQueueName for backward compat, got %q", cfg.ResultQueueName)
+	}
+}
+
+func TestSortedSetFlow_QueueIDSetOnDequeue(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "test-qid-queue"
+	queueID := "test-qid"
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+			queueName: queue,
+			queueID:   queueID,
+		}},
+		pollInterval: 50 * time.Millisecond,
+		batchSize:    10,
+		gate:         noopGate(),
+	}
+
+	msg := api.RequestMessage{ID: "msg-qid", Created: time.Now().Unix(), Deadline: 9999999999}
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, queueID)
+
+	select {
+	case received := <-flow.requestChannels[0].channel.Channel:
+		if received.QueueID != queueID {
+			t.Errorf("Expected QueueID %q, got %q", queueID, received.QueueID)
+		}
+		if received.RequestQueueName != queue {
+			t.Errorf("Expected RequestQueueName %q, got %q", queue, received.RequestQueueName)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for message")
+	}
+}
+
+func TestSortedSetFlow_ResultQueueIgnoresMessagePayload(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	configResult := "config-result-queue"
+	messageResult := "message-result-queue"
+	origQueue := *ssResultQueueName
+	*ssResultQueueName = "global-default"
+	defer func() { *ssResultQueueName = origQueue }()
+
+	flow := &RedisSortedSetFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
+		configMap: map[string]queueConfig{
+			"my-queue": {ID: "my-queue", ResultQueueName: configResult},
+		},
+	}
+
+	flow.resultChannel <- api.ResultMessage{
+		ID:      "test-1",
+		Payload: "data",
+		Routing: api.InternalRouting{QueueID: "my-queue", ResultQueueName: messageResult},
+	}
+
+	go flow.resultWorker(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	configLen, _ := rdb.LLen(ctx, configResult).Result()
+	if configLen != 1 {
+		t.Errorf("Expected 1 message in config result queue, got %d", configLen)
+	}
+
+	messageLen, _ := rdb.LLen(ctx, messageResult).Result()
+	if messageLen != 0 {
+		t.Errorf("Expected 0 messages in message-level result queue (should be ignored), got %d", messageLen)
 	}
 }

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -1119,6 +1119,32 @@ func TestLoadQueueConfigs_InferredDuplicateIDError(t *testing.T) {
 	}
 }
 
+func TestLoadQueueConfigs_DuplicateQueueNameError(t *testing.T) {
+	configs := []queueConfig{
+		{ID: "id-1", QueueName: "same-queue"},
+		{ID: "id-2", QueueName: "same-queue"},
+	}
+	seenID := make(map[string]bool, len(configs))
+	seenQueue := make(map[string]bool, len(configs))
+	var dupErr error
+	for i := range configs {
+		applyQueueConfigDefaults(&configs[i])
+		if seenID[configs[i].ID] {
+			dupErr = fmt.Errorf("duplicate queue id %q", configs[i].ID)
+			break
+		}
+		seenID[configs[i].ID] = true
+		if seenQueue[configs[i].QueueName] {
+			dupErr = fmt.Errorf("duplicate queue_name %q", configs[i].QueueName)
+			break
+		}
+		seenQueue[configs[i].QueueName] = true
+	}
+	if dupErr == nil {
+		t.Fatal("Expected duplicate queue_name error, got nil")
+	}
+}
+
 func TestSortedSetFlow_QueueIDSetOnDequeue(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strconv"
 	"sync"
@@ -1042,34 +1043,22 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 	}
 }
 
-func TestApplyQueueConfigDefaults_IDDerivesNames(t *testing.T) {
-	cfg := queueConfig{ID: "my-queue"}
+func TestApplyQueueConfigDefaults_IDPreserved(t *testing.T) {
+	cfg := queueConfig{ID: "my-id", QueueName: "my-queue", ResultQueueName: "my-result"}
 	applyQueueConfigDefaults(&cfg)
 
-	if cfg.QueueName != "request:my-queue" {
-		t.Errorf("Expected QueueName 'request:my-queue', got %q", cfg.QueueName)
+	if cfg.ID != "my-id" {
+		t.Errorf("Expected ID 'my-id', got %q", cfg.ID)
 	}
-	if cfg.ResultQueueName != "result:my-queue" {
-		t.Errorf("Expected ResultQueueName 'result:my-queue', got %q", cfg.ResultQueueName)
+	if cfg.QueueName != "my-queue" {
+		t.Errorf("Expected QueueName 'my-queue', got %q", cfg.QueueName)
 	}
-	if cfg.ID != "my-queue" {
-		t.Errorf("Expected ID 'my-queue', got %q", cfg.ID)
+	if cfg.ResultQueueName != "my-result" {
+		t.Errorf("Expected ResultQueueName 'my-result', got %q", cfg.ResultQueueName)
 	}
 }
 
-func TestApplyQueueConfigDefaults_IDWithExplicitNames(t *testing.T) {
-	cfg := queueConfig{ID: "my-queue", QueueName: "custom-req", ResultQueueName: "custom-res"}
-	applyQueueConfigDefaults(&cfg)
-
-	if cfg.QueueName != "custom-req" {
-		t.Errorf("Expected QueueName 'custom-req', got %q", cfg.QueueName)
-	}
-	if cfg.ResultQueueName != "custom-res" {
-		t.Errorf("Expected ResultQueueName 'custom-res', got %q", cfg.ResultQueueName)
-	}
-}
-
-func TestApplyQueueConfigDefaults_InferredFromQueueName(t *testing.T) {
+func TestApplyQueueConfigDefaults_IDInferredFromQueueName(t *testing.T) {
 	cfg := queueConfig{QueueName: "my-request-sortedset"}
 	applyQueueConfigDefaults(&cfg)
 
@@ -1080,7 +1069,53 @@ func TestApplyQueueConfigDefaults_InferredFromQueueName(t *testing.T) {
 		t.Errorf("Expected QueueName unchanged, got %q", cfg.QueueName)
 	}
 	if cfg.ResultQueueName != "" {
-		t.Errorf("Expected empty ResultQueueName for backward compat, got %q", cfg.ResultQueueName)
+		t.Errorf("Expected empty ResultQueueName, got %q", cfg.ResultQueueName)
+	}
+}
+
+func TestLoadQueueConfigs_DuplicateIDError(t *testing.T) {
+	input := `[{"id":"same","igw_base_url":"http://a"},{"id":"same","igw_base_url":"http://b"}]`
+	_, err := parseQueueConfigs([]byte(input))
+	if err != nil {
+		t.Fatalf("parseQueueConfigs should succeed: %v", err)
+	}
+
+	configs := []queueConfig{
+		{ID: "same", QueueName: "q1"},
+		{ID: "same", QueueName: "q2"},
+	}
+	seen := make(map[string]bool, len(configs))
+	var dupErr error
+	for i := range configs {
+		applyQueueConfigDefaults(&configs[i])
+		if seen[configs[i].ID] {
+			dupErr = fmt.Errorf("duplicate queue id %q", configs[i].ID)
+			break
+		}
+		seen[configs[i].ID] = true
+	}
+	if dupErr == nil {
+		t.Fatal("Expected duplicate ID error, got nil")
+	}
+}
+
+func TestLoadQueueConfigs_InferredDuplicateIDError(t *testing.T) {
+	configs := []queueConfig{
+		{QueueName: "same-queue"},
+		{QueueName: "same-queue"},
+	}
+	seen := make(map[string]bool, len(configs))
+	var dupErr error
+	for i := range configs {
+		applyQueueConfigDefaults(&configs[i])
+		if seen[configs[i].ID] {
+			dupErr = fmt.Errorf("duplicate queue id %q", configs[i].ID)
+			break
+		}
+		seen[configs[i].ID] = true
+	}
+	if dupErr == nil {
+		t.Fatal("Expected duplicate ID error for inferred IDs, got nil")
 	}
 }
 
@@ -1162,5 +1197,54 @@ func TestSortedSetFlow_ResultQueueIgnoresMessagePayload(t *testing.T) {
 	messageLen, _ := rdb.LLen(ctx, messageResult).Result()
 	if messageLen != 0 {
 		t.Errorf("Expected 0 messages in message-level result queue (should be ignored), got %d", messageLen)
+	}
+}
+
+func TestSortedSetFlow_ResultQueueFallsBackToMessageLevel(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	messageResult := "producer-result-queue"
+	origQueue := *ssResultQueueName
+	*ssResultQueueName = "global-default"
+	defer func() { *ssResultQueueName = origQueue }()
+
+	flow := &RedisSortedSetFlow{
+		rdb:           rdb,
+		resultChannel: make(chan api.ResultMessage, resultChannelBuffer),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
+		configMap: map[string]queueConfig{
+			"no-result-cfg": {ID: "no-result-cfg", QueueName: "req", ResultQueueName: ""},
+		},
+	}
+
+	// Config exists but has no ResultQueueName → should fall back to message-level
+	flow.resultChannel <- api.ResultMessage{
+		ID:      "fallback-1",
+		Payload: "data",
+		Routing: api.InternalRouting{QueueID: "no-result-cfg", ResultQueueName: messageResult},
+	}
+	// No config match and no message-level → should fall back to global default
+	flow.resultChannel <- api.ResultMessage{
+		ID:      "global-1",
+		Payload: "data",
+		Routing: api.InternalRouting{},
+	}
+
+	go flow.resultWorker(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	msgLen, _ := rdb.LLen(ctx, messageResult).Result()
+	if msgLen != 1 {
+		t.Errorf("Expected 1 message in producer result queue (message-level fallback), got %d", msgLen)
+	}
+
+	globalLen, _ := rdb.LLen(ctx, "global-default").Result()
+	if globalLen != 1 {
+		t.Errorf("Expected 1 message in global default queue, got %d", globalLen)
 	}
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -235,13 +235,15 @@ func floodProbes(envoyURL string, concurrency int) context.CancelFunc {
 // setEnvoyFaultAbort configures Envoy's fault injection filter via the admin
 // runtime API. percent is 0–100 (percentage of requests that return 503).
 func setEnvoyFaultAbort(envoyAdminURL string, percent int) {
-	body := fmt.Sprintf("fault.http.abort.abort_percent=%d", percent)
-	req, err := http.NewRequest(http.MethodPost, envoyAdminURL+"/runtime_modify?"+body, nil)
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
-	resp, err := httpClient.Do(req)
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
-	defer resp.Body.Close() //nolint:errcheck
-	gomega.ExpectWithOffset(1, resp.StatusCode).To(gomega.Equal(http.StatusOK))
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		body := fmt.Sprintf("fault.http.abort.abort_percent=%d", percent)
+		req, err := http.NewRequest(http.MethodPost, envoyAdminURL+"/runtime_modify?"+body, nil)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		resp, err := httpClient.Do(req)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
+		g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+	}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
 }
 
 func setDispatchGateBudget(ctx context.Context, rdb *redis.Client, budget string) {


### PR DESCRIPTION
## What does this PR do?

Adds per-queue result queue configuration to the sorted-set Redis flow. Each queue config entry can now optionally specify a `result_queue_name`. Moreover, the config may include an optional `id` (defaults to same as `queue_name`) used for internal routing; the processor now uses a config-based lookup (keyed by the ID) to route results.

**Note**: when a config-level `result_queue_name` is set, it takes precedence. Otherwise, the message-level `ResultQueueName` (set by producers) is used as a fallback, with the global `--redis.ss.result-queue-name` flag as the last default.

Also this PR:
- Validates duplicate queue IDs at config load time
- Fixes flaky `General Integration` e2e tests by making `setEnvoyFaultAbort` retry on transient port unavailability

### Config examples

**New style (explicit queues):**
```ts  
[{
  "queue_name": "custom-req", 
  "result_queue_name": "custom-res", 
  "igw_base_url": "http://..."}]
```

**New style (ID with explicit names):**
```ts  
[{
  "id": "my-handler-id", 
  "queue_name": "custom-req", 
  "result_queue_name": "custom-res", 
  "igw_base_url": "http://..."}]
```

**Old style (backward compatible):**

```ts
[{
  "queue_name": "custom-req", 
  "igw_base_url": "http://..."}
]
// id inferred from queue_name, no result queue name, 
// falls back to global --redis.ss.result-queue-name
```

## Why is this change needed?

Currently, when configuring multiple request queues via --redis.ss.queues-config-file, all queues shared the same global result queue (--redis.ss.result-queue-name). There os no way to route results from different request queues to different result queues at the config level. This PR allows each request queue to have a corresponding named result queue, determined entirely by config rather than message payload.

Related: https://github.com/llm-d-incubation/batch-gateway/pull/432

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

- docs https://github.com/llm-d-incubation/batch-gateway/pull/432
- helm updates might need to be aligned if merged https://github.com/llm-d-incubation/llm-d-async/pull/192


---

## Final notes

do we want to keep message-level `ResultQueueName`? that seems a bit error-prone and it has potential for misuse
