### PR TITLE
feat: endpoint-scraping dispatch gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 - `prometheus-saturation`: Queries Prometheus for pool saturation metric. The gate closes (returns `0.0`) when saturation ≥ threshold; when open it returns `(1 - saturation) - (1 - threshold)`, i.e. the margin below the threshold.
 - `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_SYS)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
 - `prometheus-query`: Evaluates an arbitrary user-supplied PromQL expression as the dispatch budget. The expression must resolve to an instant vector with a single sample whose value is in [0, 1]. Unlike `prometheus-saturation` and `prometheus-budget`, this gate does not construct queries internally — the user provides the complete PromQL expression. Values outside [0, 1] are clamped.
+- `endpoint-scrape`: Scrapes a raw Prometheus `/metrics` endpoint directly (no Prometheus server required). Extracts a named metric, computes saturation, and returns the available budget. Supports two modes: **direct saturation** (metric value is already in [0, 1], e.g., from the EPP) and **computed saturation** (raw count divided by `max_count_per_pod`, e.g., `vllm:num_requests_waiting`). Optionally scrapes a second endpoint for dynamic pod count.
 
 **Example Configuration with Per-Queue Gates:**
 
@@ -165,6 +166,18 @@ For more fine-grained control, configure gates per queue in your configuration f
        "gate_type": "composite",
        "gate_params": {
           "gates": "[{\"gate_type\":\"prometheus-saturation\",\"gate_params\":{\"pool\":\"inference_pool_1\"}},{\"gate_type\":\"redis-quota\",\"gate_params\":{\"address\":\"localhost:6379\",\"limit\":\"100\"}}]"
+       }
+    },
+    {
+       "queue_name": "scrape_gated_queue",
+       "inference_objective": "batch-task",
+       "request_path_url": "/v1/completions",
+       "gate_type": "endpoint-scrape",
+       "gate_params": {
+          "url": "http://vllm-sim:8000/metrics",
+          "metric": "vllm:num_requests_waiting",
+          "max_count_per_pod": "5",
+          "fallback": "1.0"
        }
     }
 ]
@@ -230,6 +243,23 @@ For more fine-grained control, configure gates per queue in your configuration f
     The result is used directly as the dispatch budget (no transformation is applied).
   - `fallback` (optional): Fallback budget value (0.0-1.0) returned when the query fails or returns no data.
     Default is `0.0` (fail closed).
+
+- `endpoint-scrape`: Scrapes a raw Prometheus text-format `/metrics` endpoint directly.
+  Computes budget as `clamp(1 - saturation - baseline, 0, 1)`.
+
+  - `url` (**required**): Full URL to scrape (e.g., `http://vllm-sim:8000/metrics`).
+  - `metric` (**required**): Metric name to extract (e.g., `vllm:num_requests_waiting`).
+  - `labels` (optional): JSON object of label filters (e.g., `{"model_name":"my-model"}`). Only samples matching all labels are used.
+  - `max_count_per_pod` (optional): Per-pod capacity. When > 0, saturation = `value / max_count`. When 0, the metric value is used directly as saturation (assumed to be in [0, 1]). Default is `0`.
+  - `baseline` (optional): Reserved headroom subtracted from budget. Default is `0.0`.
+  - `fallback` (optional): Budget returned when scrape fails or metric is missing. Default is `0.0` (fail closed).
+  - `pods_url` (optional): URL to scrape for dynamic pod count (e.g., `http://epp-svc:9090/metrics`). When set with `pods_metric`, `max_count = ready_pods * max_count_per_pod`.
+  - `pods_metric` (optional): Metric name for ready pods (e.g., `inference_pool_ready_pods`).
+  - `pods_labels` (optional): JSON label filters for the pods metric (e.g., `{"name":"my-pool"}`).
+
+  **No Prometheus server required.** This gate scrapes endpoints directly, making it suitable for
+  deployments without a dedicated Prometheus instance. Use `max_count_per_pod` with `pods_url`/`pods_metric`
+  for dynamic scaling, or set `max_count_per_pod` to a static value for single-pod setups.
 
 ## Request Messages and Consumption
 

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -282,6 +282,57 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 		}
 		return NewMetricDispatchGate(cachedSource(source, f.cacheTTL), 0.0, fallback), nil
 
