### PR TITLE
fix: preserve Headers and Endpoint in toInternalRequest

### DIFF
--- a/producer/redis_sortedset_producer.go
+++ b/producer/redis_sortedset_producer.go
@@ -107,10 +107,16 @@ func toInternalRequest(req api.Request) *api.InternalRequest {
 	ir := &api.InternalRequest{InternalRouting: api.InternalRouting{}}
 	switch v := req.(type) {
 	case *api.RequestMessage:
+		if v == nil {
+			return ir
+		}
 		cp := *v
 		ir.PublicRequest = &cp
 		return ir
 	case *api.RedisRequest:
+		if v == nil {
+			return ir
+		}
 		ir2 := *v
 		if ir2.RequestQueueName != "" {
 			ir.RequestQueueName = ir2.RequestQueueName
@@ -121,6 +127,9 @@ func toInternalRequest(req api.Request) *api.InternalRequest {
 		ir.PublicRequest = &ir2
 		return ir
 	case *api.PubSubRequest:
+		if v == nil {
+			return ir
+		}
 		ir2 := *v
 		if ir2.PubSubID != "" {
 			ir.TransportCorrelationID = ir2.PubSubID
@@ -134,6 +143,8 @@ func toInternalRequest(req api.Request) *api.InternalRequest {
 			Deadline: req.ReqDeadline(),
 			Payload:  req.ReqPayload(),
 			Metadata: req.ReqMetadata(),
+			Headers:  req.ReqHeaders(),
+			Endpoint: req.ReqEndpoint(),
 		}
 		return ir
 	}
@@ -142,6 +153,9 @@ func toInternalRequest(req api.Request) *api.InternalRequest {
 // SubmitRequest adds a request to the Redis sorted set.
 // The score is the deadline, ensuring earlier deadlines are processed first.
 func (p *RedisSortedSetProducer) SubmitRequest(ctx context.Context, req api.Request) error {
+	if req == nil {
+		return errors.New("request is required")
+	}
 	ir := toInternalRequest(req)
 	r := ir.PublicRequest
 	if r == nil {

--- a/producer/redis_sortedset_producer_test.go
+++ b/producer/redis_sortedset_producer_test.go
@@ -13,6 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// customRequest is a user-defined Request implementation for testing the
+// default branch of toInternalRequest.
+type customRequest struct {
+	id, endpoint      string
+	created, deadline int64
+	payload           map[string]any
+	metadata          map[string]string
+	headers           map[string]string
+}
+
+func (r *customRequest) ReqID() string                  { return r.id }
+func (r *customRequest) ReqCreated() int64              { return r.created }
+func (r *customRequest) ReqDeadline() int64             { return r.deadline }
+func (r *customRequest) ReqPayload() map[string]any     { return r.payload }
+func (r *customRequest) ReqMetadata() map[string]string { return r.metadata }
+func (r *customRequest) ReqHeaders() map[string]string  { return r.headers }
+func (r *customRequest) ReqEndpoint() string            { return r.endpoint }
+
 func setupTestProducer(t *testing.T) (*RedisSortedSetProducer, *miniredis.Miniredis) {
 	t.Helper()
 
@@ -81,6 +99,23 @@ func TestToInternalRequest_PubSubIDCopiesToInternalRouting(t *testing.T) {
 	assert.Equal(t, "ps-123", ir.TransportCorrelationID)
 }
 
+func TestToInternalRequest_CustomRequestPreservesHeadersAndEndpoint(t *testing.T) {
+	req := &customRequest{
+		id: "custom-1", created: 1, deadline: 2,
+		payload:  map[string]any{"k": "v"},
+		metadata: map[string]string{"m": "d"},
+		headers:  map[string]string{"Authorization": "Bearer tok"},
+		endpoint: "/v1/chat/completions",
+	}
+	ir := toInternalRequest(req)
+	rm, ok := ir.PublicRequest.(*api.RequestMessage)
+	require.True(t, ok, "expected *api.RequestMessage for custom Request type")
+	assert.Equal(t, "custom-1", rm.ID)
+	assert.Equal(t, map[string]string{"Authorization": "Bearer tok"}, rm.Headers)
+	assert.Equal(t, "/v1/chat/completions", rm.Endpoint)
+	assert.Equal(t, map[string]string{"m": "d"}, rm.Metadata)
+}
+
 func TestToInternalRequest_RedisQueueFieldsCopyToInternalRouting(t *testing.T) {
 	req := &api.RedisRequest{
 		RequestMessage: api.RequestMessage{
@@ -92,6 +127,38 @@ func TestToInternalRequest_RedisQueueFieldsCopyToInternalRouting(t *testing.T) {
 	ir := toInternalRequest(req)
 	assert.Equal(t, "req-q", ir.RequestQueueName)
 	assert.Equal(t, "res-q", ir.ResultQueueName)
+}
+
+func TestSubmitRequest_NilRequest(t *testing.T) {
+	producer, _ := setupTestProducer(t)
+	ctx := context.Background()
+
+	t.Run("untyped nil", func(t *testing.T) {
+		err := producer.SubmitRequest(ctx, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request is required")
+	})
+
+	t.Run("typed nil RequestMessage", func(t *testing.T) {
+		var req *api.RequestMessage
+		err := producer.SubmitRequest(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request is required")
+	})
+
+	t.Run("typed nil RedisRequest", func(t *testing.T) {
+		var req *api.RedisRequest
+		err := producer.SubmitRequest(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request is required")
+	})
+
+	t.Run("typed nil PubSubRequest", func(t *testing.T) {
+		var req *api.PubSubRequest
+		err := producer.SubmitRequest(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request is required")
+	})
 }
 
 func TestSubmitRequest_Validation(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Fix two bugs in the `producer` module's `toInternalRequest()`:

1. **Default branch drops `Headers` and `Endpoint`**: When a caller passes a custom `api.Request` implementation, `toInternalRequest` converts it to `*api.RequestMessage` but omits `Headers` and `Endpoint`
2. **Nil request causes panic instead of returning error**: nil-pointer dereference panic in `toInternalRequest`

## Why is this change needed?

These bugs would either silently drop user data (headers/endpoint) or crash the caller's process on a simple programming mistake (nil request), neither of which is acceptable for a released SDK.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

None
