### PR TITLE
chore: add FIPS-compliant Konflux image

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,0 +1,38 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG LDFLAGS="-s -w"
+ARG CGO_ENABLED=1
+
+USER root
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# Local replace directives (./api, ./pipeline) must exist before go mod download.
+COPY api/ api/
+COPY pipeline/ pipeline/
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/main.go cmd/main.go
+COPY pkg/ pkg/
+COPY internal/ internal
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOEXPERIMENT=strictfipsruntime go build -a -ldflags "${LDFLAGS}" -o async-processor cmd/main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:d91be7cea9f03a757d69ad7fcdfcd7849dba820110e7980d5e2a1f46ed06ea3b
+WORKDIR /
+COPY --from=builder /workspace/async-processor .
+USER 65532:65532
+
+ENTRYPOINT ["/async-processor"]


### PR DESCRIPTION
## What does this PR do?

add Konflux image for FIPS compliance

## Why is this change needed?

Required for downstream build

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

     podman run --privileged check-payload scan image --spec=quay.io/evacchi/llm-d-async:v1

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

https://redhat.atlassian.net/browse/RHOAIENG-63952