### PR TITLE
fix: broken worker shutdown path

### DIFF
--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -37,13 +37,20 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 			logger.V(logutil.DEFAULT).Info("Worker finishing, draining request channel.")
 			for {
 				select {
-				case msg := <-requestChannel:
+				case msg, ok := <-requestChannel:
+					if !ok {
+						return
+					}
 					if msg.InternalRequest == nil || msg.PublicRequest == nil {
 						continue
 					}
-					retryChannel <- pipeline.RetryMessage{
+					select {
+					case retryChannel <- pipeline.RetryMessage{
 						EmbelishedRequestMessage: msg,
 						BackoffDurationSeconds:   0,
+					}:
+					default:
+						logger.V(logutil.DEFAULT).Error(nil, "retry channel full, dropping message on shutdown", "id", msg.PublicRequest.ReqID())
 					}
 				default:
 					return

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -34,8 +34,21 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 	for {
 		select {
 		case <-ctx.Done():
-			logger.V(logutil.DEFAULT).Info("Worker finishing.")
-			return
+			logger.V(logutil.DEFAULT).Info("Worker finishing, draining request channel.")
+			for {
+				select {
+				case msg := <-requestChannel:
+					if msg.InternalRequest == nil || msg.PublicRequest == nil {
+						continue
+					}
+					retryChannel <- pipeline.RetryMessage{
+						EmbelishedRequestMessage: msg,
+						BackoffDurationSeconds:   0,
+					}
+				default:
+					return
+				}
+			}
 		case msg := <-requestChannel:
 			if msg.InternalRequest == nil || msg.PublicRequest == nil {
 				continue

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -784,11 +784,13 @@ func TestWorker_DrainsBufferedMessagesOnShutdown(t *testing.T) {
 			}
 
 			got := make(map[string]bool)
+			timeout := time.After(5 * time.Second)
 			for range tt.messages {
 				select {
 				case msg := <-retryChannel:
 					got[msg.PublicRequest.ReqID()] = true
-				default:
+				case <-timeout:
+					t.Fatal("timed out waiting for re-queued messages")
 				}
 			}
 			for _, id := range ids {

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -716,6 +717,86 @@ func TestWorker_RetriesOnShutdown(t *testing.T) {
 		t.Errorf("Expected retry, got fatal result: %s", r.Payload)
 	case <-time.After(5 * time.Second):
 		t.Errorf("Worker did not retry within 5s after shutdown")
+	}
+}
+
+func TestWorker_DrainsBufferedMessagesOnShutdown(t *testing.T) {
+	tests := []struct {
+		name        string
+		concurrency int
+		messages    int
+	}{
+		{"single worker with buffered messages", 1, 3},
+		{"multiple workers fewer than messages", 2, 5},
+		{"multiple workers more than messages", 4, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inFlightCount := min(tt.concurrency, tt.messages)
+			reqStarted := make(chan struct{}, inFlightCount)
+			httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+				select {
+				case reqStarted <- struct{}{}:
+				default:
+				}
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			})
+			inferenceClient := NewHTTPInferenceClient(httpclient)
+			requestChannel := make(chan pipeline.EmbelishedRequestMessage, tt.messages)
+			retryChannel := make(chan pipeline.RetryMessage, tt.messages)
+			resultChannel := make(chan asyncapi.ResultMessage, tt.messages)
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			var wg sync.WaitGroup
+			for w := 0; w < tt.concurrency; w++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+				}()
+			}
+
+			ids := make([]string, tt.messages)
+			for i := range tt.messages {
+				ids[i] = fmt.Sprintf("drain-%d", i)
+				requestChannel <- newEmb(asyncapi.RequestMessage{
+					ID:       ids[i],
+					Created:  time.Now().Unix(),
+					Deadline: time.Now().Add(5 * time.Minute).Unix(),
+					Payload:  map[string]any{"model": "test", "prompt": "hi"},
+				}, "http://localhost:30800/v1/completions", map[string]string{})
+			}
+
+			for range inFlightCount {
+				<-reqStarted
+			}
+			cancel()
+
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Workers did not exit within 5s")
+			}
+
+			got := make(map[string]bool)
+			for range tt.messages {
+				select {
+				case msg := <-retryChannel:
+					got[msg.PublicRequest.ReqID()] = true
+				default:
+				}
+			}
+			for _, id := range ids {
+				if !got[id] {
+					t.Errorf("message %s was not re-queued on shutdown", id)
+				}
+			}
+		})
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -58,7 +58,7 @@ var (
 	containerRuntime = detectContainerRuntime()
 	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d-incubation/async-processor:e2e-test", ginkgo.GinkgoLogr)
 	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
-	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.0.0-test", ginkgo.GinkgoLogr)
+	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.9.1", ginkgo.GinkgoLogr)
 	gaieRoot         = os.Getenv("GAIE_ROOT")
 	simRoot          = os.Getenv("SIM_ROOT")
 

--- a/test/integration/worker_dispatch_test.go
+++ b/test/integration/worker_dispatch_test.go
@@ -24,7 +24,7 @@ import (
 // (only one in-flight), all messages are re-queued via the retry channel.
 // This exercises the drain loop added to the Worker's ctx.Done() handler.
 func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
-	serverHit := make(chan struct{})
+	serverHit := make(chan struct{}, 1)
 	serverDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
@@ -77,11 +77,13 @@ func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
 	wg.Wait()
 
 	got := make(map[string]bool)
+	timeout := time.After(5 * time.Second)
 	for range ids {
 		select {
 		case msg := <-retryChannel:
 			got[msg.PublicRequest.ReqID()] = true
-		default:
+		case <-timeout:
+			t.Fatal("timed out waiting for re-queued messages")
 		}
 	}
 	for _, id := range ids {

--- a/test/integration/worker_dispatch_test.go
+++ b/test/integration/worker_dispatch_test.go
@@ -19,6 +19,76 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestWorkerDispatch_DrainsBufferedOnShutdown verifies that when the parent
+// context is cancelled with multiple messages buffered in the request channel
+// (only one in-flight), all messages are re-queued via the retry channel.
+// This exercises the drain loop added to the Worker's ctx.Done() handler.
+func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
+	serverHit := make(chan struct{})
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case serverHit <- struct{}{}:
+		default:
+		}
+		<-serverDone
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer func() {
+		close(serverDone)
+		server.Close()
+	}()
+
+	client := asyncworker.NewHTTPInferenceClient(server.Client())
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 3)
+	retryChannel := make(chan pipeline.RetryMessage, 3)
+	resultChannel := make(chan asyncapi.ResultMessage, 3)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+	}()
+
+	ids := []string{"drain-int-1", "drain-int-2", "drain-int-3"}
+	for _, id := range ids {
+		ir := asyncapi.NewInternalRequest(
+			asyncapi.InternalRouting{RequestQueueName: "test-queue"},
+			&asyncapi.RequestMessage{
+				ID:       id,
+				Created:  time.Now().Unix(),
+				Deadline: time.Now().Add(5 * time.Minute).Unix(),
+				Payload:  map[string]any{"model": "test", "prompt": "hello"},
+			},
+		)
+		requestChannel <- pipeline.EmbelishedRequestMessage{
+			InternalRequest: ir,
+			HttpHeaders:     map[string]string{"Content-Type": "application/json"},
+			RequestURL:      server.URL + "/v1/completions",
+		}
+	}
+
+	<-serverHit
+	cancel()
+	wg.Wait()
+
+	got := make(map[string]bool)
+	for range ids {
+		select {
+		case msg := <-retryChannel:
+			got[msg.PublicRequest.ReqID()] = true
+		default:
+		}
+	}
+	for _, id := range ids {
+		assert.True(t, got[id], "message %s should have been re-queued on shutdown", id)
+	}
+}
+
 // TestWorkerDispatch_MockIGW spawns an httptest.Server as a mock inference
 // gateway and verifies that the Worker correctly assembles the request URL,
 // forwards headers, sends the payload, and routes the result back.


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in the Worker shutdown path where messages buffered in the request
channel could be lost when the context is cancelled. When the Worker's select picks
ctx.Done() over a buffered message, it now drains remaining messages from the request
channel and re-enqueues them via retryChannel before exiting.

Also bumps the default llm-d-inference-sim image tag from v0.0.0-test to v0.9.1.

## Why is this change needed?

The E2E test "re-queues in-flight messages on pod termination" was flaky (2 out of 3
messages re-queued instead of 3). Root cause: with `concurrency: 1`, only one Worker
goroutine processes messages. When 3 messages are enqueued, only 1 is in-flight (HTTP
call). The other 2 sit in the request channel buffer. On shutdown, Go's select picks
randomly between `ctx.Done()` and reading buffered messages; if it picks `ctx.Done()`, the
buffered messages are silently dropped. This applies at any concurrency where buffered
messages exceed available workers.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #235
