### PR TITLE
chore: bump internal module versions to v0.7.0-RC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,9 @@ module github.com/llm-d-incubation/llm-d-async
 
 go 1.25.0
 
-// TODO(#107): After the first tagged api release, bump the version below
-// from v0.0.0 to that semver (e.g. v0.1.0). Keep the replace line for in-repo development.
-require github.com/llm-d-incubation/llm-d-async/api v0.0.0
+require github.com/llm-d-incubation/llm-d-async/api v0.7.0-RC
 
-require github.com/llm-d-incubation/llm-d-async/pipeline v0.0.0
+require github.com/llm-d-incubation/llm-d-async/pipeline v0.7.0-RC
 
 replace github.com/llm-d-incubation/llm-d-async/api => ./api
 

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -2,6 +2,6 @@ module github.com/llm-d-incubation/llm-d-async/pipeline
 
 go 1.25.0
 
-require github.com/llm-d-incubation/llm-d-async/api v0.0.0
+require github.com/llm-d-incubation/llm-d-async/api v0.7.0-RC
 
 replace github.com/llm-d-incubation/llm-d-async/api => ../api

--- a/producer/go.mod
+++ b/producer/go.mod
@@ -4,8 +4,7 @@ go 1.25.0
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0
-	// TODO(#107): After the first tagged api release (e.g. api/v0.1.0), bump this require from v0.0.0 to that semver (e.g. v0.1.0).
-	github.com/llm-d-incubation/llm-d-async/api v0.0.0
+	github.com/llm-d-incubation/llm-d-async/api v0.7.0-RC
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -20,5 +19,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// TODO(#107): Keep for monorepo builds; omitted when consumers require published versions only.
 replace github.com/llm-d-incubation/llm-d-async/api => ../api


### PR DESCRIPTION
## What does this PR do?

- Bumps the internal `api` and `pipeline` sub-module versions from the `v0.0.0` placeholder to `v0.7.0-RC` in `go.mod`, `pipeline/go.mod`, and `producer/go.mod`.
- Removes the `TODO(#107)` comments that tracked this work.

## Why is this change needed?

The `v0.0.0` versions were placeholder values pending the first tagged release of the internal sub-modules. With `v0.7.0-RC` now tagged, these references can be updated to the actual release version, resolving #107.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Related to #107
