### PR TITLE
feat: health and readiness probes

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -76,6 +76,7 @@ spec:
           {{- end }}
           - --concurrency={{ .Values.ap.concurrency | default 8 }}
           - --drain-timeout={{ .Values.ap.drainTimeout | default "2m" }}
+          - --health-port={{ .Values.ap.health.port | default 8081 }}
           - --metrics-endpoint-auth={{ .Values.ap.metrics.secure }}
           - --metrics-port={{ .Values.ap.metrics.port | default 9090 }}
           {{- if and .Values.ap.otel.redisTracing .Values.ap.otel.endpoint }}
@@ -130,6 +131,33 @@ spec:
           - name: metrics
             containerPort: {{ .Values.ap.metrics.port | default 9090 }}
             protocol: TCP
+          - name: health
+            containerPort: {{ .Values.ap.health.port | default 8081 }}
+            protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: {{ .Values.ap.health.startupProbe.initialDelaySeconds | default 0 }}
+          periodSeconds: {{ .Values.ap.health.startupProbe.periodSeconds | default 2 }}
+          timeoutSeconds: {{ .Values.ap.health.startupProbe.timeoutSeconds | default 3 }}
+          failureThreshold: {{ .Values.ap.health.startupProbe.failureThreshold | default 30 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: {{ .Values.ap.health.livenessProbe.initialDelaySeconds | default 5 }}
+          periodSeconds: {{ .Values.ap.health.livenessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.ap.health.livenessProbe.timeoutSeconds | default 3 }}
+          failureThreshold: {{ .Values.ap.health.livenessProbe.failureThreshold | default 3 }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          initialDelaySeconds: {{ .Values.ap.health.readinessProbe.initialDelaySeconds | default 5 }}
+          periodSeconds: {{ .Values.ap.health.readinessProbe.periodSeconds | default 5 }}
+          timeoutSeconds: {{ .Values.ap.health.readinessProbe.timeoutSeconds | default 3 }}
+          failureThreshold: {{ .Values.ap.health.readinessProbe.failureThreshold | default 3 }}
         {{- with .Values.ap.securityContext }}
         securityContext:
           {{- toYaml . | nindent 12 }}

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -42,6 +42,23 @@ ap:
     # Enable per-command Redis tracing spans. Can produce high span volume —
     # leave disabled unless actively debugging Redis.
     redisTracing: false
+  health:
+    port: 8081
+    livenessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+    startupProbe:
+      initialDelaySeconds: 0
+      periodSeconds: 2
+      timeoutSeconds: 3
+      failureThreshold: 30
   metrics:
     enabled: true
     port: 9090

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -160,8 +160,13 @@ func main() {
 		checker = hc.HealthCheck
 	}
 	healthServer := health.NewServer(healthPort, checker, setupLog.WithName("health"))
+	healthLn, err := healthServer.ListenAndServe()
+	if err != nil {
+		setupLog.Error(err, "Failed to bind health server")
+		os.Exit(1)
+	}
 	go func() {
-		if err := healthServer.Start(); err != nil {
+		if err := healthServer.Serve(healthLn); err != nil {
 			setupLog.Error(err, "Health server failed")
 		}
 	}()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/llm-d-incubation/llm-d-async/internal/health"
 	"github.com/llm-d-incubation/llm-d-async/internal/logging"
 	uotel "github.com/llm-d-incubation/llm-d-async/internal/otel"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
@@ -36,6 +37,7 @@ func main() {
 
 	var loggerVerbosity int
 
+	var healthPort int
 	var metricsPort int
 	var metricsEndpointAuth bool
 
@@ -55,6 +57,7 @@ func main() {
 
 	flag.IntVar(&loggerVerbosity, "v", logging.DEFAULT, "number for the log level verbosity")
 
+	flag.IntVar(&healthPort, "health-port", 8081, "The health probe port")
 	flag.IntVar(&metricsPort, "metrics-port", 9090, "The metrics port")
 	flag.BoolVar(&metricsEndpointAuth, "metrics-endpoint-auth", true, "Enables authentication and authorization of the metrics endpoint")
 
@@ -152,6 +155,17 @@ func main() {
 
 	metrics.Register(metrics.GetAsyncProcessorCollectors(impl.Characteristics().SupportsMessageLatency)...)
 
+	var checker health.Checker
+	if hc, ok := impl.(pipeline.HealthChecker); ok {
+		checker = hc.HealthCheck
+	}
+	healthServer := health.NewServer(healthPort, checker, setupLog.WithName("health"))
+	go func() {
+		if err := healthServer.Start(); err != nil {
+			setupLog.Error(err, "Health server failed")
+		}
+	}()
+
 	signalCtx := ctrl.SetupSignalHandler()
 
 	// Register metrics handler.
@@ -212,7 +226,10 @@ func main() {
 	}
 
 	impl.Start(signalCtx)
+	healthServer.SetReady()
+
 	<-signalCtx.Done()
+	healthServer.SetNotReady()
 
 	setupLog.Info("Signal received, stopping message consumption")
 	impl.StopConsuming()
@@ -230,6 +247,12 @@ func main() {
 	}
 
 	impl.Shutdown()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := healthServer.Shutdown(shutdownCtx); err != nil {
+		setupLog.Error(err, "Health server shutdown error")
+	}
 }
 
 func buildTLSConfig(caCertPath, certPath, keyPath string, insecureSkipVerify bool) (*tls.Config, error) {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,104 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+const checkerTimeout = 3 * time.Second
+
+// Checker returns nil when the backend is healthy.
+type Checker func(ctx context.Context) error
+
+// Server serves Kubernetes health probe endpoints.
+type Server struct {
+	ready   atomic.Bool
+	checker Checker
+	server  *http.Server
+	logger  logr.Logger
+}
+
+type response struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+func NewServer(port int, checker Checker, logger logr.Logger) *Server {
+	s := &Server{
+		checker: checker,
+		logger:  logger,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/readyz", s.handleReadyz)
+
+	s.server = &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return s
+}
+
+func (s *Server) SetReady() {
+	s.ready.Store(true)
+	s.logger.Info("Readiness set to true")
+}
+
+func (s *Server) SetNotReady() {
+	s.ready.Store(false)
+	s.logger.Info("Readiness set to false")
+}
+
+func (s *Server) Start() error {
+	s.logger.Info("Health server starting", "addr", s.server.Addr)
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
+}
+
+func writeJSON(w http.ResponseWriter, code int, resp response) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if s.checker != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), checkerTimeout)
+		defer cancel()
+		if err := s.checker(ctx); err != nil {
+			writeJSON(w, http.StatusServiceUnavailable, response{Status: "error", Error: err.Error()})
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, response{Status: "ok"})
+}
+
+func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	if !s.ready.Load() {
+		writeJSON(w, http.StatusServiceUnavailable, response{Status: "not ready"})
+		return
+	}
+	if s.checker != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), checkerTimeout)
+		defer cancel()
+		if err := s.checker(ctx); err != nil {
+			writeJSON(w, http.StatusServiceUnavailable, response{Status: "not ready", Error: err.Error()})
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, response{Status: "ready"})
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -57,9 +58,21 @@ func (s *Server) SetNotReady() {
 	s.logger.Info("Readiness set to false")
 }
 
-func (s *Server) Start() error {
-	s.logger.Info("Health server starting", "addr", s.server.Addr)
-	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+// ListenAndServe binds the health port and returns the listener.
+// The caller should invoke Serve in a goroutine. This split lets
+// main() detect bind failures synchronously before proceeding.
+func (s *Server) ListenAndServe() (net.Listener, error) {
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return nil, err
+	}
+	s.logger.Info("Health server listening", "addr", ln.Addr().String())
+	return ln, nil
+}
+
+// Serve accepts connections on the listener. Blocks until shutdown.
+func (s *Server) Serve(ln net.Listener) error {
+	if err := s.server.Serve(ln); err != nil && err != http.ErrServerClosed {
 		return err
 	}
 	return nil
@@ -75,15 +88,7 @@ func writeJSON(w http.ResponseWriter, code int, resp response) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	if s.checker != nil {
-		ctx, cancel := context.WithTimeout(r.Context(), checkerTimeout)
-		defer cancel()
-		if err := s.checker(ctx); err != nil {
-			writeJSON(w, http.StatusServiceUnavailable, response{Status: "error", Error: err.Error()})
-			return
-		}
-	}
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, response{Status: "ok"})
 }
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,44 +35,17 @@ func parseResponse(t *testing.T, rec *httptest.ResponseRecorder) response {
 	return resp
 }
 
-func TestHealthz_NoChecker(t *testing.T) {
-	s := NewServer(0, nil, logr.Discard())
-	rec := httptest.NewRecorder()
-	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
-	resp := parseResponse(t, rec)
-	if resp.Status != "ok" {
-		t.Fatalf("expected status ok, got %s", resp.Status)
-	}
-}
-
-func TestHealthz_HealthyChecker(t *testing.T) {
-	s := NewServer(0, healthyChecker, logr.Discard())
-	rec := httptest.NewRecorder()
-	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
-}
-
-func TestHealthz_UnhealthyChecker(t *testing.T) {
+func TestHealthz_AlwaysOK(t *testing.T) {
 	s := NewServer(0, unhealthyChecker, logr.Discard())
 	rec := httptest.NewRecorder()
 	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 regardless of checker, got %d", rec.Code)
 	}
 	resp := parseResponse(t, rec)
-	if resp.Status != "error" {
-		t.Fatalf("expected status error, got %s", resp.Status)
-	}
-	if resp.Error == "" {
-		t.Fatal("expected non-empty error message")
+	if resp.Status != "ok" {
+		t.Fatalf("expected status ok, got %s", resp.Status)
 	}
 }
 
@@ -150,12 +122,13 @@ func TestReadyz_ReadyThenNotReady(t *testing.T) {
 	}
 }
 
-func TestHealthz_CheckerTimeout(t *testing.T) {
+func TestReadyz_CheckerTimeout(t *testing.T) {
 	s := NewServer(0, slowChecker, logr.Discard())
+	s.SetReady()
 	rec := httptest.NewRecorder()
 
 	start := time.Now()
-	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 	elapsed := time.Since(start)
 
 	if rec.Code != http.StatusServiceUnavailable {
@@ -167,32 +140,20 @@ func TestHealthz_CheckerTimeout(t *testing.T) {
 }
 
 func TestServer_StartAndShutdown(t *testing.T) {
-	ln, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatalf("failed to find free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	if err := ln.Close(); err != nil {
-		t.Fatalf("failed to close listener: %v", err)
-	}
+	s := NewServer(0, nil, logr.Discard())
 
-	s := NewServer(port, nil, logr.Discard())
+	ln, err := s.ListenAndServe()
+	if err != nil {
+		t.Fatalf("failed to bind: %v", err)
+	}
+	addr := ln.Addr().String()
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- s.Start() }()
+	go func() { errCh <- s.Serve(ln) }()
 
-	// Wait for server to be ready
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", port))
-		if err == nil {
-			resp.Body.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	client := &http.Client{Timeout: 5 * time.Second}
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", port))
+	resp, err := client.Get(fmt.Sprintf("http://%s/healthz", addr))
 	if err != nil {
 		t.Fatalf("health server not reachable: %v", err)
 	}
@@ -208,6 +169,6 @@ func TestServer_StartAndShutdown(t *testing.T) {
 	}
 
 	if err := <-errCh; err != nil {
-		t.Fatalf("Start returned error: %v", err)
+		t.Fatalf("Serve returned error: %v", err)
 	}
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,213 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func healthyChecker(_ context.Context) error { return nil }
+
+func unhealthyChecker(_ context.Context) error { return errors.New("backend unavailable") }
+
+func slowChecker(ctx context.Context) error {
+	select {
+	case <-time.After(10 * time.Second):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func parseResponse(t *testing.T, rec *httptest.ResponseRecorder) response {
+	t.Helper()
+	var resp response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return resp
+}
+
+func TestHealthz_NoChecker(t *testing.T) {
+	s := NewServer(0, nil, logr.Discard())
+	rec := httptest.NewRecorder()
+	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	resp := parseResponse(t, rec)
+	if resp.Status != "ok" {
+		t.Fatalf("expected status ok, got %s", resp.Status)
+	}
+}
+
+func TestHealthz_HealthyChecker(t *testing.T) {
+	s := NewServer(0, healthyChecker, logr.Discard())
+	rec := httptest.NewRecorder()
+	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestHealthz_UnhealthyChecker(t *testing.T) {
+	s := NewServer(0, unhealthyChecker, logr.Discard())
+	rec := httptest.NewRecorder()
+	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	resp := parseResponse(t, rec)
+	if resp.Status != "error" {
+		t.Fatalf("expected status error, got %s", resp.Status)
+	}
+	if resp.Error == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestReadyz_NotReady(t *testing.T) {
+	s := NewServer(0, nil, logr.Discard())
+	rec := httptest.NewRecorder()
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	resp := parseResponse(t, rec)
+	if resp.Status != "not ready" {
+		t.Fatalf("expected status 'not ready', got %s", resp.Status)
+	}
+}
+
+func TestReadyz_Ready_NoChecker(t *testing.T) {
+	s := NewServer(0, nil, logr.Discard())
+	s.SetReady()
+	rec := httptest.NewRecorder()
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	resp := parseResponse(t, rec)
+	if resp.Status != "ready" {
+		t.Fatalf("expected status ready, got %s", resp.Status)
+	}
+}
+
+func TestReadyz_Ready_HealthyChecker(t *testing.T) {
+	s := NewServer(0, healthyChecker, logr.Discard())
+	s.SetReady()
+	rec := httptest.NewRecorder()
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestReadyz_Ready_UnhealthyChecker(t *testing.T) {
+	s := NewServer(0, unhealthyChecker, logr.Discard())
+	s.SetReady()
+	rec := httptest.NewRecorder()
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	resp := parseResponse(t, rec)
+	if resp.Error == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestReadyz_ReadyThenNotReady(t *testing.T) {
+	s := NewServer(0, nil, logr.Discard())
+
+	s.SetReady()
+	rec := httptest.NewRecorder()
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("after SetReady: expected 200, got %d", rec.Code)
+	}
+
+	s.SetNotReady()
+	rec = httptest.NewRecorder()
+	s.handleReadyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("after SetNotReady: expected 503, got %d", rec.Code)
+	}
+}
+
+func TestHealthz_CheckerTimeout(t *testing.T) {
+	s := NewServer(0, slowChecker, logr.Discard())
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	s.handleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("checker should have timed out within ~3s, took %v", elapsed)
+	}
+}
+
+func TestServer_StartAndShutdown(t *testing.T) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+
+	s := NewServer(port, nil, logr.Discard())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Start() }()
+
+	// Wait for server to be ready
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", port))
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", port))
+	if err != nil {
+		t.Fatalf("health server not reachable: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown error: %v", err)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -16,6 +16,12 @@ type Flow interface {
 	ResultChannel() chan api.ResultMessage
 }
 
+// HealthChecker is an optional interface that Flow implementations can
+// satisfy to report backend-specific health.
+type HealthChecker interface {
+	HealthCheck(ctx context.Context) error
+}
+
 type Characteristics struct {
 	HasExternalBackoff     bool
 	SupportsMessageLatency bool

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -143,7 +143,10 @@ type RequestChannelData struct {
 	queueName      string
 }
 
-var _ pipeline.Flow = (*RedisMQFlow)(nil)
+var (
+	_ pipeline.Flow          = (*RedisMQFlow)(nil)
+	_ pipeline.HealthChecker = (*RedisMQFlow)(nil)
+)
 
 type RedisMQFlow struct {
 	rdb             *redis.Client
@@ -372,6 +375,10 @@ func consumeSubscription(ctx context.Context, rdb *redis.Client, msgChannel chan
 			msgChannel <- &ir
 		}
 	}
+}
+
+func (r *RedisMQFlow) HealthCheck(ctx context.Context) error {
+	return r.rdb.Ping(ctx).Err()
 }
 
 func (r *RedisMQFlow) Characteristics() pipeline.Characteristics {

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -94,7 +94,10 @@ type requestChannelData struct {
 	gate      pipeline.DispatchGate
 }
 
-var _ pipeline.Flow = (*RedisSortedSetFlow)(nil)
+var (
+	_ pipeline.Flow          = (*RedisSortedSetFlow)(nil)
+	_ pipeline.HealthChecker = (*RedisSortedSetFlow)(nil)
+)
 
 type RedisSortedSetFlow struct {
 	rdb             *redis.Client
@@ -304,6 +307,10 @@ func (r *RedisSortedSetFlow) RetryChannel() chan pipeline.RetryMessage {
 
 func (r *RedisSortedSetFlow) ResultChannel() chan api.ResultMessage {
 	return r.resultChannel
+}
+
+func (r *RedisSortedSetFlow) HealthCheck(ctx context.Context) error {
+	return r.rdb.Ping(ctx).Err()
 }
 
 func (r *RedisSortedSetFlow) Characteristics() pipeline.Characteristics {

--- a/test/e2e/e2e_health_test.go
+++ b/test/e2e/e2e_health_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = ginkgo.Describe("Health Probes", func() {
+	ginkgo.It("exposes healthy /healthz and /readyz endpoints", func() {
+		// Pick an ephemeral local port for port-forward.
+		ln, err := net.Listen("tcp", ":0")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		localPort := ln.Addr().(*net.TCPAddr).Port
+		gomega.Expect(ln.Close()).To(gomega.Succeed())
+
+		// Port-forward the health port (8081) of the integration async-processor pod.
+		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+			"-n", nsName, "port-forward",
+			"deployment/integration-async-processor",
+			fmt.Sprintf("%d:8081", localPort))
+		session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer session.Kill()
+
+		baseURL := fmt.Sprintf("http://localhost:%d", localPort)
+
+		// Wait for port-forward to be ready.
+		gomega.Eventually(func() error {
+			resp, err := http.Get(baseURL + "/healthz")
+			if err != nil {
+				return err
+			}
+			resp.Body.Close() //nolint:errcheck
+			return nil
+		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying /healthz returns 200")
+		resp, err := http.Get(baseURL + "/healthz")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
+		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+
+		var healthResp map[string]string
+		gomega.Expect(json.NewDecoder(resp.Body).Decode(&healthResp)).To(gomega.Succeed())
+		gomega.Expect(healthResp["status"]).To(gomega.Equal("ok"))
+
+		ginkgo.By("Verifying /readyz returns 200")
+		resp2, err := http.Get(baseURL + "/readyz")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer resp2.Body.Close() //nolint:errcheck
+		gomega.Expect(resp2.StatusCode).To(gomega.Equal(http.StatusOK))
+
+		var readyResp map[string]string
+		gomega.Expect(json.NewDecoder(resp2.Body).Decode(&readyResp)).To(gomega.Succeed())
+		gomega.Expect(readyResp["status"]).To(gomega.Equal("ready"))
+	})
+})

--- a/test/e2e/e2e_health_test.go
+++ b/test/e2e/e2e_health_test.go
@@ -15,13 +15,11 @@ import (
 
 var _ = ginkgo.Describe("Health Probes", func() {
 	ginkgo.It("exposes healthy /healthz and /readyz endpoints", func() {
-		// Pick an ephemeral local port for port-forward.
 		ln, err := net.Listen("tcp", ":0")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		localPort := ln.Addr().(*net.TCPAddr).Port
 		gomega.Expect(ln.Close()).To(gomega.Succeed())
 
-		// Port-forward the health port (8081) of the integration async-processor pod.
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "port-forward",
 			"deployment/integration-async-processor",
@@ -32,9 +30,8 @@ var _ = ginkgo.Describe("Health Probes", func() {
 
 		baseURL := fmt.Sprintf("http://localhost:%d", localPort)
 
-		// Wait for port-forward to be ready.
 		gomega.Eventually(func() error {
-			resp, err := http.Get(baseURL + "/healthz")
+			resp, err := httpClient.Get(baseURL + "/healthz")
 			if err != nil {
 				return err
 			}
@@ -43,7 +40,7 @@ var _ = ginkgo.Describe("Health Probes", func() {
 		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed())
 
 		ginkgo.By("Verifying /healthz returns 200")
-		resp, err := http.Get(baseURL + "/healthz")
+		resp, err := httpClient.Get(baseURL + "/healthz")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer resp.Body.Close() //nolint:errcheck
 		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
@@ -53,7 +50,7 @@ var _ = ginkgo.Describe("Health Probes", func() {
 		gomega.Expect(healthResp["status"]).To(gomega.Equal("ok"))
 
 		ginkgo.By("Verifying /readyz returns 200")
-		resp2, err := http.Get(baseURL + "/readyz")
+		resp2, err := httpClient.Get(baseURL + "/readyz")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer resp2.Body.Close() //nolint:errcheck
 		gomega.Expect(resp2.StatusCode).To(gomega.Equal(http.StatusOK))


### PR DESCRIPTION
## What does this PR do?

Implements liveness, readiness, startup (health) probes

## Why is this change needed?

This is an important feature for k8s support that is currently missing

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes https://github.com/llm-d-incubation/llm-d-async/issues/226