### PR TITLE
feat: two-phase graceful shutdown with in-flight request draining

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -75,6 +75,7 @@ spec:
           - --prometheus-cache-ttl={{ .Values.ap.prometheusCacheTTL }}
           {{- end }}
           - --concurrency={{ .Values.ap.concurrency | default 8 }}
+          - --drain-timeout={{ .Values.ap.drainTimeout | default "2m" }}
           - --metrics-endpoint-auth={{ .Values.ap.metrics.secure }}
           {{- if and .Values.ap.otel.redisTracing .Values.ap.otel.endpoint }}
           - --redis-tracing=true

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -5,6 +5,7 @@ ap:
     tag: 0.6.0
   imagePullPolicy: Always
   concurrency: 8
+  drainTimeout: "2m"
   prometheusURL: ""
   prometheusCacheTTL: ""
   otel:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,8 @@ func main() {
 
 	var redisTracing bool
 
+	var drainTimeout time.Duration
+
 	var tlsCACert string
 	var tlsCert string
 	var tlsKey string
@@ -58,6 +60,7 @@ func main() {
 
 	flag.IntVar(&concurrency, "concurrency", 8, "number of concurrent workers")
 	flag.DurationVar(&requestTimeout, "request-timeout", 5*time.Minute, "timeout for individual inference requests")
+	flag.DurationVar(&drainTimeout, "drain-timeout", 2*time.Minute, "maximum time to wait for in-flight requests to complete after SIGTERM")
 
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
 	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
@@ -149,13 +152,16 @@ func main() {
 
 	metrics.Register(metrics.GetAsyncProcessorCollectors(impl.Characteristics().SupportsMessageLatency)...)
 
-	ctx := ctrl.SetupSignalHandler()
+	signalCtx := ctrl.SetupSignalHandler()
 
 	// Register metrics handler.
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:
 	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/metrics/server
 	// - https://book.kubebuilder.io/reference/metrics.html
+	drainCtx, drainCancel := context.WithCancel(logr.NewContext(context.Background(), setupLog))
+	defer drainCancel()
+
 	metricsServerOptions := metricsserver.Options{
 		BindAddress: fmt.Sprintf(":%d", metricsPort),
 		FilterProvider: func() func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
@@ -173,7 +179,7 @@ func main() {
 		setupLog.Error(err, "Failed to create metrics server")
 		os.Exit(1)
 	}
-	go msrv.Start(ctx) // nolint:errcheck
+	go msrv.Start(signalCtx) // nolint:errcheck
 
 	tlsConfig, err := buildTLSConfig(tlsCACert, tlsCert, tlsKey, tlsInsecureSkipVerify)
 	if err != nil {
@@ -201,13 +207,28 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			asyncworker.Worker(ctx, impl.Characteristics(), inferenceClient, requestChannel, impl.RetryChannel(), impl.ResultChannel(), requestTimeout)
+			asyncworker.Worker(signalCtx, drainCtx, impl.Characteristics(), inferenceClient, requestChannel, impl.RetryChannel(), impl.ResultChannel(), requestTimeout)
 		}()
 	}
 
-	impl.Start(ctx)
-	<-ctx.Done()
-	wg.Wait()
+	impl.Start(signalCtx)
+	<-signalCtx.Done()
+
+	setupLog.Info("Signal received, stopping message consumption")
+	impl.StopConsuming()
+
+	setupLog.Info("Draining in-flight requests", "timeout", drainTimeout)
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		setupLog.Info("All workers drained successfully")
+	case <-time.After(drainTimeout):
+		setupLog.Info("Drain timeout reached, cancelling in-flight requests")
+		drainCancel()
+		wg.Wait()
+	}
+
 	impl.Shutdown()
 }
 

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -9,6 +9,7 @@ import (
 type Flow interface {
 	Characteristics() Characteristics
 	Start(ctx context.Context)
+	StopConsuming()
 	Shutdown()
 	RequestChannels() []RequestChannel
 	RetryChannel() chan RetryMessage

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -39,13 +39,29 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 			defer idle.Stop()
 			for {
 				select {
-				case msg := <-requestChannel:
+				case msg, ok := <-requestChannel:
+					if !ok {
+						return
+					}
 					if msg.InternalRequest == nil || msg.PublicRequest == nil {
 						continue
 					}
-					retryChannel <- pipeline.RetryMessage{
+					retryMsg := pipeline.RetryMessage{
 						EmbelishedRequestMessage: msg,
 						BackoffDurationSeconds:   0,
+					}
+					select {
+					case retryChannel <- retryMsg:
+					default:
+						select {
+						case retryChannel <- retryMsg:
+						case <-requestCtx.Done():
+							logger.V(logutil.DEFAULT).Error(nil, "drain timeout reached, dropping message", "id", msg.PublicRequest.ReqID())
+							return
+						}
+					}
+					if !idle.Stop() {
+						<-idle.C
 					}
 					idle.Reset(100 * time.Millisecond)
 				case <-idle.C:

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -27,32 +27,28 @@ const (
 	maxDelaySeconds  = 60
 )
 
-func Worker(ctx context.Context, characteristics pipeline.Characteristics, client asyncapi.InferenceClient, requestChannel chan pipeline.EmbelishedRequestMessage,
+func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Characteristics, client asyncapi.InferenceClient, requestChannel chan pipeline.EmbelishedRequestMessage,
 	retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, requestTimeout time.Duration) {
 
-	logger := log.FromContext(ctx)
+	logger := log.FromContext(requestCtx)
 	for {
 		select {
-		case <-ctx.Done():
+		case <-consumeCtx.Done():
 			logger.V(logutil.DEFAULT).Info("Worker finishing, draining request channel.")
+			idle := time.NewTimer(100 * time.Millisecond)
+			defer idle.Stop()
 			for {
 				select {
-				case msg, ok := <-requestChannel:
-					if !ok {
-						return
-					}
+				case msg := <-requestChannel:
 					if msg.InternalRequest == nil || msg.PublicRequest == nil {
 						continue
 					}
-					select {
-					case retryChannel <- pipeline.RetryMessage{
+					retryChannel <- pipeline.RetryMessage{
 						EmbelishedRequestMessage: msg,
 						BackoffDurationSeconds:   0,
-					}:
-					default:
-						logger.V(logutil.DEFAULT).Error(nil, "retry channel full, dropping message on shutdown", "id", msg.PublicRequest.ReqID())
 					}
-				default:
+					idle.Reset(100 * time.Millisecond)
+				case <-idle.C:
 					return
 				}
 			}
@@ -63,18 +59,15 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 			queueID := msg.QueueID
 			queueName := msg.RequestQueueName
 			if msg.RetryCount == 0 {
-				// Only count first attempt as a new request.
 				metrics.RecordAsyncReq(queueID, queueName)
 			}
-			payloadBytes := validateAndMarshal(ctx, resultChannel, msg)
+			payloadBytes := validateAndMarshal(requestCtx, resultChannel, msg)
 			if payloadBytes == nil {
 				continue
 			}
 
-			// Using a function object for easy boundaries for 'return' and 'defer'!
 			sendInferenceRequest := func() {
-				// Restore parent trace context from request metadata (producer injects W3C trace context).
-				reqCtx := ctx
+				reqCtx := requestCtx
 				if md := msg.PublicRequest.ReqMetadata(); len(md) > 0 {
 					reqCtx = otel.GetTextMapPropagator().Extract(reqCtx, propagation.MapCarrier(md))
 				}
@@ -94,8 +87,6 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 				)
 				defer span.End()
 
-				// Create a per-request context bounded by both the message deadline
-				// and the configured request timeout, whichever comes first.
 				reqDeadline := time.Now().Add(requestTimeout)
 				if dline := msg.PublicRequest.ReqDeadline(); dline > 0 {
 					if msgDeadline := time.Unix(dline, 0); msgDeadline.Before(reqDeadline) {
@@ -109,7 +100,6 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 				responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
 
 				if err == nil {
-					// Success - got a valid response
 					metrics.RecordSuccessfulReq(queueID, queueName)
 					select {
 					case resultChannel <- asyncapi.ResultMessage{
@@ -118,15 +108,12 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 						Routing:  msg.InternalRouting,
 						Metadata: msg.PublicRequest.ReqMetadata(),
 					}:
-					case <-ctx.Done():
+					case <-requestCtx.Done():
 					}
 					return
 				}
 
-				// Shutdown: parent context cancelled and the error is context-related
-				// (not a completed HTTP response like 4xx). Re-enqueue directly —
-				// retryMessage's select would take ctx.Done() immediately.
-				if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				if requestCtx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 					_, bgSpan := uotel.DetachedContext(reqCtx, "re-enqueue")
 					bgSpan.SetAttributes(attribute.String(uotel.AttrRequestID, msg.PublicRequest.ReqID()))
 					defer bgSpan.End()
@@ -137,33 +124,29 @@ func Worker(ctx context.Context, characteristics pipeline.Characteristics, clien
 					return
 				}
 
-				// Check if error implements InferenceError
 				var inferenceErr asyncapi.InferenceError
 				if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {
-					// Unknown error type or fatal error - fail immediately
 					span.RecordError(err)
 					span.SetStatus(codes.Error, "inference request failed")
 					span.SetAttributes(attribute.String(uotel.AttrErrorCategory, inferenceErrorCategory(err)))
 					metrics.RecordFailedReq(queueID, queueName)
 					select {
 					case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to send request to inference: %s", err.Error())):
-					case <-ctx.Done():
+					case <-requestCtx.Done():
 					}
 					return
 				}
 
-				// Retryable error - check if it's due to rate limiting
 				if inferenceErr.Category().Sheddable() {
 					metrics.RecordSheddedReq(queueID, queueName)
 				}
 				span.SetAttributes(attribute.String(uotel.AttrErrorCategory, string(inferenceErr.Category())))
-				// Pass server-specified Retry-After duration if available.
 				var retryAfter time.Duration
 				var clientErr *asyncapi.ClientError
 				if errors.As(err, &clientErr) {
 					retryAfter = clientErr.RetryAfter
 				}
-				retryMessage(ctx, msg, retryChannel, resultChannel, retryAfter)
+				retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter)
 			}
 			sendInferenceRequest()
 		}

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -132,7 +132,7 @@ func TestSheddedRequest(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -168,7 +168,7 @@ func TestSuccessfulRequest(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -202,7 +202,7 @@ func TestFatalError_NoRetry(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -248,7 +248,7 @@ func TestRateLimitRequest(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -284,7 +284,7 @@ func TestRequestTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Use a very short request timeout to trigger the deadline.
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -517,7 +517,7 @@ func TestRateLimitRequest_WithRetryAfterHeader(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -615,7 +615,7 @@ func TestWorker_cancelledCtxExitsPromptly(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 		close(done)
 	}()
 
@@ -655,7 +655,7 @@ func TestClientError_NoRetry(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -696,7 +696,7 @@ func TestWorker_RetriesOnShutdown(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID:       msgId,
@@ -755,7 +755,7 @@ func TestWorker_DrainsBufferedMessagesOnShutdown(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+					Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 				}()
 			}
 
@@ -828,7 +828,7 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -878,7 +878,7 @@ func TestMetrics_RateLimited(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -918,7 +918,7 @@ func TestMetrics_FatalError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -958,7 +958,7 @@ func TestMetrics_DeadlineExceeded(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -995,7 +995,7 @@ func TestMetrics_LabelsIsolated(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	deadline := time.Now().Add(100 * time.Second).Unix()
 
@@ -1079,7 +1079,7 @@ func TestWorker_SpanOnSuccess(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-success", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1120,7 +1120,7 @@ func TestWorker_SpanOnFatalError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-fatal", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1161,7 +1161,7 @@ func TestWorker_SpanOnRetryableError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-429", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1199,7 +1199,7 @@ func TestWorker_SpanOnServerError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-500", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1242,7 +1242,7 @@ func TestWorker_TraceContextExtraction(t *testing.T) {
 	otel.GetTextMapPropagator().Inject(parentCtx, propagation.MapCarrier(metadata))
 	parentSpan.End()
 
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-ctx", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1281,7 +1281,7 @@ func TestWorker_SpanOnShutdownReenqueue(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-shutdown", Created: time.Now().Unix(), Deadline: time.Now().Add(5 * time.Minute).Unix(),
@@ -1337,7 +1337,7 @@ func TestWorker_SpanIncludesQueueName(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
 	requestChannel <- newEmbR(
 		asyncapi.InternalRouting{QueueID: "my-test-qid", RequestQueueName: "my-test-queue"},
@@ -1362,5 +1362,116 @@ func TestWorker_SpanIncludesQueueName(t *testing.T) {
 	}
 	if spanAttr(s, uotel.AttrQueueName) != "my-test-queue" {
 		t.Errorf("expected queue.name=my-test-queue, got %s", spanAttr(s, uotel.AttrQueueName))
+	}
+}
+
+func TestWorker_InFlightCompletesOnConsumeCancel(t *testing.T) {
+	msgId := "inflight-complete"
+	reqStarted := make(chan struct{})
+	reqDone := make(chan struct{})
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		close(reqStarted)
+		<-reqDone
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"result":"ok"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	consumeCtx, consumeCancel := context.WithCancel(context.Background())
+	requestCtx, requestCancel := context.WithCancel(context.Background())
+	defer requestCancel()
+
+	done := make(chan struct{})
+	go func() {
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		close(done)
+	}()
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       msgId,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(5 * time.Minute).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	<-reqStarted
+	consumeCancel()
+	close(reqDone)
+
+	select {
+	case r := <-resultChannel:
+		if r.ID != msgId {
+			t.Errorf("Expected result message id %s, got %s", msgId, r.ID)
+		}
+	case msg := <-retryChannel:
+		t.Errorf("Expected successful result, got retry for %s", msg.PublicRequest.ReqID())
+	case <-time.After(5 * time.Second):
+		t.Fatal("Worker did not return result within 5s")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker did not exit after consumeCtx cancel and request completion")
+	}
+}
+
+func TestWorker_DrainTimeoutCancelsInFlight(t *testing.T) {
+	msgId := "drain-timeout"
+	reqStarted := make(chan struct{})
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		close(reqStarted)
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	consumeCtx, consumeCancel := context.WithCancel(context.Background())
+	requestCtx, requestCancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		close(done)
+	}()
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       msgId,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(5 * time.Minute).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	<-reqStarted
+	consumeCancel()
+	requestCancel()
+
+	select {
+	case msg := <-retryChannel:
+		if msg.PublicRequest.ReqID() != msgId {
+			t.Errorf("Expected retry message id %s, got %s", msgId, msg.PublicRequest.ReqID())
+		}
+		if msg.BackoffDurationSeconds != 0 {
+			t.Errorf("Expected zero backoff on shutdown re-enqueue, got %f", msg.BackoffDurationSeconds)
+		}
+	case r := <-resultChannel:
+		t.Errorf("Expected retry on drain timeout, got result: %s", r.Payload)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Worker did not re-enqueue within 5s after drain timeout")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker did not exit after drain timeout")
 	}
 }

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -748,14 +748,15 @@ func TestWorker_DrainsBufferedMessagesOnShutdown(t *testing.T) {
 			retryChannel := make(chan pipeline.RetryMessage, tt.messages)
 			resultChannel := make(chan asyncapi.ResultMessage, tt.messages)
 
-			ctx, cancel := context.WithCancel(context.Background())
+			consumeCtx, consumeCancel := context.WithCancel(context.Background())
+			requestCtx, requestCancel := context.WithCancel(context.Background())
 
 			var wg sync.WaitGroup
 			for w := 0; w < tt.concurrency; w++ {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+					Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 				}()
 			}
 
@@ -773,7 +774,8 @@ func TestWorker_DrainsBufferedMessagesOnShutdown(t *testing.T) {
 			for range inFlightCount {
 				<-reqStarted
 			}
-			cancel()
+			consumeCancel()
+			requestCancel()
 
 			done := make(chan struct{})
 			go func() { wg.Wait(); close(done) }()

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -54,6 +54,8 @@ type PubSubMQFlow struct {
 	resultChannel   chan api.ResultMessage
 	gate            pipeline.DispatchGate
 	gateFactory     pipeline.GateFactory
+	consumeCancel   context.CancelFunc
+	consumeWg       sync.WaitGroup
 	drainCancel     context.CancelFunc
 	drainWg         sync.WaitGroup
 }
@@ -174,16 +176,31 @@ func (r *PubSubMQFlow) RequestChannels() []pipeline.RequestChannel {
 }
 
 func (r *PubSubMQFlow) Start(ctx context.Context) {
-	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), log.FromContext(ctx)))
+	logger := log.FromContext(ctx)
+	consumeCtx, consumeCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
+	r.consumeCancel = consumeCancel
+
+	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
 	r.drainCancel = drainCancel
 
 	for _, channelData := range r.requestChannels {
-		go r.requestWorker(ctx, pubSubClient, channelData.subscriberID, channelData.requestChannel.Channel, channelData.gate)
+		r.consumeWg.Add(1)
+		go func(cd RequestChannelData) {
+			defer r.consumeWg.Done()
+			r.requestWorker(consumeCtx, pubSubClient, cd.subscriberID, cd.requestChannel.Channel, cd.gate)
+		}(channelData)
 	}
 	publisher := pubSubClient.Publisher(r.resultTopicID)
 	r.drainWg.Add(2)
 	go func() { defer r.drainWg.Done(); resultWorker(drainCtx, publisher, r.resultChannel) }()
 	go func() { defer r.drainWg.Done(); addMsgToRetryQueue(drainCtx, r.retryChannel) }()
+}
+
+func (r *PubSubMQFlow) StopConsuming() {
+	if r.consumeCancel != nil {
+		r.consumeCancel()
+	}
+	r.consumeWg.Wait()
 }
 
 func (r *PubSubMQFlow) Shutdown() {
@@ -235,27 +252,36 @@ func publishPubSub(ctx context.Context, publisher *pubsub.Publisher, msg []byte,
 func addMsgToRetryQueue(ctx context.Context, retryChannel chan pipeline.RetryMessage) {
 	logger := log.FromContext(ctx)
 
+	handleRetry := func(msg pipeline.RetryMessage) {
+		if msg.InternalRequest == nil {
+			return
+		}
+		value, ok := resultChannels.Load(msg.TransportCorrelationID)
+		if !ok {
+			logger.V(logutil.DEFAULT).Error(nil, "Result channel not found for retry message", "pubsubID", msg.TransportCorrelationID)
+			return
+		}
+		resultChannel := value.(chan bool)
+		logger.V(logutil.DEBUG).Info("Retrying message", "pubsubID", msg.TransportCorrelationID)
+		resultChannel <- false
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			for {
+				select {
+				case msg := <-retryChannel:
+					handleRetry(msg)
+				default:
+					return
+				}
+			}
 
 		case msg := <-retryChannel:
-			if msg.InternalRequest == nil {
-				continue
-			}
-			value, ok := resultChannels.Load(msg.TransportCorrelationID)
-			if !ok {
-				logger.V(logutil.DEFAULT).Error(nil, "Result channel not found for retry message", "pubsubID", msg.TransportCorrelationID)
-				continue
-			}
-			resultChannel := value.(chan bool)
-			logger.V(logutil.DEBUG).Info("Retrying message", "pubsubID", msg.TransportCorrelationID)
-			resultChannel <- false
-
+			handleRetry(msg)
 		}
 	}
-
 }
 
 func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID string, ch chan *api.InternalRequest, gate pipeline.DispatchGate) {
@@ -263,7 +289,7 @@ func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.C
 
 	sub := pubSubClient.Subscriber(subscriberID)
 
-	for {
+	for ctx.Err() == nil {
 		receiveCtx, cancel := context.WithCancel(ctx)
 		budget := gate.Budget(ctx)
 		go func() {

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -150,6 +150,8 @@ type RedisMQFlow struct {
 	requestChannels []RequestChannelData
 	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
+	consumeCancel   context.CancelFunc
+	consumeWg       sync.WaitGroup
 	drainCancel     context.CancelFunc
 	drainWg         sync.WaitGroup
 	enableTracing   bool
@@ -219,17 +221,32 @@ func NewRedisMQFlow(opts ...PubSubOption) (*RedisMQFlow, error) {
 }
 
 func (r *RedisMQFlow) Start(ctx context.Context) {
-	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), log.FromContext(ctx)))
+	logger := log.FromContext(ctx)
+	consumeCtx, consumeCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
+	r.consumeCancel = consumeCancel
+
+	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
 	r.drainCancel = drainCancel
 
 	for _, channelData := range r.requestChannels {
-		go requestWorker(ctx, r.rdb, channelData.requestChannel.Channel, channelData.queueName)
+		r.consumeWg.Add(1)
+		go func(cd RequestChannelData) {
+			defer r.consumeWg.Done()
+			requestWorker(consumeCtx, r.rdb, cd.requestChannel.Channel, cd.queueName)
+		}(channelData)
 	}
 
 	r.drainWg.Add(3)
 	go func() { defer r.drainWg.Done(); addMsgToRetryWorker(drainCtx, r.rdb, r.retryChannel, *retryQueueName) }()
 	go func() { defer r.drainWg.Done(); r.retryWorker(drainCtx, r.rdb) }()
 	go func() { defer r.drainWg.Done(); r.resultWorker(drainCtx, *resultQueueName) }() // #nosec G118
+}
+
+func (r *RedisMQFlow) StopConsuming() {
+	if r.consumeCancel != nil {
+		r.consumeCancel()
+	}
+	r.consumeWg.Wait()
 }
 
 func (r *RedisMQFlow) Shutdown() {
@@ -367,30 +384,36 @@ func (r *RedisMQFlow) Characteristics() pipeline.Characteristics {
 // Puts msgs from the retry channel into a Redis sorted-set with a duration Score.
 func addMsgToRetryWorker(ctx context.Context, rdb *redis.Client, retryChannel chan pipeline.RetryMessage, sortedSetName string) {
 	logger := log.FromContext(ctx)
+	addRetry := func(msg pipeline.RetryMessage) {
+		if msg.InternalRequest == nil {
+			return
+		}
+		score := float64(time.Now().Unix()) + msg.BackoffDurationSeconds
+		bytes, err := json.Marshal(msg.InternalRequest)
+		if err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to marshal message for retry in Redis")
+			return
+		}
+		if err := retryRedisOp(ctx, func(opCtx context.Context) error {
+			return rdb.ZAdd(opCtx, sortedSetName, redis.Z{Score: score, Member: string(bytes)}).Err()
+		}); err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Failed to add message for retry in Redis")
+		}
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			for {
+				select {
+				case msg := <-retryChannel:
+					addRetry(msg)
+				default:
+					return
+				}
+			}
 
 		case msg := <-retryChannel:
-			if msg.InternalRequest == nil {
-				continue
-			}
-			score := float64(time.Now().Unix()) + msg.BackoffDurationSeconds
-			bytes, err := json.Marshal(msg.InternalRequest)
-			if err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to marshal message for retry in Redis")
-				continue // skip this message.
-			}
-			err = rdb.ZAdd(ctx, sortedSetName, redis.Z{
-				Score:  score,
-				Member: string(bytes),
-			}).Err()
-
-			if err != nil {
-				// skip this message. We're not going to retry a "preparing to retry" step.
-				logger.V(logutil.DEFAULT).Error(err, "Failed to add message for retry in Redis")
-			}
+			addRetry(msg)
 		}
 	}
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -107,6 +107,8 @@ type RedisSortedSetFlow struct {
 	gate            pipeline.DispatchGate
 	gateFactory     pipeline.GateFactory
 	configMap       map[string]queueConfig
+	consumeCancel   context.CancelFunc
+	consumeWg       sync.WaitGroup
 	drainCancel     context.CancelFunc
 	drainWg         sync.WaitGroup
 	enableTracing   bool
@@ -255,15 +257,30 @@ func applyQueueConfigDefaults(cfg *queueConfig) {
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {
-	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), log.FromContext(ctx)))
+	logger := log.FromContext(ctx)
+	consumeCtx, consumeCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
+	r.consumeCancel = consumeCancel
+
+	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
 	r.drainCancel = drainCancel
 
 	for _, ch := range r.requestChannels {
-		go r.requestWorker(ctx, ch.channel.Channel, ch.queueName, ch.queueID)
+		r.consumeWg.Add(1)
+		go func(ch requestChannelData) {
+			defer r.consumeWg.Done()
+			r.requestWorker(consumeCtx, ch.channel.Channel, ch.queueName, ch.queueID)
+		}(ch)
 	}
 	r.drainWg.Add(2)
 	go func() { defer r.drainWg.Done(); r.retryWorker(drainCtx) }()  // #nosec G118
 	go func() { defer r.drainWg.Done(); r.resultWorker(drainCtx) }() // #nosec G118
+}
+
+func (r *RedisSortedSetFlow) StopConsuming() {
+	if r.consumeCancel != nil {
+		r.consumeCancel()
+	}
+	r.consumeWg.Wait()
 }
 
 func (r *RedisSortedSetFlow) Shutdown() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -331,6 +331,7 @@ func applyManifests() {
 		{"composite", helmValuesDir + "/composite.yaml"},
 		{"prometheus-query", helmValuesDir + "/prometheus-query.yaml"},
 		{"endpoint-scrape", helmValuesDir + "/endpoint-scrape.yaml"},
+		{"short-drain", helmValuesDir + "/short-drain.yaml"},
 	} {
 		helmInstall(r.name, r.values, map[string]string{
 			"ap.image.repository": imageRepo,
@@ -557,6 +558,7 @@ func doRedeployEPPWithFlowControl() {
 		"composite-async-processor",
 		"prometheus-query-async-processor",
 		"endpoint-scrape-async-processor",
+		"short-drain-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "restart", "deployment/"+deploy)
@@ -573,6 +575,7 @@ func doRedeployEPPWithFlowControl() {
 		"composite-async-processor",
 		"prometheus-query-async-processor",
 		"endpoint-scrape-async-processor",
+		"short-drain-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "status", "deployment/"+deploy, "--timeout=120s")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,9 +22,13 @@ var _ = ginkgo.Describe("General Integration", func() {
 		// Delete, pause for in-flight results, delete again.
 		rdb.Del(ctx, integrationRequestQueue) //nolint:errcheck
 		rdb.Del(ctx, integrationResultQueue)  //nolint:errcheck
+		rdb.Del(ctx, shortDrainRequestQueue)  //nolint:errcheck
+		rdb.Del(ctx, shortDrainResultQueue)   //nolint:errcheck
 		gomega.Consistently(func() int64 {
 			return rdb.LLen(ctx, integrationResultQueue).Val() +
-				rdb.ZCard(ctx, integrationRequestQueue).Val()
+				rdb.ZCard(ctx, integrationRequestQueue).Val() +
+				rdb.LLen(ctx, shortDrainResultQueue).Val() +
+				rdb.ZCard(ctx, shortDrainRequestQueue).Val()
 		}, 3*time.Second, 500*time.Millisecond).Should(gomega.Equal(int64(0)))
 	})
 
@@ -152,11 +156,20 @@ var _ = ginkgo.Describe("General Integration", func() {
 		}
 	})
 
-	ginkgo.It("re-queues in-flight messages on pod termination", func() {
-		// Add a 60s delay to 100% of requests so they stay in-flight in the Worker.
+	ginkgo.It("completes in-flight requests during graceful shutdown", func() {
+		// Add a 60s delay to 100% of requests so they stay in-flight.
+		// The drain timeout (2m) is longer than the delay, so the Worker
+		// should finish in-flight requests and produce results rather than
+		// re-enqueuing them.
+		//
+		// With concurrency=1 and terminationGracePeriodSeconds=130, the
+		// worker processes requests sequentially. Each takes ~60s due to
+		// the Envoy delay, so at most 2 out of 3 complete before SIGKILL.
+		// The remaining message is re-enqueued. We verify:
+		//   1. At least one request completed (drain works).
+		//   2. No messages are lost (results + re-enqueued = total).
 		setEnvoyFaultDelay(envoyAdminURL, 100)
 
-		// Ensure the deployment is restored even if the test fails.
 		ginkgo.DeferCleanup(func() {
 			setEnvoyFaultDelay(envoyAdminURL, 0)
 			cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
@@ -185,9 +198,7 @@ var _ = ginkgo.Describe("General Integration", func() {
 			return rdb.ZCard(ctx, integrationRequestQueue).Val()
 		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Equal(int64(0)))
 
-		// Scale the deployment to 0 to trigger graceful shutdown. Using scale
-		// instead of pod delete prevents a replacement pod from consuming the
-		// re-queued messages before we can assert.
+		// Scale the deployment to 0 to trigger graceful shutdown.
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "scale", "deployment/integration-async-processor",
 			"--replicas=0", "--timeout=60s")
@@ -199,16 +210,80 @@ var _ = ginkgo.Describe("General Integration", func() {
 		cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "wait", "pod",
 			"-l", "app.kubernetes.io/instance=integration",
+			"--for=delete", "--timeout=120s")
+		session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(180 * time.Second).Should(gexec.Exit(0))
+
+		// Two-phase shutdown: in-flight requests should complete during
+		// drain instead of being immediately cancelled and re-enqueued.
+		resultCount := getResultCount(ctx, rdb, integrationResultQueue)
+		requeueCount := rdb.ZCard(ctx, integrationRequestQueue).Val()
+
+		// At least one request must have completed (proves drain works).
+		gomega.Expect(resultCount).To(gomega.BeNumerically(">=", 1),
+			"expected at least one in-flight request to complete during drain phase")
+
+		// No messages lost: completed results + re-enqueued = total.
+		gomega.Expect(resultCount + requeueCount).To(gomega.BeNumerically(">=", int64(len(ids))),
+			"expected no message loss: results + re-enqueued should equal total")
+	})
+
+	ginkgo.It("re-enqueues in-flight messages when drain timeout is exceeded", func() {
+		// The short-drain processor has drain-timeout=5s. With Envoy injecting
+		// a 60s delay, requests cannot complete within the drain window and
+		// must be re-enqueued.
+		setEnvoyFaultDelay(envoyAdminURL, 100)
+
+		ginkgo.DeferCleanup(func() {
+			setEnvoyFaultDelay(envoyAdminURL, 0)
+			cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+				"-n", nsName, "scale", "deployment/short-drain-async-processor",
+				"--replicas=1", "--timeout=60s")
+			session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(session).WithTimeout(60 * time.Second).Should(gexec.Exit(0))
+
+			cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+				"-n", nsName, "rollout", "status",
+				"deployment/short-drain-async-processor", "--timeout=120s")
+			session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(session).WithTimeout(180 * time.Second).Should(gexec.Exit(0))
+		})
+
+		ids := []string{"drain-timeout-1", "drain-timeout-2", "drain-timeout-3"}
+		for _, id := range ids {
+			enqueueMessage(ctx, rdb, shortDrainRequestQueue, makeRequestMessage(id, 5*time.Minute))
+		}
+
+		// Wait for messages to be popped (now in-flight, stuck in delay).
+		gomega.Eventually(func() int64 {
+			return rdb.ZCard(ctx, shortDrainRequestQueue).Val()
+		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Equal(int64(0)))
+
+		// Scale to 0 to trigger graceful shutdown.
+		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+			"-n", nsName, "scale", "deployment/short-drain-async-processor",
+			"--replicas=0", "--timeout=60s")
+		session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(60 * time.Second).Should(gexec.Exit(0))
+
+		// Wait for the pod to fully terminate.
+		cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+			"-n", nsName, "wait", "pod",
+			"-l", "app.kubernetes.io/instance=short-drain",
 			"--for=delete", "--timeout=60s")
 		session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Eventually(session).WithTimeout(90 * time.Second).Should(gexec.Exit(0))
 
-		// The Worker should have re-queued the in-flight messages back to
-		// Redis on shutdown instead of treating them as fatal errors.
-		count := rdb.ZCard(ctx, integrationRequestQueue).Val()
+		// The drain timeout (5s) expired before the Envoy delay (60s) completed,
+		// so in-flight messages should have been re-enqueued to the request queue.
+		count := rdb.ZCard(ctx, shortDrainRequestQueue).Val()
 		gomega.Expect(count).To(gomega.BeNumerically(">=", int64(len(ids))),
-			"expected all in-flight messages re-queued after shutdown")
+			"expected all in-flight messages re-enqueued after drain timeout")
 	})
 
 	ginkgo.It("does not lose messages on pod termination", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -224,8 +224,8 @@ var _ = ginkgo.Describe("General Integration", func() {
 		gomega.Expect(resultCount).To(gomega.BeNumerically(">=", 1),
 			"expected at least one in-flight request to complete during drain phase")
 
-		// No messages lost: completed results + re-enqueued = total.
-		gomega.Expect(resultCount + requeueCount).To(gomega.BeNumerically(">=", int64(len(ids))),
+		// No messages lost or duplicated: completed results + re-enqueued = total.
+		gomega.Expect(resultCount+requeueCount).To(gomega.Equal(int64(len(ids))),
 			"expected no message loss: results + re-enqueued should equal total")
 	})
 
@@ -282,7 +282,7 @@ var _ = ginkgo.Describe("General Integration", func() {
 		// The drain timeout (5s) expired before the Envoy delay (60s) completed,
 		// so in-flight messages should have been re-enqueued to the request queue.
 		count := rdb.ZCard(ctx, shortDrainRequestQueue).Val()
-		gomega.Expect(count).To(gomega.BeNumerically(">=", int64(len(ids))),
+		gomega.Expect(count).To(gomega.Equal(int64(len(ids))),
 			"expected all in-flight messages re-enqueued after drain timeout")
 	})
 

--- a/test/e2e/helm/short-drain.yaml
+++ b/test/e2e/helm/short-drain.yaml
@@ -1,0 +1,28 @@
+ap:
+  imagePullPolicy: Never
+  messageQueueImpl: "redis-sortedset"
+  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  concurrency: 1
+  drainTimeout: "5s"
+  otel:
+    endpoint: ""
+    insecure: true
+    sampler: "always_on"
+    samplerArg: "1.0"
+    redisTracing: false
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    enabled: true
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
+    resultQueueName: "short-drain-result-list"
+    pollIntervalMs: 500
+    batchSize: 10
+    queuesConfig:
+      - queue_name: "short-drain-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -31,6 +31,9 @@ const (
 
 	endpointScrapeRequestQueue = "endpoint-scrape-request-sortedset"
 	endpointScrapeResultQueue  = "endpoint-scrape-result-list"
+
+	shortDrainRequestQueue = "short-drain-request-sortedset"
+	shortDrainResultQueue  = "short-drain-result-list"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}

--- a/test/integration/worker_dispatch_test.go
+++ b/test/integration/worker_dispatch_test.go
@@ -50,7 +50,7 @@ func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+		asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
 			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 	}()
 
@@ -121,7 +121,7 @@ func TestWorkerDispatch_MockIGW(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	ir := asyncapi.NewInternalRequest(
@@ -190,7 +190,7 @@ func TestWorkerDispatch_EndpointOverride(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	ir := asyncapi.NewInternalRequest(
@@ -237,7 +237,7 @@ func TestWorkerDispatch_ServerErrorTriggersRetry(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	ir := asyncapi.NewInternalRequest(
@@ -286,7 +286,7 @@ func TestWorkerDispatch_ResultCallback(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	routing := asyncapi.InternalRouting{
@@ -346,7 +346,7 @@ func TestWorkerDispatch_RequeuesOnShutdown(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		asyncworker.Worker(ctx, pipeline.Characteristics{HasExternalBackoff: false},
+		asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
 			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 	}()
 

--- a/test/integration/worker_dispatch_test.go
+++ b/test/integration/worker_dispatch_test.go
@@ -44,13 +44,14 @@ func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
 	retryChannel := make(chan pipeline.RetryMessage, 3)
 	resultChannel := make(chan asyncapi.ResultMessage, 3)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	consumeCtx, consumeCancel := context.WithCancel(context.Background())
+	requestCtx, requestCancel := context.WithCancel(context.Background())
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
+		asyncworker.Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false},
 			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 	}()
 
@@ -73,7 +74,8 @@ func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
 	}
 
 	<-serverHit
-	cancel()
+	consumeCancel()
+	requestCancel()
 	wg.Wait()
 
 	got := make(map[string]bool)

--- a/test/integration/worker_otel_test.go
+++ b/test/integration/worker_otel_test.go
@@ -67,7 +67,7 @@ func TestWorkerDispatch_TraceparentInjected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	ir := asyncapi.NewInternalRequest(
@@ -125,7 +125,7 @@ func TestWorkerDispatch_SpanHierarchy(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	ir := asyncapi.NewInternalRequest(
@@ -209,7 +209,7 @@ func TestWorkerDispatch_MetadataTraceContextPropagation(t *testing.T) {
 	otel.GetTextMapPropagator().Inject(producerCtx, propagation.MapCarrier(metadata))
 	producerSpan.End()
 
-	go asyncworker.Worker(ctx, pipeline.Characteristics{},
+	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{},
 		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
 
 	ir := asyncapi.NewInternalRequest(


### PR DESCRIPTION
## What does this PR do?

Implements two-phase graceful shutdown with in-flight request draining.

Currently, a single context controls both message consumption and HTTP request processing. On SIGTERM, in-flight inference requests are immediately cancelled, even if the inference server is about to respond, and then re-enqueued. This wastes work and adds unnecessary latency.

## Why is this change needed?

Now shutdown proceeds in three phases:

1. `impl.StopConsuming()`` cancels the internal consumeCtx, waits for request-pulling goroutines to stop, no new messages enter the pipeline.
2. workers continue processing current HTTP requests using a separate `drainCtx`` (not tied to the signal). A configurable `--drain-timeout` (default 2m) controls how long to wait. If it expires, `drainCtx` is cancelled, aborting remaining requests (workers re-enqueue them)
3. `impl.Shutdown()`` flushes retry/result workers as before.

Key changes:
- pipeline.Flow — new `StopConsuming()` method
- `Worker(consumeCtx, requestCtx, ...)` now takes `consumeCtx` stops message pickup, `requestCtx` controls HTTP request lifecycle
- All Flow backends (Redis sorted set, Redis pub/sub, GCP Pub/Sub) add consumeCancel/consumeWg for StopConsuming()
- Helm chart exposes `--drain-timeout` via `drainTimeout`
- Worker drain loop uses a 100ms idle timer (instead of non-blocking default) so the merge goroutine can forward any held message; uses blocking send to retryChannel to prevent message drops

Addresses #227. Without two-phase shutdown:
- In-flight requests are aborted on SIGTERM even when nearly complete, wasting inference compute
- There is no configurable drain timeout: the process either finishes instantly or is killed by SIGKILL
- The `addMsgToRetryWorker` in Redis pub/sub mode could lose buffered retry messages on shutdown (no drain loop)
- The GCP Pub/Sub requestWorker had an infinite loop on shutdown (no exit condition)


## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Commits are signed off (git commit -s) per DCO
- [x] Code follows project contributing guidelines
- [x] Tests pass locally (make test)
- [ ] Linters pass (make lint)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #227