+	case "endpoint-scrape":
+		url := params["url"]
+		if url == "" {
+			return nil, fmt.Errorf("endpoint-scrape gate requires a 'url' parameter")
+		}
+		metric := params["metric"]
+		if metric == "" {
+			return nil, fmt.Errorf("endpoint-scrape gate requires a 'metric' parameter")
+		}
+
+		var labels map[string]string
+		if labelsJSON := params["labels"]; labelsJSON != "" {
+			if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
+				return nil, fmt.Errorf("endpoint-scrape gate failed to parse 'labels': %w", err)
+			}
+		}
+
+		maxCountPerPod, err := parseFloat("max_count_per_pod", params["max_count_per_pod"], 0)
+		if err != nil {
+			return nil, err
+		}
+		baseline, err := parseFloat("baseline", params["baseline"], 0.0)
+		if err != nil {
+			return nil, err
+		}
+		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
+		if err != nil {
+			return nil, err
+		}
+
+		var podsLabels map[string]string
+		if podsLabelsJSON := params["pods_labels"]; podsLabelsJSON != "" {
+			if err := json.Unmarshal([]byte(podsLabelsJSON), &podsLabels); err != nil {
+				return nil, fmt.Errorf("endpoint-scrape gate failed to parse 'pods_labels': %w", err)
+			}
+		}
+
+		cfg := ScrapeConfig{
+			URL:            url,
+			MetricName:     metric,
+			Labels:         labels,
+			MaxCountPerPod: maxCountPerPod,
+			PodsURL:        params["pods_url"],
+			PodsMetric:     params["pods_metric"],
+			PodsLabels:     podsLabels,
+		}
+
+		var ms MetricSource = NewScrapeMetricSource(cfg)
+		ms = cachedSource(ms, f.cacheTTL)
+		return NewMetricDispatchGate(ms, baseline, fallback), nil
+
 	default:
 		// Unknown gate types default to open gate
 		return ConstOpenGate(), nil

