### PR TITLE
fix: graceful shutdown for in-flight requests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -171,13 +172,19 @@ func main() {
 	inferenceClient := asyncworker.NewHTTPInferenceClient(inferenceHTTPClient)
 
 	requestChannel := policy.MergeRequestChannels(impl.RequestChannels()).Channel
+	var wg sync.WaitGroup
 	for w := 1; w <= concurrency; w++ {
-
-		go asyncworker.Worker(ctx, impl.Characteristics(), inferenceClient, requestChannel, impl.RetryChannel(), impl.ResultChannel(), requestTimeout)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			asyncworker.Worker(ctx, impl.Characteristics(), inferenceClient, requestChannel, impl.RetryChannel(), impl.ResultChannel(), requestTimeout)
+		}()
 	}
 
 	impl.Start(ctx)
 	<-ctx.Done()
+	wg.Wait()
+	impl.Shutdown()
 }
 
 func buildTLSConfig(caCertPath, certPath, keyPath string, insecureSkipVerify bool) (*tls.Config, error) {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -9,6 +9,7 @@ import (
 type Flow interface {
 	Characteristics() Characteristics
 	Start(ctx context.Context)
+	Shutdown()
 	RequestChannels() []RequestChannel
 	RetryChannel() chan RetryMessage
 	ResultChannel() chan api.ResultMessage

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -74,6 +74,16 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 					return
 				}
 
+				// Shutdown: parent context canceled, re-enqueue via the drain path.
+				// Send directly — retryMessage's select would take ctx.Done() immediately.
+				if ctx.Err() != nil {
+					retryChannel <- pipeline.RetryMessage{
+						EmbelishedRequestMessage: msg,
+						BackoffDurationSeconds:   0,
+					}
+					return
+				}
+
 				// Check if error implements InferenceError
 				var inferenceErr asyncapi.InferenceError
 				if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -74,9 +74,10 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 					return
 				}
 
-				// Shutdown: parent context canceled, re-enqueue via the drain path.
-				// Send directly — retryMessage's select would take ctx.Done() immediately.
-				if ctx.Err() != nil {
+				// Shutdown: parent context cancelled and the error is context-related
+				// (not a completed HTTP response like 4xx). Re-enqueue directly —
+				// retryMessage's select would take ctx.Done() immediately.
+				if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 					retryChannel <- pipeline.RetryMessage{
 						EmbelishedRequestMessage: msg,
 						BackoffDurationSeconds:   0,

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -670,3 +670,40 @@ func TestClientError_NoRetry(t *testing.T) {
 		t.Errorf("Timeout waiting for result")
 	}
 }
+
+func TestWorker_RetriesOnShutdown(t *testing.T) {
+	msgId := "shutdown-retry"
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       msgId,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(5 * time.Minute).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case msg := <-retryChannel:
+		if msg.PublicRequest.ReqID() != msgId {
+			t.Errorf("Expected retry message id %s, got %s", msgId, msg.PublicRequest.ReqID())
+		}
+	case r := <-resultChannel:
+		t.Errorf("Expected retry, got fatal result: %s", r.Payload)
+	case <-time.After(5 * time.Second):
+		t.Errorf("Worker did not retry within 5s after shutdown")
+	}
+}

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -673,7 +673,9 @@ func TestClientError_NoRetry(t *testing.T) {
 
 func TestWorker_RetriesOnShutdown(t *testing.T) {
 	msgId := "shutdown-retry"
+	reqStarted := make(chan struct{})
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		close(reqStarted)
 		<-req.Context().Done()
 		return nil, req.Context().Err()
 	})
@@ -693,7 +695,7 @@ func TestWorker_RetriesOnShutdown(t *testing.T) {
 		Payload:  map[string]any{"model": "test", "prompt": "hi"},
 	}, "http://localhost:30800/v1/completions", map[string]string{})
 
