### PR TITLE
perf(redis): exponential backoff for retry-worker polling loop

### DIFF
--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -41,6 +41,30 @@ var (
 
 const retryPopBatchSize = 100
 
+// Retry-polling interval bounds for the exponential backoff used by retryWorker.
+// When the worker drains no due messages from the retry sorted set, the next
+// sleep doubles up to maxRetryPollInterval; on a successful drain it resets to
+// baseRetryPollInterval. Declared as var (rather than const) so tests can
+// override to small values for fast, deterministic backoff coverage.
+var (
+	baseRetryPollInterval = 1 * time.Second
+	maxRetryPollInterval  = 30 * time.Second
+)
+
+// nextRetryPollInterval returns the next polling interval given the current
+// interval, base, and max. Doubles current, caps at max. Pure function so the
+// backoff math is unit-testable independently of the Redis-backed worker loop.
+func nextRetryPollInterval(current, base, max time.Duration) time.Duration {
+	if current < base {
+		return base
+	}
+	next := current * 2
+	if next > max {
+		return max
+	}
+	return next
+}
+
 // popDueRetryMessagesScript atomically fetches due retry entries (score <= now) and removes them.
 var popDueRetryMessagesScript = redis.NewScript(`
 local key = KEYS[1]
@@ -348,6 +372,12 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 		msgChannels[channelData.queueName] = channelData.requestChannel.Channel
 	}
 
+	// sleepDuration grows exponentially when no due retries are found and resets
+	// to baseRetryPollInterval whenever the drain cycle processes at least one
+	// message. This avoids hammering Redis with ZRANGEBYSCORE/ZREM at fixed 1Hz
+	// while idle. See #100.
+	sleepDuration := baseRetryPollInterval
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -357,6 +387,7 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 			// Keep one fixed cutoff for this drain cycle so we only process
 			// messages due at cycle start, avoiding an ever-expanding window.
 			currentTimeSec := time.Now().Unix()
+			drainedAny := false
 
 			for {
 				results, err := popDueRetryMessages(ctx, rdb, *retryQueueName, currentTimeSec, retryPopBatchSize)
@@ -367,6 +398,7 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 				if len(results) == 0 {
 					break
 				}
+				drainedAny = true
 
 				for i, msg := range results {
 					var message api.InternalRequest
@@ -393,7 +425,21 @@ func (r *RedisMQFlow) retryWorker(ctx context.Context, rdb *redis.Client) {
 					}
 				}
 			}
-			time.Sleep(time.Second)
+
+			if drainedAny {
+				sleepDuration = baseRetryPollInterval
+			} else {
+				sleepDuration = nextRetryPollInterval(sleepDuration, baseRetryPollInterval, maxRetryPollInterval)
+			}
+
+			// Cancellable sleep — exit promptly on shutdown instead of waiting
+			// out the remainder of the current interval (which can be up to
+			// maxRetryPollInterval under the backoff).
+			select {
+			case <-time.After(sleepDuration):
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -654,3 +654,88 @@ func TestRetryRedisOp_UsesBackgroundCtxAfterCancel(t *testing.T) {
 		}
 	}
 }
+
+// TestNextRetryPollInterval covers the pure backoff math for retryWorker.
+// See #100.
+func TestNextRetryPollInterval(t *testing.T) {
+	base := 1 * time.Second
+	max := 30 * time.Second
+
+	tests := []struct {
+		name    string
+		current time.Duration
+		want    time.Duration
+	}{
+		{"zero current snaps to base", 0, base},
+		{"below base snaps to base", 100 * time.Millisecond, base},
+		{"base doubles to 2x", base, 2 * time.Second},
+		{"2s doubles to 4s", 2 * time.Second, 4 * time.Second},
+		{"8s doubles to 16s (still below cap)", 8 * time.Second, 16 * time.Second},
+		{"16s doubles to 30s (capped at max)", 16 * time.Second, 30 * time.Second},
+		{"at-cap stays at cap", max, max},
+		{"above cap clamps to cap", 60 * time.Second, max},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nextRetryPollInterval(tt.current, base, max)
+			if got != tt.want {
+				t.Errorf("nextRetryPollInterval(%v, %v, %v) = %v, want %v",
+					tt.current, base, max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMQRetryWorker_ExitsPromptlyOnCancelDuringSleep verifies that ctx
+// cancellation interrupts the worker's sleep instead of waiting out the full
+// interval. With maxRetryPollInterval overridden to several seconds and the
+// retry queue empty (so the worker reaches the long sleep), cancelling the
+// context should cause the worker to exit within ~100ms rather than after
+// the full interval. Regression guard for the cancellable-sleep change in #100.
+func TestMQRetryWorker_ExitsPromptlyOnCancelDuringSleep(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer rdb.Close() // nolint:errcheck
+
+	// Override intervals: short base so the worker quickly reaches the long
+	// max-clamped sleep, long max so an uncancellable sleep would visibly stall.
+	oldBase, oldMax := baseRetryPollInterval, maxRetryPollInterval
+	baseRetryPollInterval = 5 * time.Millisecond
+	maxRetryPollInterval = 5 * time.Second
+	defer func() {
+		baseRetryPollInterval = oldBase
+		maxRetryPollInterval = oldMax
+	}()
+
+	flow := &RedisMQFlow{
+		rdb:             rdb,
+		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
+		retryChannel:    make(chan pipeline.RetryMessage),
+		requestChannels: []RequestChannelData{},
+	}
+
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		flow.retryWorker(workerCtx, rdb)
+		close(done)
+	}()
+
+	// Let the worker run long enough to traverse the backoff curve and reach
+	// the max-clamped sleep, then cancel.
+	time.Sleep(200 * time.Millisecond)
+	cancelStart := time.Now()
+	workerCancel()
+
+	select {
+	case <-done:
+		exitLatency := time.Since(cancelStart)
+		if exitLatency > 500*time.Millisecond {
+			t.Errorf("retryWorker took %v to exit after cancel; want < 500ms (uncancellable sleep would have taken up to %v)",
+				exitLatency, maxRetryPollInterval)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("retryWorker did not exit within 2s of context cancellation")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `retryWorker` for the pubsub-based `RedisMQFlow` polls Redis on a fixed 1-second interval regardless of whether there's any work to do. Under idle load that's **~86,400 `ZRANGEBYSCORE` calls/day per instance**, all returning empty.

This PR replaces the fixed sleep with **exponential backoff with snap reset**: each empty drain doubles the sleep duration, each successful drain resets it to the base interval. Capped at 30s so worst-case latency to notice a new due retry stays bounded.

### Algorithm

```
base = 1s, max = 30s

next_sleep = base                       when any retry was drained
next_sleep = min(2*current, max)        when no retries were found
```

Multiplicative increase, snap reset. Same shape used by TCP, Kubernetes client-go retries, AWS SDK retries — well-trodden.

### Complexity

**Idle:** O(T) → O(log(max/base) + T/max) calls. At 1 hour idle: ~3,600 calls → ~120 calls (~30× reduction). Worst-case latency to notice a new due retry: bounded by `max` (30s).

**Active:** unchanged. Drain is unbounded per cycle; sleep resets to base immediately on the first successful drain.

### Cancellable sleep (bonus fix)

Replaces `time.Sleep(d)` with `select { case <-time.After(d): case <-ctx.Done(): return }`. Under the new backoff, shutdown could otherwise wait up to 30s before noticing `ctx.Done()`; the select makes the worker exit within milliseconds. Existing `TestMQRetryWorker_RequeuesOnShutdown` is unchanged and still passes.

### Out of scope

Issue mentions Redis keyspace notifications as an "alternatively". Skipped here — that's a larger change (requires `notify-keyspace-events` configured on production Redis, adds server-side load) and a separate design discussion. Mentioned as future work.

### Tests

- **`TestNextRetryPollInterval`** — 8 sub-cases covering zero, below-base, doubling, pre-cap, at-cap, above-cap. Pure function test, no Redis required.
- **`TestMQRetryWorker_ExitsPromptlyOnCancelDuringSleep`** — regression guard for the cancellable-sleep change. With `max = 5s` and the retry queue empty (worker reaches the long sleep), cancelling the context should make the worker exit within 500ms.

Intervals are package `var` (rather than `const`) so tests can override to millisecond values for fast, deterministic coverage.

### Verification

- `go test ./pkg/redis/...` — passes (including the existing `TestMQRetryWorker_RequeuesOnShutdown`)
- `make lint` — 0 issues
- The remaining `test/e2e/...` failure is pre-existing on `main` (requires `kind` / a kube cluster).

**Which issue(s) this PR fixes**:
Fixes #100
