### PR TITLE
prometheus: add labels for counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem
 **Example PromQL queries:**
 
 ```promql
-# Per-queue success rate over the last 5 minutes
-rate(llm_d_async_async_successful_requests_total[5m])
+# Per-queue success ratio over the last 5 minutes
+rate(llm_d_async_async_successful_requests_total[5m]) / rate(llm_d_async_async_request_total[5m])
 
 # Which queues are getting rate-limited?
 rate(llm_d_async_async_shedded_requests_total[5m])

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The architecture adheres to the following core principles:
     - [Request Merge Policy](#request-merge-policy)
   - [Retries](#retries)
   - [Results](#results)
+  - [Metrics](#metrics)
   - [Implementations](#implementations)
     - [Redis Sorted Set (Persisted)](#redis-sorted-set-persisted)
       - [Redis Sorted Set Command line parameters](#redis-sorted-set-command-line-parameters)
@@ -321,6 +322,40 @@ Results will be written to the results queue and will have the following structu
     // or
     "error" : "error's reason"
 }
+```
+
+## Metrics
+
+The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem. All counters and histograms carry `queue_id` and `queue_name` labels so you can filter and aggregate per queue.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `llm_d_async_async_request_total` | Counter | New async requests (first attempt only) |
+| `llm_d_async_async_successful_requests_total` | Counter | Requests that received a successful inference response |
+| `llm_d_async_async_failed_requests_total` | Counter | Requests that failed with a fatal or non-retryable error |
+| `llm_d_async_async_shedded_requests_total` | Counter | Requests shedded due to rate limiting (429 / capacity) |
+| `llm_d_async_async_exceeded_deadline_requests_total` | Counter | Requests that exceeded their deadline before completion |
+| `llm_d_async_async_request_retries_total` | Counter | Retry attempts |
+| `llm_d_async_async_message_latency_time_millis` | Histogram | End-to-end message latency in milliseconds (publish to successful processing). Only registered when the transport supports message latency (e.g., GCP Pub/Sub). |
+
+**Labels:**
+
+| Label | Description |
+|-------|-------------|
+| `queue_id` | Transport-level queue identifier |
+| `queue_name` | Logical queue name from the queue configuration |
+
+**Example PromQL queries:**
+
+```promql
+# Per-queue success rate over the last 5 minutes
+rate(llm_d_async_async_successful_requests_total[5m])
+
+# Which queues are getting rate-limited?
+rate(llm_d_async_async_shedded_requests_total[5m])
+
+# Retry ratio by queue
+rate(llm_d_async_async_request_retries_total[5m]) / rate(llm_d_async_async_request_total[5m])
 ```
 
 ## Implementations

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -34,9 +34,11 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 			if msg.InternalRequest == nil || msg.PublicRequest == nil {
 				continue
 			}