--- a/pkg/async/inference/flowcontrol/scrape_metric_source.go
+++ b/pkg/async/inference/flowcontrol/scrape_metric_source.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+)
+
+var _ MetricSource = (*ScrapeMetricSource)(nil)
+
+// ScrapeMetricSource implements MetricSource by scraping raw Prometheus /metrics
+// endpoints. It reads a metric value, optionally computes saturation using a
+// max capacity (static or dynamic from a pods metric), and returns budget in [0, 1].
+//
+// Two modes for max capacity:
+//   - Static: maxCountPerPod is used directly as the total max count (single pod or precomputed).
+//   - Dynamic: when podsURL/podsMetric are set, ready pods are scraped from a second
+//     endpoint (e.g., EPP) and max_count = ready_pods * maxCountPerPod.
+//
+// When maxCountPerPod == 0, the metric value is assumed to already be saturation in [0, 1].
+// Output value = 1 - saturation (available capacity / budget).
+type ScrapeMetricSource struct {
+	client         *http.Client
+	url            string
+	metricName     string
+	labels         map[string]string
+	maxCountPerPod float64
+	podsURL        string
+	podsMetric     string
+	podsLabels     map[string]string
+}
+
+// ScrapeConfig holds configuration for NewScrapeMetricSource.
+type ScrapeConfig struct {
+	URL            string
+	MetricName     string
+	Labels         map[string]string
+	MaxCountPerPod float64
+	PodsURL        string
+	PodsMetric     string
+	PodsLabels     map[string]string
+}
+
+// NewScrapeMetricSource creates a MetricSource that scrapes Prometheus
+// text-format /metrics endpoints and returns budget values in [0, 1].
+func NewScrapeMetricSource(cfg ScrapeConfig) *ScrapeMetricSource {
+	return &ScrapeMetricSource{
+		client:         &http.Client{Timeout: 10 * time.Second},
+		url:            cfg.URL,
+		metricName:     cfg.MetricName,
+		labels:         cfg.Labels,
+		maxCountPerPod: cfg.MaxCountPerPod,
+		podsURL:        cfg.PodsURL,
+		podsMetric:     cfg.PodsMetric,
+		podsLabels:     cfg.PodsLabels,
+	}
+}
+
+func (s *ScrapeMetricSource) Query(ctx context.Context) ([]Sample, error) {
+	samples, err := scrapeMetric(ctx, s.client, s.url, s.metricName, s.labels)
+	if err != nil {
+		return nil, err
+	}
+
+	maxCount := s.maxCountPerPod
+	if s.podsURL != "" && s.podsMetric != "" {
+		podsSamples, err := scrapeMetric(ctx, s.client, s.podsURL, s.podsMetric, s.podsLabels)
+		if err != nil {
+			return nil, fmt.Errorf("scrape pods metric: %w", err)
+		}
+		if len(podsSamples) == 0 {
+			return nil, fmt.Errorf("scrape: pods metric %s not found at %s", s.podsMetric, s.podsURL)
+		}
+		pods := podsSamples[0].Value
+		if pods <= 0 {
+			return nil, fmt.Errorf("scrape: ready pods is %g, cannot compute capacity", pods)
+		}
+		maxCount = pods * s.maxCountPerPod
+	}
+
+	result := make([]Sample, len(samples))
+	for i, sample := range samples {
+		var saturation float64
+		if maxCount > 0 {
+			saturation = sample.Value / maxCount
+		} else {
+			saturation = sample.Value
+		}
+		saturation = clampFloat(saturation, 0, 1)
+		result[i] = Sample{Labels: sample.Labels, Value: 1 - saturation}
+	}
+
+	return result, nil
+}
+
+func scrapeMetric(ctx context.Context, client *http.Client, url, metricName string, labelFilters map[string]string) ([]Sample, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("scrape: build request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scrape: fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scrape: %s returned %d", url, resp.StatusCode)
+	}
+
+	return parseSamples(resp.Body, metricName, labelFilters)
+}
+
+func parseSamples(body io.Reader, metricName string, labelFilters map[string]string) ([]Sample, error) {
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(body)
+	if err != nil {
+		return nil, fmt.Errorf("scrape: parse metrics: %w", err)
+	}
+
+	family, ok := families[metricName]
+	if !ok {
+		return nil, nil
+	}
+
+	var samples []Sample
+	for _, m := range family.GetMetric() {
+		labels := make(map[string]string)
+		for _, lp := range m.GetLabel() {
+			labels[lp.GetName()] = lp.GetValue()
+		}
+
+		if !matchLabels(labels, labelFilters) {
+			continue
+		}
+
+		var value float64
+		switch {
+		case m.GetGauge() != nil:
+			value = m.GetGauge().GetValue()
+		case m.GetCounter() != nil:
+			value = m.GetCounter().GetValue()
+		case m.GetUntyped() != nil:
+			value = m.GetUntyped().GetValue()
+		default:
+			continue
+		}
+
+		samples = append(samples, Sample{Labels: labels, Value: value})
+	}
+
+	return samples, nil
+}
+
+func matchLabels(actual, filters map[string]string) bool {
+	for k, v := range filters {
+		if actual[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func clampFloat(v, min, max float64) float64 {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}

--- a/pkg/async/inference/flowcontrol/scrape_metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/scrape_metric_source_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testMetricsBody = `# HELP vllm:num_requests_waiting Number of requests waiting.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model_name="sim-model"} 3
+vllm:num_requests_waiting{model_name="other-model"} 7
+# HELP inference_pool_saturation Pool saturation ratio.
+# TYPE inference_pool_saturation gauge
+inference_pool_saturation{name="pool-a"} 0.75
+inference_pool_saturation{name="pool-b"} 0.2
+`
+
+const testPodsMetricsBody = `# HELP ready_pods Number of ready pods.
+# TYPE ready_pods gauge
+ready_pods{name="pool-a"} 4
+`
+
+func newTestMetricsServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestScrapeMetricSource(t *testing.T) {
+	server := newTestMetricsServer(testMetricsBody)
+	defer server.Close()
+
+	t.Run("StaticMaxCount", func(t *testing.T) {
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:            server.URL,
+			MetricName:     "vllm:num_requests_waiting",
+			Labels:         map[string]string{"model_name": "sim-model"},
+			MaxCountPerPod: 5,
+		})
+		samples, err := source.Query(context.Background())
+		require.NoError(t, err)
+		require.Len(t, samples, 1)
+		// value=3, maxCount=5 → saturation=0.6 → budget=0.4
+		assert.InDelta(t, 0.4, samples[0].Value, 0.001)
+	})
+
+	t.Run("DirectSaturation", func(t *testing.T) {
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:        server.URL,
+			MetricName: "inference_pool_saturation",
+			Labels:     map[string]string{"name": "pool-a"},
+		})
+		samples, err := source.Query(context.Background())
+		require.NoError(t, err)
+		require.Len(t, samples, 1)
+		// value=0.75, maxCount=0 → saturation=0.75 → budget=0.25
+		assert.InDelta(t, 0.25, samples[0].Value, 0.001)
+	})
+
+	t.Run("OverSaturationClamped", func(t *testing.T) {
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:            server.URL,
+			MetricName:     "vllm:num_requests_waiting",
+			Labels:         map[string]string{"model_name": "other-model"},
+			MaxCountPerPod: 5,
+		})
+		samples, err := source.Query(context.Background())
+		require.NoError(t, err)
+		require.Len(t, samples, 1)
+		// value=7, maxCount=5 → saturation=1.4 → clamped to 1.0 → budget=0.0
+		assert.InDelta(t, 0.0, samples[0].Value, 0.001)
+	})
+
+	t.Run("NoMatch", func(t *testing.T) {
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:        server.URL,
+			MetricName: "nonexistent_metric",
+		})
+		samples, err := source.Query(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, samples)
+	})
+
+	t.Run("ServerError", func(t *testing.T) {
+		errServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer errServer.Close()
+
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:        errServer.URL,
+			MetricName: "any",
+		})
+		_, err := source.Query(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("DynamicPodsCount", func(t *testing.T) {
+		podsServer := newTestMetricsServer(testPodsMetricsBody)
+		defer podsServer.Close()
+
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:            server.URL,
+			MetricName:     "vllm:num_requests_waiting",
+			Labels:         map[string]string{"model_name": "sim-model"},
+			MaxCountPerPod: 5,
+			PodsURL:        podsServer.URL,
+			PodsMetric:     "ready_pods",
+			PodsLabels:     map[string]string{"name": "pool-a"},
+		})
+		samples, err := source.Query(context.Background())
+		require.NoError(t, err)
+		require.Len(t, samples, 1)
+		// value=3, pods=4, maxCountPerPod=5 → maxCount=20 → saturation=0.15 → budget=0.85
+		assert.InDelta(t, 0.85, samples[0].Value, 0.001)
+	})
+
+	t.Run("ZeroValue", func(t *testing.T) {
+		zeroBody := `# TYPE idle_metric gauge
+idle_metric 0
+`
+		zeroServer := newTestMetricsServer(zeroBody)
+		defer zeroServer.Close()
+
+		source := NewScrapeMetricSource(ScrapeConfig{
+			URL:            zeroServer.URL,
+			MetricName:     "idle_metric",
+			MaxCountPerPod: 10,
+		})
+		samples, err := source.Query(context.Background())
+		require.NoError(t, err)
+		require.Len(t, samples, 1)
+		// value=0, maxCount=10 → saturation=0 → budget=1.0
+		assert.InDelta(t, 1.0, samples[0].Value, 0.001)
+	})
+}