-	time.Sleep(50 * time.Millisecond)
+	<-reqStarted
 	cancel()
 
 	select {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -54,6 +54,7 @@ type PubSubMQFlow struct {
 	resultChannel   chan api.ResultMessage
 	gate            pipeline.DispatchGate
 	gateFactory     pipeline.GateFactory
+	drainCancel     context.CancelFunc
 }
 type RequestChannelData struct {
 	requestChannel pipeline.RequestChannel
@@ -172,13 +173,22 @@ func (r *PubSubMQFlow) RequestChannels() []pipeline.RequestChannel {
 }
 
 func (r *PubSubMQFlow) Start(ctx context.Context) {
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	r.drainCancel = drainCancel
+
 	for _, channelData := range r.requestChannels {
 		go r.requestWorker(ctx, pubSubClient, channelData.subscriberID, channelData.requestChannel.Channel, channelData.gate)
 	}
 	publisher := pubSubClient.Publisher(r.resultTopicID)
-	go resultWorker(ctx, publisher, r.resultChannel)
+	go resultWorker(drainCtx, publisher, r.resultChannel)
 
-	go addMsgToRetryQueue(ctx, r.retryChannel)
+	go addMsgToRetryQueue(drainCtx, r.retryChannel)
+}
+
+func (r *PubSubMQFlow) Shutdown() {
+	if r.drainCancel != nil {
+		r.drainCancel()
+	}
 }
 
 func resultWorker(ctx context.Context, publisher *pubsub.Publisher, resultChannel chan api.ResultMessage) {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -55,6 +55,7 @@ type PubSubMQFlow struct {
 	gate            pipeline.DispatchGate
 	gateFactory     pipeline.GateFactory
 	drainCancel     context.CancelFunc
+	drainWg         sync.WaitGroup
 }
 type RequestChannelData struct {
 	requestChannel pipeline.RequestChannel
@@ -173,22 +174,23 @@ func (r *PubSubMQFlow) RequestChannels() []pipeline.RequestChannel {
 }
 
 func (r *PubSubMQFlow) Start(ctx context.Context) {
-	drainCtx, drainCancel := context.WithCancel(context.Background())
+	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), log.FromContext(ctx)))
 	r.drainCancel = drainCancel
 
 	for _, channelData := range r.requestChannels {
 		go r.requestWorker(ctx, pubSubClient, channelData.subscriberID, channelData.requestChannel.Channel, channelData.gate)
 	}
 	publisher := pubSubClient.Publisher(r.resultTopicID)
-	go resultWorker(drainCtx, publisher, r.resultChannel)
-
-	go addMsgToRetryQueue(drainCtx, r.retryChannel)
+	r.drainWg.Add(2)
+	go func() { defer r.drainWg.Done(); resultWorker(drainCtx, publisher, r.resultChannel) }()
+	go func() { defer r.drainWg.Done(); addMsgToRetryQueue(drainCtx, r.retryChannel) }()
 }
 
 func (r *PubSubMQFlow) Shutdown() {
 	if r.drainCancel != nil {
 		r.drainCancel()
 	}
+	r.drainWg.Wait()
 }
 
 func resultWorker(ctx context.Context, publisher *pubsub.Publisher, resultChannel chan api.ResultMessage) {

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -124,6 +124,7 @@ type RedisMQFlow struct {
 	requestChannels []RequestChannelData
 	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
+	drainCancel     context.CancelFunc
 }
 
 func NewRedisMQFlow() (*RedisMQFlow, error) {
@@ -170,16 +171,24 @@ func NewRedisMQFlow() (*RedisMQFlow, error) {
 }
 
 func (r *RedisMQFlow) Start(ctx context.Context) {
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	r.drainCancel = drainCancel
 
 	for _, channelData := range r.requestChannels {
 		go requestWorker(ctx, r.rdb, channelData.requestChannel.Channel, channelData.queueName)
 	}
 
-	go addMsgToRetryWorker(ctx, r.rdb, r.retryChannel, *retryQueueName)
+	go addMsgToRetryWorker(drainCtx, r.rdb, r.retryChannel, *retryQueueName)
 
-	go r.retryWorker(ctx, r.rdb)
+	go r.retryWorker(drainCtx, r.rdb)
 
-	go r.resultWorker(ctx, *resultQueueName) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+	go r.resultWorker(drainCtx, *resultQueueName) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+}
+
+func (r *RedisMQFlow) Shutdown() {
+	if r.drainCancel != nil {
+		r.drainCancel()
+	}
 }
 func (r *RedisMQFlow) RequestChannels() []pipeline.RequestChannel {
 

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-async/api"
@@ -125,6 +126,7 @@ type RedisMQFlow struct {
 	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
 	drainCancel     context.CancelFunc
+	drainWg         sync.WaitGroup
 }
 
 func NewRedisMQFlow() (*RedisMQFlow, error) {
@@ -171,24 +173,24 @@ func NewRedisMQFlow() (*RedisMQFlow, error) {
 }
 
 func (r *RedisMQFlow) Start(ctx context.Context) {
-	drainCtx, drainCancel := context.WithCancel(context.Background())
+	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), log.FromContext(ctx)))
 	r.drainCancel = drainCancel
 
 	for _, channelData := range r.requestChannels {
 		go requestWorker(ctx, r.rdb, channelData.requestChannel.Channel, channelData.queueName)
 	}
 
-	go addMsgToRetryWorker(drainCtx, r.rdb, r.retryChannel, *retryQueueName)
-
-	go r.retryWorker(drainCtx, r.rdb)
-
-	go r.resultWorker(drainCtx, *resultQueueName) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+	r.drainWg.Add(3)
+	go func() { defer r.drainWg.Done(); addMsgToRetryWorker(drainCtx, r.rdb, r.retryChannel, *retryQueueName) }()
+	go func() { defer r.drainWg.Done(); r.retryWorker(drainCtx, r.rdb) }()
+	go func() { defer r.drainWg.Done(); r.resultWorker(drainCtx, *resultQueueName) }() // #nosec G118
 }
 
 func (r *RedisMQFlow) Shutdown() {
 	if r.drainCancel != nil {
 		r.drainCancel()
 	}
+	r.drainWg.Wait()
 }
 func (r *RedisMQFlow) RequestChannels() []pipeline.RequestChannel {
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -107,6 +107,7 @@ type RedisSortedSetFlow struct {
 	gateFactory     pipeline.GateFactory
 	configMap       map[string]queueConfig
 	drainCancel     context.CancelFunc
+	drainWg         sync.WaitGroup
 }
 
 // SortedSetOption is a functional option for configuring RedisSortedSetFlow
@@ -238,20 +239,22 @@ func applyQueueConfigDefaults(cfg *queueConfig) {
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {
-	drainCtx, drainCancel := context.WithCancel(context.Background())
+	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), log.FromContext(ctx)))
 	r.drainCancel = drainCancel
 
 	for _, ch := range r.requestChannels {
 		go r.requestWorker(ctx, ch.channel.Channel, ch.queueName, ch.queueID)
 	}
-	go r.retryWorker(drainCtx)  // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
-	go r.resultWorker(drainCtx) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+	r.drainWg.Add(2)
+	go func() { defer r.drainWg.Done(); r.retryWorker(drainCtx) }()  // #nosec G118
+	go func() { defer r.drainWg.Done(); r.resultWorker(drainCtx) }() // #nosec G118
 }
 
 func (r *RedisSortedSetFlow) Shutdown() {
 	if r.drainCancel != nil {
 		r.drainCancel()
 	}
+	r.drainWg.Wait()
 }
 
 func (r *RedisSortedSetFlow) RequestChannels() []pipeline.RequestChannel {

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -106,6 +106,7 @@ type RedisSortedSetFlow struct {
 	gate            pipeline.DispatchGate
 	gateFactory     pipeline.GateFactory
 	configMap       map[string]queueConfig
+	drainCancel     context.CancelFunc
 }
 
 // SortedSetOption is a functional option for configuring RedisSortedSetFlow
@@ -237,11 +238,20 @@ func applyQueueConfigDefaults(cfg *queueConfig) {
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	r.drainCancel = drainCancel
+
 	for _, ch := range r.requestChannels {
 		go r.requestWorker(ctx, ch.channel.Channel, ch.queueName, ch.queueID)
 	}
-	go r.retryWorker(ctx)  // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
-	go r.resultWorker(ctx) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+	go r.retryWorker(drainCtx)  // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+	go r.resultWorker(drainCtx) // #nosec G118 -- lifecycle-scoped ctx, not request-scoped
+}
+
+func (r *RedisSortedSetFlow) Shutdown() {
+	if r.drainCancel != nil {
+		r.drainCancel()
+	}
 }
 
 func (r *RedisSortedSetFlow) RequestChannels() []pipeline.RequestChannel {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -207,8 +207,8 @@ var _ = ginkgo.Describe("General Integration", func() {
 		// The Worker should have re-queued the in-flight messages back to
 		// Redis on shutdown instead of treating them as fatal errors.
 		count := rdb.ZCard(ctx, integrationRequestQueue).Val()
-		gomega.Expect(count).To(gomega.BeNumerically(">=", 1),
-			"expected re-queued messages in request queue after shutdown")
+		gomega.Expect(count).To(gomega.BeNumerically(">=", int64(len(ids))),
+			"expected all in-flight messages re-queued after shutdown")
 	})
 
 	ginkgo.It("does not lose messages on pod termination", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,6 +30,7 @@ var _ = ginkgo.Describe("General Integration", func() {
 
 	ginkgo.AfterEach(func() {
 		setEnvoyFaultAbort(envoyAdminURL, 0)
+		setEnvoyFaultDelay(envoyAdminURL, 0)
 	})
 
 	ginkgo.It("processes a message end-to-end", func() {
@@ -151,11 +152,70 @@ var _ = ginkgo.Describe("General Integration", func() {
 		}
 	})
 
+	ginkgo.It("re-queues in-flight messages on pod termination", func() {
+		// Add a 60s delay to 100% of requests so they stay in-flight in the Worker.
+		setEnvoyFaultDelay(envoyAdminURL, 100)
+
+		// Ensure the deployment is restored even if the test fails.
+		ginkgo.DeferCleanup(func() {
+			setEnvoyFaultDelay(envoyAdminURL, 0)
+			cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+				"-n", nsName, "scale", "deployment/integration-async-processor",
+				"--replicas=1", "--timeout=60s")
+			session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(session).WithTimeout(60 * time.Second).Should(gexec.Exit(0))
+
+			cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+				"-n", nsName, "rollout", "status",
+				"deployment/integration-async-processor", "--timeout=120s")
+			session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(session).WithTimeout(180 * time.Second).Should(gexec.Exit(0))
+		})
+
+		ids := []string{"shutdown-1", "shutdown-2", "shutdown-3"}
+		for _, id := range ids {
+			enqueueMessage(ctx, rdb, integrationRequestQueue, makeRequestMessage(id, 5*time.Minute))
+		}
+
+		// Wait until the processor has popped messages from the request queue
+		// (they are now in-flight, stuck in Envoy's delay).
+		gomega.Eventually(func() int64 {
+			return rdb.ZCard(ctx, integrationRequestQueue).Val()
+		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Equal(int64(0)))
+
+		// Scale the deployment to 0 to trigger graceful shutdown. Using scale
+		// instead of pod delete prevents a replacement pod from consuming the
+		// re-queued messages before we can assert.
+		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+			"-n", nsName, "scale", "deployment/integration-async-processor",
+			"--replicas=0", "--timeout=60s")
+		session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(60 * time.Second).Should(gexec.Exit(0))
+
+		// Wait for the pod to fully terminate.
+		cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+			"-n", nsName, "wait", "pod",
+			"-l", "app.kubernetes.io/instance=integration",
+			"--for=delete", "--timeout=60s")
+		session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(90 * time.Second).Should(gexec.Exit(0))
+
+		// The Worker should have re-queued the in-flight messages back to
+		// Redis on shutdown instead of treating them as fatal errors.
+		count := rdb.ZCard(ctx, integrationRequestQueue).Val()
+		gomega.Expect(count).To(gomega.BeNumerically(">=", 1),
+			"expected re-queued messages in request queue after shutdown")
+	})
+
 	ginkgo.It("does not lose messages on pod termination", func() {
 		// Enable 100% fault injection so messages fail and enter the retry loop.
 		setEnvoyFaultAbort(envoyAdminURL, 100)
 
-		ids := []string{"shutdown-1", "shutdown-2", "shutdown-3"}
+		ids := []string{"shutdown-noloss-1", "shutdown-noloss-2", "shutdown-noloss-3"}
 		for _, id := range ids {
 			enqueueMessage(ctx, rdb, integrationRequestQueue, makeRequestMessage(id, 5*time.Minute))
 		}

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -246,6 +246,21 @@ func setEnvoyFaultAbort(envoyAdminURL string, percent int) {
 	}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
 }
 
+// setEnvoyFaultDelay configures Envoy's fault injection delay via the admin
+// runtime API. percent is 0–100 (percentage of requests delayed by 60s,
+// the duration configured in the static Envoy config).
+func setEnvoyFaultDelay(envoyAdminURL string, percent int) {
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		body := fmt.Sprintf("fault.http.delay.fixed_delay_percent=%d", percent)
+		req, err := http.NewRequest(http.MethodPost, envoyAdminURL+"/runtime_modify?"+body, nil)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		resp, err := httpClient.Do(req)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
+		g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+	}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
+}
+
 func setDispatchGateBudget(ctx context.Context, rdb *redis.Client, budget string) {
 	gomega.ExpectWithOffset(1, rdb.Set(ctx, dispatchGateBudgetKey, budget, 0).Err()).NotTo(gomega.HaveOccurred())
 }

--- a/test/e2e/yaml/envoy.yaml
+++ b/test/e2e/yaml/envoy.yaml
@@ -12,6 +12,7 @@ data:
         - name: static
           static_layer:
             fault.http.abort.abort_percent: 0
+            fault.http.delay.fixed_delay_percent: 0
         - name: admin
           admin_layer: {}
     admin:
@@ -110,6 +111,11 @@ data:
                       - name: envoy.filters.http.fault
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+                          delay:
+                            percentage:
+                              numerator: 0
+                              denominator: HUNDRED
+                            fixed_delay: 60s
                           abort:
                             percentage:
                               numerator: 0

--- a/test/integration/worker_dispatch_test.go
+++ b/test/integration/worker_dispatch_test.go
@@ -248,3 +248,70 @@ func TestWorkerDispatch_ResultCallback(t *testing.T) {
 		t.Fatal("Timed out waiting for result")
 	}
 }
+
+// TestWorkerDispatch_RequeuesOnShutdown verifies that when the parent context
+// is cancelled (simulating SIGTERM) while an inference request is in-flight,
+// the Worker sends the message to the retry channel instead of treating it
+// as a fatal error.
+func TestWorkerDispatch_RequeuesOnShutdown(t *testing.T) {
+	// Server blocks until explicitly released (simulates in-flight request).
+	serverHit := make(chan struct{})
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(serverHit)
+		<-serverDone
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	client := asyncworker.NewHTTPInferenceClient(server.Client())
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+	}()
+
+	ir := asyncapi.NewInternalRequest(
+		asyncapi.InternalRouting{RequestQueueName: "test-queue"},
+		&asyncapi.RequestMessage{
+			ID:       "shutdown-requeue-1",
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(5 * time.Minute).Unix(),
+			Payload:  map[string]any{"model": "test", "prompt": "hello"},
+		},
+	)
+
+	requestChannel <- pipeline.EmbelishedRequestMessage{
+		InternalRequest: ir,
+		HttpHeaders:     map[string]string{"Content-Type": "application/json"},
+		RequestURL:      server.URL + "/v1/completions",
+	}
+
+	// Wait for the server to receive the request before cancelling.
+	<-serverHit
+
+	// Simulate SIGTERM.
+	cancel()
+
+	select {
+	case msg := <-retryChannel:
+		assert.Equal(t, "shutdown-requeue-1", msg.PublicRequest.ReqID())
+		assert.Equal(t, float64(0), msg.BackoffDurationSeconds)
+	case r := <-resultChannel:
+		t.Fatalf("Expected retry on shutdown, got fatal result: %s", r.Payload)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Worker did not send retry within 5s after shutdown")
+	}
+
+	// Release the server handler so it returns and server.Close() doesn't hang.
+	close(serverDone)
+	server.Close()
+	wg.Wait()
+}


### PR DESCRIPTION
## What does this PR do?

Fixes graceful shutdown so that in-flight inference requests are re-queued instead of dropped when SIGTERM is received.

Ordered shutdown sequence (cmd/main.go):

  - Workers now run under a sync.WaitGroup
  - On SIGTERM: workers finish first (wg.Wait()), then impl.Shutdown() drains retry/result channels to Redis
  - Should address a potential race where retry/result workers could exit before workers had a chance to send their in-flight messages

Worker shutdown detection (pkg/asyncworker/worker.go):
  - After SendRequest returns an error, checks ctx.Err() (parent context) before error classification
  - If shutdown, sends directly to the retry channel with zero backoff, bypassing retryMessage (whose select would take ctx.Done() immediately)

`Shutdown()` on `pipeline.Flow` (pipeline/pipeline.go):
  - New interface method called after workers finish
  - Each flow implementation (`RedisSortedSetFlow`, `RedisMQFlow`, `PubSubMQFlow`) starts retry/result workers on a separate `drainCtx` that only cancels when `Shutdown()` is called
  - Request workers still use the signal context and stop on SIGTERM

## Why is this change needed?

When SIGTERM fires, the parent context cancels, which cancels all per-request contexts. In-flight HTTP calls return context.Canceled, which HTTPInferenceClient.SendRequest wraps as
  ClientError{ErrCategoryUnknown}. The Worker treated Unknown as fatal: it sends an error result and drops the message instead of re-queuing it. Additionally, even if the Worker tries to retry, the retry channel send could race with the retry worker's drain loop since they shared the same context.




## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

follow up to #195 