### PR TITLE
fix: follow up helm updates

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -76,6 +76,7 @@ spec:
           {{- end }}
           - --concurrency={{ .Values.ap.concurrency | default 8 }}
           - --metrics-endpoint-auth={{ .Values.ap.metrics.secure }}
+          - --metrics-port={{ .Values.ap.metrics.port | default 9090 }}
           {{- if and .Values.ap.otel.redisTracing .Values.ap.otel.endpoint }}
           - --redis-tracing=true
           {{- end }}

--- a/charts/async-processor/templates/prometheus-rule.yaml
+++ b/charts/async-processor/templates/prometheus-rule.yaml
@@ -28,7 +28,7 @@ spec:
             summary: Async processor retry rate is high
             description: >-
               Retry rate exceeds {{ .Values.ap.prometheusRule.rules.highRetryRate.threshold }} (ratio)
-              for async requests in namespace {{ "{{ $labels.namespace }}" }}.
+              for async requests in namespace {{ .Release.Namespace }}.
         {{- end }}
         {{- if .Values.ap.prometheusRule.rules.highDeadlineExceededRate.enabled }}
         - alert: AsyncProcessorHighDeadlineExceededRate
@@ -45,7 +45,7 @@ spec:
             summary: Async processor deadline exceeded rate is high
             description: >-
               Deadline exceeded rate exceeds {{ .Values.ap.prometheusRule.rules.highDeadlineExceededRate.threshold }} (ratio)
-              for async requests in namespace {{ "{{ $labels.namespace }}" }}.
+              for async requests in namespace {{ .Release.Namespace }}.
         {{- end }}
         {{- if .Values.ap.prometheusRule.rules.lowSuccessRate.enabled }}
         - alert: AsyncProcessorLowSuccessRate
@@ -62,7 +62,7 @@ spec:
             summary: Async processor success rate is low
             description: >-
               Success rate is below {{ .Values.ap.prometheusRule.rules.lowSuccessRate.threshold }} (ratio)
-              for async requests in namespace {{ "{{ $labels.namespace }}" }}.
+              for async requests in namespace {{ .Release.Namespace }}.
         {{- end }}
         {{- if .Values.ap.prometheusRule.rules.highShedRate.enabled }}
         - alert: AsyncProcessorHighShedRate
@@ -79,6 +79,6 @@ spec:
             summary: Async processor shed rate is high
             description: >-
               Shed rate exceeds {{ .Values.ap.prometheusRule.rules.highShedRate.threshold }} (ratio)
-              for async requests in namespace {{ "{{ $labels.namespace }}" }}.
+              for async requests in namespace {{ .Release.Namespace }}.
         {{- end }}
 {{- end }}

--- a/charts/async-processor/tests/deployment_test.yaml
+++ b/charts/async-processor/tests/deployment_test.yaml
@@ -114,6 +114,20 @@ tests:
             containerPort: 8080
             protocol: TCP
 
+  - it: should pass default metrics port to binary args
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-port=9090
+
+  - it: should pass custom metrics port to binary args
+    set:
+      ap.metrics.port: 8080
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-port=8080
+
   - it: should configure redis-pubsub by default when redis enabled
     asserts:
       - contains:

--- a/charts/async-processor/tests/observability_test.yaml
+++ b/charts/async-processor/tests/observability_test.yaml
@@ -102,6 +102,27 @@ tests:
           path: metadata.labels.team
           value: inference
 
+  - it: should use release namespace in alert descriptions
+    templates:
+      - templates/prometheus-rule.yaml
+    release:
+      namespace: test-ns
+    set:
+      ap.prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[0].annotations.description
+          pattern: "namespace test-ns"
+      - matchRegex:
+          path: spec.groups[0].rules[1].annotations.description
+          pattern: "namespace test-ns"
+      - matchRegex:
+          path: spec.groups[0].rules[2].annotations.description
+          pattern: "namespace test-ns"
+      - matchRegex:
+          path: spec.groups[0].rules[3].annotations.description
+          pattern: "namespace test-ns"
+
   # -- Grafana Dashboard ConfigMap --
   - it: should not render Grafana dashboard ConfigMap by default
     templates:


### PR DESCRIPTION
## What does this PR do?

Fixes a couple of remaining issues from https://github.com/llm-d-incubation/llm-d-async/pull/240 
1. `containerPort` is set from `ap.metrics.port` but `--metrics-port` is never passed to the binary args. 
2. `{{ "{{ $labels.namespace }}" }}` will render as empty text

## Why is this change needed?

The review for https://github.com/llm-d-incubation/llm-d-async/pull/240 highlighted a couple shortcomings that we address here.


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

follow up https://github.com/llm-d-incubation/llm-d-async/pull/240 