### PR TITLE
release: ensure consistent submodule versioning

### DIFF
--- a/.github/workflows/ci-tag-submodules.yaml
+++ b/.github/workflows/ci-tag-submodules.yaml
@@ -1,0 +1,30 @@
+name: CI - Tag Go Submodules
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  tag-submodules:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Tag submodules
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          SUBMODULES=$(find . -mindepth 2 -maxdepth 2 -name go.mod -not -path './vendor/*' -exec dirname {} \; | sed 's|^\./||' | sort)
+          echo "Root tag: ${VERSION}"
+          echo "Detected submodules: ${SUBMODULES}"
+
+          for prefix in ${SUBMODULES}; do
+            TAG="${prefix}/${VERSION}"
+            echo "Creating tag: ${TAG}"
+            git tag "${TAG}"
+          done
+
+          git push origin --tags

--- a/.github/workflows/ci-tag-submodules.yaml
+++ b/.github/workflows/ci-tag-submodules.yaml
@@ -21,10 +21,20 @@ jobs:
           echo "Root tag: ${VERSION}"
           echo "Detected submodules: ${SUBMODULES}"
 
+          CREATED_TAGS=""
           for prefix in ${SUBMODULES}; do
             TAG="${prefix}/${VERSION}"
-            echo "Creating tag: ${TAG}"
-            git tag "${TAG}"
+            if git rev-parse "${TAG}" >/dev/null 2>&1; then
+              echo "Tag already exists, skipping: ${TAG}"
+            else
+              echo "Creating tag: ${TAG}"
+              git tag "${TAG}"
+              CREATED_TAGS="${CREATED_TAGS} ${TAG}"
+            fi
           done
 