+			queueID := msg.QueueID
+			queueName := msg.RequestQueueName
 			if msg.RetryCount == 0 {
 				// Only count first attempt as a new request.
-				metrics.AsyncReqs.Inc()
+				metrics.RecordAsyncReq(queueID, queueName)
 			}
 			payloadBytes := validateAndMarshal(ctx, resultChannel, msg)
 			if payloadBytes == nil {
@@ -61,7 +63,7 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 
 				if err == nil {
 					// Success - got a valid response
-					metrics.SuccessfulReqs.Inc()
+					metrics.RecordSuccessfulReq(queueID, queueName)
 					select {
 					case resultChannel <- asyncapi.ResultMessage{
 						ID:       msg.PublicRequest.ReqID(),
@@ -89,7 +91,7 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 				var inferenceErr asyncapi.InferenceError
 				if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {
 					// Unknown error type or fatal error - fail immediately
-					metrics.FailedReqs.Inc()
+					metrics.RecordFailedReq(queueID, queueName)
 					select {
 					case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to send request to inference: %s", err.Error())):
 					case <-ctx.Done():
@@ -99,7 +101,7 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 
 				// Retryable error - check if it's due to rate limiting
 				if inferenceErr.Category().Sheddable() {
-					metrics.SheddedRequests.Inc()
+					metrics.RecordSheddedReq(queueID, queueName)
 				}
 				// Pass server-specified Retry-After duration if available.
 				var retryAfter time.Duration
@@ -119,10 +121,12 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	if msg.PublicRequest == nil {
 		return nil
 	}
+	queueID := msg.QueueID
+	queueName := msg.RequestQueueName
 	r := msg.PublicRequest
 	deadline := r.ReqDeadline()
 	if deadline <= 0 {
-		metrics.FailedReqs.Inc()
+		metrics.RecordFailedReq(queueID, queueName)
 		select {
 		case resultChannel <- CreateErrorResultMessage(r, msg.InternalRouting, "Failed: deadline is missing or invalid (Unix seconds)."):
 		case <-ctx.Done():
@@ -131,7 +135,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	}
 
 	if deadline < time.Now().Unix() {
-		metrics.ExceededDeadlineReqs.Inc()
+		metrics.RecordExceededDeadlineReq(queueID, queueName)
 		select {
 		case resultChannel <- CreateDeadlineExceededResultMessage(r, msg.InternalRouting):
 		case <-ctx.Done():
@@ -141,7 +145,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 
 	payloadBytes, err := json.Marshal(r.ReqPayload())
 	if err != nil {
-		metrics.FailedReqs.Inc()
+		metrics.RecordFailedReq(queueID, queueName)
 		select {
 		case resultChannel <- CreateErrorResultMessage(r, msg.InternalRouting, fmt.Sprintf("Failed to marshal message's payload: %s", err.Error())):
 		case <-ctx.Done():
@@ -156,10 +160,12 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	if msg.PublicRequest == nil {
 		return
 	}
+	queueID := msg.QueueID
+	queueName := msg.RequestQueueName
 	deadline := msg.PublicRequest.ReqDeadline()
 	secondsToDeadline := deadline - time.Now().Unix()
 	if secondsToDeadline <= 0 {
-		metrics.ExceededDeadlineReqs.Inc()
+		metrics.RecordExceededDeadlineReq(queueID, queueName)
 		select {
 		case resultChannel <- CreateDeadlineExceededResultMessage(msg.PublicRequest, msg.InternalRouting):
 		case <-ctx.Done():
@@ -175,7 +181,7 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	}
 
 	if finalDuration >= float64(secondsToDeadline) {
-		metrics.ExceededDeadlineReqs.Inc()
+		metrics.RecordExceededDeadlineReq(queueID, queueName)
 		select {
 		case resultChannel <- CreateDeadlineExceededResultMessage(msg.PublicRequest, msg.InternalRouting):
 		case <-ctx.Done():
@@ -184,7 +190,7 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	}
 
 	msg.RetryCount++
-	metrics.Retries.Inc()
+	metrics.RecordRetry(queueID, queueName)
 	select {
 	case retryChannel <- pipeline.RetryMessage{
 		EmbelishedRequestMessage: msg,

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -729,7 +729,7 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       nil,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
 			Header:     make(http.Header),
 		}, nil
 	})
@@ -737,7 +737,8 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
@@ -778,7 +779,7 @@ func TestMetrics_RateLimited(t *testing.T) {
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusTooManyRequests,
-			Body:       nil,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
 			Header:     make(http.Header),
 		}, nil
 	})
@@ -786,7 +787,8 @@ func TestMetrics_RateLimited(t *testing.T) {
 	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
@@ -825,7 +827,8 @@ func TestMetrics_FatalError(t *testing.T) {
 	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
@@ -858,13 +861,14 @@ func TestMetrics_DeadlineExceeded(t *testing.T) {
 	queueName := "metrics-deadline-queue"
 
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}, nil
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
 	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
@@ -894,13 +898,14 @@ func TestMetrics_LabelsIsolated(t *testing.T) {
 	queueB := "metrics-iso-b"
 
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}, nil
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
 	})
 	inferenceClient := NewHTTPInferenceClient(httpclient)
 	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -13,6 +13,10 @@ import (
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 )
 
 const defaultRequestTimeout = 5 * time.Minute
@@ -707,5 +711,233 @@ func TestWorker_RetriesOnShutdown(t *testing.T) {
 		t.Errorf("Expected retry, got fatal result: %s", r.Payload)
 	case <-time.After(5 * time.Second):
 		t.Errorf("Worker did not retry within 5s after shutdown")
+	}
+}
+
+func counterValue(cv *prometheus.CounterVec, queueID, queueName string) float64 {
+	c, err := cv.GetMetricWithLabelValues(queueID, queueName)
+	if err != nil {
+		return 0
+	}
+	return testutil.ToFloat64(c)
+}
+
+func TestMetrics_SuccessfulRequest(t *testing.T) {
+	queueID := "metrics-success-qid"
+	queueName := "metrics-success-queue"
+
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       nil,
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{
+		QueueID:          queueID,
+		RequestQueueName: queueName,
+	}, asyncapi.RequestMessage{
+		ID:       "m-success",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-resultChannel:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	if got := counterValue(metrics.AsyncReqs, queueID, queueName); got < 1 {
+		t.Errorf("AsyncReqs(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+	if got := counterValue(metrics.SuccessfulReqs, queueID, queueName); got < 1 {
+		t.Errorf("SuccessfulReqs(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+	if got := counterValue(metrics.FailedReqs, queueID, queueName); got != 0 {
+		t.Errorf("FailedReqs(%s,%s) = %f, want 0", queueID, queueName, got)
+	}
+	if got := counterValue(metrics.SheddedRequests, queueID, queueName); got != 0 {
+		t.Errorf("SheddedRequests(%s,%s) = %f, want 0", queueID, queueName, got)
+	}
+}
+
+func TestMetrics_RateLimited(t *testing.T) {
+	queueID := "metrics-shedded-qid"
+	queueName := "metrics-shedded-queue"
+
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       nil,
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{
+		QueueID:          queueID,
+		RequestQueueName: queueName,
+	}, asyncapi.RequestMessage{
+		ID:       "m-shedded",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-retryChannel:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	if got := counterValue(metrics.SheddedRequests, queueID, queueName); got < 1 {
+		t.Errorf("SheddedRequests(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+	if got := counterValue(metrics.Retries, queueID, queueName); got < 1 {
+		t.Errorf("Retries(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+}
+
+func TestMetrics_FatalError(t *testing.T) {
+	queueID := "metrics-fatal-qid"
+	queueName := "metrics-fatal-queue"
+
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("connection refused")
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{
+		QueueID:          queueID,
+		RequestQueueName: queueName,
+	}, asyncapi.RequestMessage{
+		ID:       "m-fatal",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-resultChannel:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	if got := counterValue(metrics.FailedReqs, queueID, queueName); got < 1 {
+		t.Errorf("FailedReqs(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+	if got := counterValue(metrics.SuccessfulReqs, queueID, queueName); got != 0 {
+		t.Errorf("SuccessfulReqs(%s,%s) = %f, want 0", queueID, queueName, got)
+	}
+}
+
+func TestMetrics_DeadlineExceeded(t *testing.T) {
+	queueID := "metrics-deadline-qid"
+	queueName := "metrics-deadline-queue"
+
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{
+		QueueID:          queueID,
+		RequestQueueName: queueName,
+	}, asyncapi.RequestMessage{
+		ID:       "m-deadline",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(-10 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-resultChannel:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	if got := counterValue(metrics.ExceededDeadlineReqs, queueID, queueName); got < 1 {
+		t.Errorf("ExceededDeadlineReqs(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+}
+
+func TestMetrics_LabelsIsolated(t *testing.T) {
+	queueA := "metrics-iso-a"
+	queueB := "metrics-iso-b"
+
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+	deadline := time.Now().Add(100 * time.Second).Unix()
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{
+		QueueID: queueA, RequestQueueName: queueA,
+	}, asyncapi.RequestMessage{
+		ID: "iso-a", Created: time.Now().Unix(), Deadline: deadline,
+		Payload: map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-resultChannel:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message A")
+	}
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{
+		QueueID: queueB, RequestQueueName: queueB,
+	}, asyncapi.RequestMessage{
+		ID: "iso-b", Created: time.Now().Unix(), Deadline: deadline,
+		Payload: map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-resultChannel:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message B")
+	}
+
+	aCount := counterValue(metrics.SuccessfulReqs, queueA, queueA)
+	bCount := counterValue(metrics.SuccessfulReqs, queueB, queueB)
+	if aCount < 1 {
+		t.Errorf("SuccessfulReqs for queue A = %f, want >= 1", aCount)
+	}
+	if bCount < 1 {
+		t.Errorf("SuccessfulReqs for queue B = %f, want >= 1", bCount)
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,39 +11,72 @@ import (
 const (
 	// SchedulerSubsystem is the metric prefix of the package.
 	SchedulerSubsystem = "llm_d_async"
+
+	LabelQueueID   = "queue_id"
+	LabelQueueName = "queue_name"
 )
 
+var queueLabels = []string{LabelQueueID, LabelQueueName}
+
 var (
-	Retries = prometheus.NewCounter(prometheus.CounterOpts{
+	Retries = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_request_retries_total",
 		Help: "Total number of async request retries.",
-	})
-	AsyncReqs = prometheus.NewCounter(prometheus.CounterOpts{
+	}, queueLabels)
+	AsyncReqs = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_request_total",
 		Help: "Total number of async requests.",
-	})
-	ExceededDeadlineReqs = prometheus.NewCounter(prometheus.CounterOpts{
+	}, queueLabels)
+	ExceededDeadlineReqs = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_exceeded_deadline_requests_total",
 		Help: "Total number of async requests that exceeded their deadline.",
-	})
-	FailedReqs = prometheus.NewCounter(prometheus.CounterOpts{
+	}, queueLabels)
+	FailedReqs = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_failed_requests_total",
 		Help: "Total number of async requests that failed.",
-	})
-	SuccessfulReqs = prometheus.NewCounter(prometheus.CounterOpts{
+	}, queueLabels)
+	SuccessfulReqs = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_successful_requests_total",
 		Help: "Total number of async requests that succeeded.",
-	})
-	SheddedRequests = prometheus.NewCounter(prometheus.CounterOpts{
+	}, queueLabels)
+	SheddedRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_shedded_requests_total",
 		Help: "Total number of async requests that were shedded.",
-	})
-	MessageLatencyTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+	}, queueLabels)
+	MessageLatencyTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_message_latency_time_millis",
 		Help:    "Time from message publish to message being successfully processed.",
 		Buckets: []float64{100, 1000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000},
-	})
+	}, queueLabels)
 )
+
+func RecordRetry(queueID, queueName string) {
+	Retries.WithLabelValues(queueID, queueName).Inc()
+}
+
+func RecordAsyncReq(queueID, queueName string) {
+	AsyncReqs.WithLabelValues(queueID, queueName).Inc()
+}
+
+func RecordExceededDeadlineReq(queueID, queueName string) {
+	ExceededDeadlineReqs.WithLabelValues(queueID, queueName).Inc()
+}
+
+func RecordFailedReq(queueID, queueName string) {
+	FailedReqs.WithLabelValues(queueID, queueName).Inc()
+}
+
+func RecordSuccessfulReq(queueID, queueName string) {
+	SuccessfulReqs.WithLabelValues(queueID, queueName).Inc()
+}
+
+func RecordSheddedReq(queueID, queueName string) {
+	SheddedRequests.WithLabelValues(queueID, queueName).Inc()
+}
+
+func RecordMessageLatency(millis float64, queueID, queueName string) {
+	MessageLatencyTime.WithLabelValues(queueID, queueName).Observe(millis)
+}
 
 // GetCollectors returns all custom collectors for the async processor.
 func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Collector {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -362,7 +362,7 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 		if !result {
 			msg.Nack()
 		} else {
-			metrics.MessageLatencyTime.Observe(float64(time.Since(msg.PublishTime).Milliseconds()))
+			metrics.RecordMessageLatency(float64(time.Since(msg.PublishTime).Milliseconds()), ir.QueueID, ir.RequestQueueName)
 			msg.Ack()
 		}
 	})


### PR DESCRIPTION
## What does this PR do?

Converts all Prometheus counters and the histogram in `pkg/metrics` from flat globals (`prometheus.Counter` / `prometheus.Histogram`) to label-bearing vectors (`*prometheus.CounterVec` / `*prometheus.HistogramVec`) with `queue_id` and `queue_name` labels. Adds `Record*()` helper functions so call sites don't touch `WithLabelValues` directly. Updates all increment sites in the worker and pubsub packages to pass queue identity through to every metric.

## Why is this change needed?

With flat counters you can see total retries, total shedded requests, etc., but you can't tell *which queue* is getting rate-limited or which is succeeding. The worker already carries `QueueID` and `RequestQueueName` on every message — this PR threads them into the metrics so operators can filter and alert per queue.

Will follow up with a PR to expand on OTel support.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

Five new tests in `pkg/asyncworker/worker_test.go`:
- `TestMetrics_SuccessfulRequest` — 200 OK increments `AsyncReqs` + `SuccessfulReqs` for the correct labels; `FailedReqs`/`SheddedRequests` stay at 0.
- `TestMetrics_RateLimited` — 429 increments `SheddedRequests` + `Retries` for the correct labels.
- `TestMetrics_FatalError` — transport error increments `FailedReqs`; `SuccessfulReqs` stays at 0.
- `TestMetrics_DeadlineExceeded` — expired deadline increments `ExceededDeadlineReqs`.
- `TestMetrics_LabelsIsolated` — two messages with different queue names get independent counters, proving labels don't bleed.

All 21 worker tests pass (16 existing + 5 new).

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