--- a/test/e2e/e2e_endpoint_scrape_gate_test.go
+++ b/test/e2e/e2e_endpoint_scrape_gate_test.go
@@ -1,0 +1,83 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// These tests drive the endpoint-scrape gate by scraping the sim's /metrics
+// endpoint directly (no Prometheus or EPP needed):
+//
+//	setSimWaitingRequests → sim reports vllm:num_requests_waiting on /metrics
+//	  → async-processor scrapes /metrics, computes saturation, gate opens/closes
+var _ = ginkgo.Describe("Endpoint Scrape Dispatch Gate E2E", ginkgo.Ordered, func() {
+	var ctx context.Context
+
+	ginkgo.BeforeEach(func() {
+		ctx = context.Background()
+		rdb.Del(ctx, endpointScrapeRequestQueue) //nolint:errcheck
+		rdb.Del(ctx, endpointScrapeResultQueue)  //nolint:errcheck
+		setSimWaitingRequests(simAdminURL, 0)
+	})
+
+	ginkgo.It("processes a message when scrape metric is below max count", func() {
+		setSimWaitingRequests(simAdminURL, 0)
+
+		msg := makeRequestMessage("scrape-below-max", 5*time.Minute)
+		enqueueMessage(ctx, rdb, endpointScrapeRequestQueue, msg)
+
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, endpointScrapeResultQueue)
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 1))
+
+		result := popResult(ctx, rdb, endpointScrapeResultQueue)
+		gomega.Expect(result).NotTo(gomega.BeNil())
+		gomega.Expect(result.ID).To(gomega.Equal("scrape-below-max"))
+	})
+
+	ginkgo.It("pauses processing when scrape metric reaches max count", func() {
+		// waiting=5, max_count_per_pod=5 → saturation=1.0 → gate closed
+		setSimWaitingRequests(simAdminURL, 5)
+
+		msg := makeRequestMessage("scrape-at-max", 5*time.Minute)
+		enqueueMessage(ctx, rdb, endpointScrapeRequestQueue, msg)
+
+		gomega.Consistently(func() int64 {
+			return getResultCount(ctx, rdb, endpointScrapeResultQueue)
+		}, 10*time.Second, 1*time.Second).Should(gomega.Equal(int64(0)))
+
+		// Drop waiting → saturation falls → gate reopens → message processed.
+		setSimWaitingRequests(simAdminURL, 0)
+
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, endpointScrapeResultQueue)
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 1))
+
+		result := popResult(ctx, rdb, endpointScrapeResultQueue)
+		gomega.Expect(result).NotTo(gomega.BeNil())
+		gomega.Expect(result.ID).To(gomega.Equal("scrape-at-max"))
+	})
+
+	ginkgo.It("resumes processing for multiple messages when metric drops", func() {
+		setSimWaitingRequests(simAdminURL, 5)
+
+		for i := 1; i <= 3; i++ {
+			msg := makeRequestMessage(fmt.Sprintf("scrape-resume-%d", i), 5*time.Minute)
+			enqueueMessage(ctx, rdb, endpointScrapeRequestQueue, msg)
+		}
+
+		gomega.Consistently(func() int64 {
+			return getResultCount(ctx, rdb, endpointScrapeResultQueue)
+		}, 5*time.Second, 1*time.Second).Should(gomega.Equal(int64(0)))
+
+		setSimWaitingRequests(simAdminURL, 0)
+
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, endpointScrapeResultQueue)
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 3))
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -320,6 +320,7 @@ func applyManifests() {
 		{"quota", helmValuesDir + "/quota.yaml"},
 		{"composite", helmValuesDir + "/composite.yaml"},
 		{"prometheus-query", helmValuesDir + "/prometheus-query.yaml"},
+		{"endpoint-scrape", helmValuesDir + "/endpoint-scrape.yaml"},
 	} {
 		helmInstall(r.name, r.values, map[string]string{
 			"ap.image.repository": imageRepo,
@@ -536,6 +537,7 @@ func doRedeployEPPWithFlowControl() {
 		"quota-async-processor",
 		"composite-async-processor",
 		"prometheus-query-async-processor",
+		"endpoint-scrape-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "restart", "deployment/"+deploy)
@@ -551,6 +553,7 @@ func doRedeployEPPWithFlowControl() {
 		"quota-async-processor",
 		"composite-async-processor",
 		"prometheus-query-async-processor",
+		"endpoint-scrape-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "status", "deployment/"+deploy, "--timeout=120s")

--- a/test/e2e/helm/endpoint-scrape.yaml
+++ b/test/e2e/helm/endpoint-scrape.yaml
@@ -1,0 +1,27 @@
+ap:
+  imagePullPolicy: Never
+  messageQueueImpl: "redis-sortedset"
+  concurrency: 1
+  prometheusCacheTTL: "0s"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    enabled: true
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
+    resultQueueName: "endpoint-scrape-result-list"
+    pollIntervalMs: 500
+    batchSize: 10
+    queuesConfig:
+      - queue_name: "endpoint-scrape-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "endpoint-scrape"
+        gate_params:
+          url: "http://llm-sim.e2e-integration.svc.cluster.local:8000/metrics"
+          metric: "vllm:num_requests_waiting"
+          max_count_per_pod: "5"
+          fallback: "1.0"
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -28,6 +28,9 @@ const (
 	redisGateRequestQueue = "redis-gate-request-sortedset"
 	redisGateResultQueue  = "redis-gate-result-list"
 	dispatchGateBudgetKey = "dispatch-gate-budget"
+
+	endpointScrapeRequestQueue = "endpoint-scrape-request-sortedset"
+	endpointScrapeResultQueue  = "endpoint-scrape-result-list"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}

--- a/test/integration/endpoint_scrape_gate_factory_test.go
+++ b/test/integration/endpoint_scrape_gate_factory_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const metricsTemplate = `# HELP vllm:num_requests_waiting Number of requests waiting.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model_name="sim-model"} %s
+`
+
+func TestGateFactory_EndpointScrape_StaticMaxCount(t *testing.T) {
+	var queryCount int64
+	metricValue := &atomic.Value{}
+	metricValue.Store("2")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&queryCount, 1)
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprintf(w, metricsTemplate, metricValue.Load().(string))
+	}))
+	defer server.Close()
+
+	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 200*time.Millisecond)
+
+	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+		"url":                server.URL,
+		"metric":             "vllm:num_requests_waiting",
+		"max_count_per_pod":  "10",
+		"baseline":           "0.0",
+		"fallback":           "0.0",
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// value=2, maxCount=10 → saturation=0.2 → budget=0.8 → gate open
+	budget := gate.Budget(ctx)
+	assert.InDelta(t, 0.8, budget, 0.01)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&queryCount))
+
+	// Second call within cache TTL reuses cached result.
+	budget2 := gate.Budget(ctx)
+	assert.InDelta(t, 0.8, budget2, 0.01)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&queryCount), "Should use cached result")
+
+	// Wait for cache to expire, update metric.
+	time.Sleep(250 * time.Millisecond)
+	metricValue.Store("10")
+
+	// value=10, maxCount=10 → saturation=1.0 → budget=0.0 → gate closed
+	budget3 := gate.Budget(ctx)
+	assert.Equal(t, 0.0, budget3, "Gate should close when fully saturated")
+	assert.Equal(t, int64(2), atomic.LoadInt64(&queryCount))
+}
+
+func TestGateFactory_EndpointScrape_DirectSaturation(t *testing.T) {
+	const metricsBody = `# TYPE pool_saturation gauge
+pool_saturation{name="pool-a"} 0.6
+`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprint(w, metricsBody)
+	}))
+	defer server.Close()
+
+	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
+
+	// No max_count_per_pod → metric value used directly as saturation
+	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+		"url":      server.URL,
+		"metric":   "pool_saturation",
+		"labels":   `{"name":"pool-a"}`,
+		"baseline": "0.1",
+	})
+	require.NoError(t, err)
+
+	// saturation=0.6 → budget=1-0.6=0.4 → minus baseline 0.1 → 0.3
+	budget := gate.Budget(context.Background())
+	assert.InDelta(t, 0.3, budget, 0.01)
+}
+
+func TestGateFactory_EndpointScrape_DynamicPods(t *testing.T) {
+	simServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprintf(w, metricsTemplate, "6")
+	}))
+	defer simServer.Close()
+
+	const podsBody = `# TYPE ready_pods gauge
+ready_pods{name="pool-a"} 3
+`
+	podsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprint(w, podsBody)
+	}))
+	defer podsServer.Close()
+
+	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
+
+	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+		"url":                simServer.URL,
+		"metric":             "vllm:num_requests_waiting",
+		"max_count_per_pod":  "10",
+		"pods_url":           podsServer.URL,
+		"pods_metric":        "ready_pods",
+		"pods_labels":        `{"name":"pool-a"}`,
+	})
+	require.NoError(t, err)
+
+	// value=6, pods=3, maxCountPerPod=10 → maxCount=30 → saturation=0.2 → budget=0.8
+	budget := gate.Budget(context.Background())
+	assert.InDelta(t, 0.8, budget, 0.01)
+}
+
+func TestGateFactory_EndpointScrape_MissingParams(t *testing.T) {
+	factory := flowcontrol.NewGateFactory("")
+
+	_, err := factory.CreateGate("endpoint-scrape", map[string]string{
+		"metric": "some_metric",
+	})
+	assert.Error(t, err, "Should fail when url is missing")
+
+	_, err = factory.CreateGate("endpoint-scrape", map[string]string{
+		"url": "http://localhost:8000/metrics",
+	})
+	assert.Error(t, err, "Should fail when metric is missing")
+}
+
+func TestGateFactory_EndpointScrape_FallbackOnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
+
+	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+		"url":      server.URL,
+		"metric":   "any",
+		"fallback": "0.5",
+	})
+	require.NoError(t, err)
+
+	budget := gate.Budget(context.Background())
+	assert.Equal(t, 0.5, budget, "Should return fallback on scrape error")
+}