-          git push origin --tags
+          if [ -n "${CREATED_TAGS}" ]; then
+            git push origin ${CREATED_TAGS}
+          else
+            echo "No new tags to push"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,31 @@ To add a new integration test, create a `*_test.go` file in `test/integration/` 
 package integration_test
 ```
 
+## Releasing
+
+This repository is a multi-module Go repo. The lightweight sub-modules (`api`, `pipeline`, `producer`) each have their own `go.mod` so that external consumers can depend on them without pulling in the heavyweight root module.
+
+### Preparing a release
+
+1. Update cross-module version references:
+
+```bash
+make set-version VERSION=v0.8.0
+```
+
+This rewrites all `require` directives across `go.mod` files and runs `go mod tidy`. Sub-modules are detected automatically from subdirectories containing a `go.mod`.
+
+2. Commit the result and push a tag on the root module:
+
+```bash
+git tag v0.8.0
+git push origin v0.8.0
+```
+
+3. The `CI - Tag Go Submodules` workflow automatically creates the prefixed tags required by Go modules (e.g. `api/v0.8.0`, `pipeline/v0.8.0`, `producer/v0.8.0`).
+
+Go requires sub-module tags to carry the directory prefix — see [Managing module source](https://go.dev/doc/modules/managing-source) for details.
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for our vulnerability disclosure process.

--- a/Makefile
+++ b/Makefile
@@ -344,8 +344,6 @@ endef
 
 # SUBMODULES discovers Go sub-modules by finding subdirectories with their own go.mod.
 SUBMODULES := $(patsubst %/go.mod,%,$(wildcard */go.mod))
-# Regex alternation for sed (e.g. api\|pipeline\|producer).
-SUBMODULES_RE := $(shell echo '$(SUBMODULES)' | sed 's/ /\\|/g')
 
 ## set-version: Update cross-module require versions in all go.mod files (e.g. make set-version VERSION=v0.8.0)
 .PHONY: set-version
@@ -353,11 +351,19 @@ set-version:
 	@if [ -z "$(VERSION)" ]; then \
 	  echo "VERSION is required (e.g. make set-version VERSION=v0.8.0)"; exit 1; \
 	fi
+	@if [ -z "$(SUBMODULES)" ]; then \
+	  echo "No submodules detected (no */go.mod found). Nothing to update."; exit 1; \
+	fi
 	@echo "Setting cross-module versions to $(VERSION)..."
 	@echo "Detected submodules: $(SUBMODULES)"
 	@for f in go.mod $(foreach m,$(SUBMODULES),$(m)/go.mod); do \
 	  if [ -f "$$f" ]; then \
-	    sed -i.bak -E 's|(github\.com/llm-d-incubation/llm-d-async/($(SUBMODULES_RE))) v[^ ]+|\1 $(VERSION)|g' "$$f" && rm -f "$$f.bak"; \
+	    dir=$$(dirname "$$f"); \
+	    for sub in $(SUBMODULES); do \
+	      if grep -q "github.com/llm-d-incubation/llm-d-async/$$sub " "$$f"; then \
+	        (cd "$$dir" && go mod edit -require "github.com/llm-d-incubation/llm-d-async/$$sub@$(VERSION)"); \
+	      fi; \
+	    done; \
 	  fi; \
 	done
 	@echo "Running go mod tidy..."
@@ -367,12 +373,14 @@ set-version:
 	done
 	@echo "Updated cross-module versions:"
 	@printf "  %-20s %-12s %s\n" "SOURCE" "REQUIRES" "VERSION"
-	@grep -rn 'llm-d-async/' ./go.mod ./*/go.mod \
-	  | grep -v module | grep -v replace \
-	  | sed -E 's|^([^:]+):[0-9]+:.*llm-d-async/($(SUBMODULES_RE)) (v[^ ]+).*|\1 \2 \3|' \
-	  | while read file sub ver; do \
-	    printf "  %-20s %-12s %s\n" "$$file" "$$sub" "$$ver"; \
-	  done
+	@for d in . $(SUBMODULES); do \
+	  if [ -f "$$d/go.mod" ]; then \
+	    (cd "$$d" && go mod edit -json | jq -r '.Require[]? | select(.Path | startswith("github.com/llm-d-incubation/llm-d-async/")) | "\(.Path | ltrimstr("github.com/llm-d-incubation/llm-d-async/")) \(.Version)"') \
+	    | while read sub ver; do \
+	      printf "  %-20s %-12s %s\n" "$$d/go.mod" "$$sub" "$$ver"; \
+	    done; \
+	  fi; \
+	done
 
 ## Copied from https://github.com/llm-d-incubation/batch-gateway
 ## publish-helm-chart: Patch chart for VERSION, package, append chart to SHA256SUMS, push to oci://ghcr.io/llm-d-incubation/charts (requires VERSION, yq, helm; GITHUB_TOKEN, GITHUB_ACTOR for push).

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,40 @@ mv $(1) $(1)-$(3) ;\
 ln -sf $(1)-$(3) $(1)
 endef
 
+##@ Release
+
+# SUBMODULES discovers Go sub-modules by finding subdirectories with their own go.mod.
+SUBMODULES := $(patsubst %/go.mod,%,$(wildcard */go.mod))
+# Regex alternation for sed (e.g. api\|pipeline\|producer).
+SUBMODULES_RE := $(shell echo '$(SUBMODULES)' | sed 's/ /\\|/g')
+
+## set-version: Update cross-module require versions in all go.mod files (e.g. make set-version VERSION=v0.8.0)
+.PHONY: set-version
+set-version:
+	@if [ -z "$(VERSION)" ]; then \
+	  echo "VERSION is required (e.g. make set-version VERSION=v0.8.0)"; exit 1; \
+	fi
+	@echo "Setting cross-module versions to $(VERSION)..."
+	@echo "Detected submodules: $(SUBMODULES)"
+	@for f in go.mod $(foreach m,$(SUBMODULES),$(m)/go.mod); do \
+	  if [ -f "$$f" ]; then \
+	    sed -i.bak -E 's|(github\.com/llm-d-incubation/llm-d-async/($(SUBMODULES_RE))) v[^ ]+|\1 $(VERSION)|g' "$$f" && rm -f "$$f.bak"; \
+	  fi; \
+	done
+	@echo "Running go mod tidy..."
+	@go mod tidy
+	@for d in $(SUBMODULES); do \
+	  if [ -f "$$d/go.mod" ]; then (cd "$$d" && go mod tidy); fi; \
+	done
+	@echo "Updated cross-module versions:"
+	@printf "  %-20s %-12s %s\n" "SOURCE" "REQUIRES" "VERSION"
+	@grep -rn 'llm-d-async/' ./go.mod ./*/go.mod \
+	  | grep -v module | grep -v replace \
+	  | sed -E 's|^([^:]+):[0-9]+:.*llm-d-async/($(SUBMODULES_RE)) (v[^ ]+).*|\1 \2 \3|' \
+	  | while read file sub ver; do \
+	    printf "  %-20s %-12s %s\n" "$$file" "$$sub" "$$ver"; \
+	  done
+
 ## Copied from https://github.com/llm-d-incubation/batch-gateway
 ## publish-helm-chart: Patch chart for VERSION, package, append chart to SHA256SUMS, push to oci://ghcr.io/llm-d-incubation/charts (requires VERSION, yq, helm; GITHUB_TOKEN, GITHUB_ACTOR for push).
 .PHONY: publish-helm-chart

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/llm-d-incubation/llm-d-async
 
 go 1.25.0
 
-require github.com/llm-d-incubation/llm-d-async/api v0.7.0-RC
+require github.com/llm-d-incubation/llm-d-async/api v0.7.0-rc.4
 
-require github.com/llm-d-incubation/llm-d-async/pipeline v0.7.0-RC
+require github.com/llm-d-incubation/llm-d-async/pipeline v0.7.0-rc.4
 
 replace github.com/llm-d-incubation/llm-d-async/api => ./api
 

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -2,6 +2,6 @@ module github.com/llm-d-incubation/llm-d-async/pipeline
 
 go 1.25.0
 
-require github.com/llm-d-incubation/llm-d-async/api v0.7.0-RC
+require github.com/llm-d-incubation/llm-d-async/api v0.7.0-rc.4
 
 replace github.com/llm-d-incubation/llm-d-async/api => ../api

--- a/producer/go.mod
+++ b/producer/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0
-	github.com/llm-d-incubation/llm-d-async/api v0.7.0-RC
+	github.com/llm-d-incubation/llm-d-async/api v0.7.0-rc.4
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 )


### PR DESCRIPTION
## What does this PR do?

Add a GH workflow + Makefile to update all versions of the submodules + tags.

E.g. say next version is v0.7.0-rc.5, the new flow becomes:

```
$ make set-version VERSION=v0.7.0-rc.5
Setting cross-module versions to v0.7.0-rc.5...
Running go mod tidy...
Updated cross-module versions:
  SOURCE               REQUIRES     VERSION
  ./go.mod             api          v0.7.0-rc.4
  ./go.mod             pipeline     v0.7.0-rc.4
  pipeline/go.mod      api          v0.7.0-rc.4
  producer/go.mod      api          v0.7.0-rc.4
$ git commit -asm 'bump: v0.7.0-rc.5'
$ git tag v0.7.0-rc.5
$ git push origin v0.7.0-rc.5
```

The GH workflow kicks off, and tags _also_:

- api/v0.7.0-rc.5
- pipeline/v0.7.0-rc.5
- producer/v0.7.0-rc.5

The modules are discovered automatically according to `**/go.mod`

## Why is this change needed?

Currently the process is quite error-prone: we need to replace the version numbers manually and tag each submodule.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

added a few lines in CONTRIBUTING.md