--- a/test/integration/endpoint_scrape_gate_factory_test.go
+++ b/test/integration/endpoint_scrape_gate_factory_test.go
@@ -36,11 +36,11 @@ func TestGateFactory_EndpointScrape_StaticMaxCount(t *testing.T) {
 	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 200*time.Millisecond)
 
 	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
-		"url":                server.URL,
-		"metric":             "vllm:num_requests_waiting",
-		"max_count_per_pod":  "10",
-		"baseline":           "0.0",
-		"fallback":           "0.0",
+		"url":               server.URL,
+		"metric":            "vllm:num_requests_waiting",
+		"max_count_per_pod": "10",
+		"baseline":          "0.0",
+		"fallback":          "0.0",
 	})
 	require.NoError(t, err)
 
@@ -111,12 +111,12 @@ ready_pods{name="pool-a"} 3
 	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
 
 	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
-		"url":                simServer.URL,
-		"metric":             "vllm:num_requests_waiting",
-		"max_count_per_pod":  "10",
-		"pods_url":           podsServer.URL,
-		"pods_metric":        "ready_pods",
-		"pods_labels":        `{"name":"pool-a"}`,
+		"url":               simServer.URL,
+		"metric":            "vllm:num_requests_waiting",
+		"max_count_per_pod": "10",
+		"pods_url":          podsServer.URL,
+		"pods_metric":       "ready_pods",
+		"pods_labels":       `{"name":"pool-a"}`,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What does this PR do?

Adds a new endpoint-scrape dispatch gate type that scrapes raw Prometheus-formatted `/metrics` endpoints directly, without requiring a Prometheus server.

The gate reads a named metric from any endpoint exposing Prometheus text format (e.g., vLLM model servers, EPP), computes saturation, and returns a
dispatch budget in [0, 1]. It supports two modes:

- Direct saturation: the metric value is already a ratio in [0, 1] (e.g., EPP's `inference_extension_flow_control_pool_saturation`)
- Computed saturation: a raw count divided by a max capacity (e.g., `vllm:num_requests_waiting / (ready_pods * max_count_per_pod)`)

Dynamic pod count is supported by optionally scraping a second endpoint for `ready_pods`.


## Why is this change needed?

The existing Prometheus-based gates (`prometheus-saturation`, `prometheus-budget`, `prometheus-query`) require a Prometheus server to be deployed and scraping the relevant targets. This adds operational complexity, especially in smaller deployments or dev/test environments.

Model servers (vLLM) and the EPP already expose metrics on their `/metrics` endpoints. The endpoint-scrape gate scrapes these directly, making metric-based flow control available without any additional infrastructure.


## How was this tested?

- [x] Unit tests added/updated 
- [x] Integration/e2e tests added/updated 
- [x] Manual testing performed 





      # Unit + integration
      make test
      make test-integration
    
      # E2E (endpoint-scrape only)
      make test-e2e FOCUS="Endpoint Scrape"

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

related #194