### PR TITLE
feat: add queue depth, in-flight, and broker backlog metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,6 +47,7 @@ func main() {
 	var redisTracing bool
 
 	var drainTimeout time.Duration
+	var backlogPollInterval time.Duration
 
 	var tlsCACert string
 	var tlsCert string
@@ -61,6 +62,7 @@ func main() {
 	flag.IntVar(&concurrency, "concurrency", 8, "number of concurrent workers")
 	flag.DurationVar(&requestTimeout, "request-timeout", 5*time.Minute, "timeout for individual inference requests")
 	flag.DurationVar(&drainTimeout, "drain-timeout", 2*time.Minute, "maximum time to wait for in-flight requests to complete after SIGTERM")
+	flag.DurationVar(&backlogPollInterval, "metrics-backlog-poll-interval", 15*time.Second, "interval to poll the broker for queue backlog metrics (0 disables); only applies to flows that support it (redis-sortedset, gcp-pubsub)")
 
 	flag.StringVar(&requestMergePolicy, "request-merge-policy", "random-robin", "The request merge policy to use. Supported policies: random-robin")
 	flag.StringVar(&messageQueueImpl, "message-queue-impl", "redis-pubsub", "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
@@ -212,6 +214,13 @@ func main() {
 	}
 
 	impl.Start(signalCtx)
+
+	if reporter, ok := impl.(pipeline.BacklogReporter); ok && backlogPollInterval > 0 {
+		go pollBacklog(signalCtx, reporter, backlogPollInterval)
+	} else if !ok {
+		setupLog.Info("Selected flow does not support broker backlog metrics", "message-queue-impl", messageQueueImpl)
+	}
+
 	<-signalCtx.Done()
 
 	setupLog.Info("Signal received, stopping message consumption")
@@ -271,6 +280,34 @@ func buildTLSConfig(caCertPath, certPath, keyPath string, insecureSkipVerify boo
 	}
 
 	return tlsConfig, nil
+}
+
+// pollBacklog periodically queries the broker for queue backlog and publishes
+// it as the async_broker_backlog gauge until ctx is cancelled.
+func pollBacklog(ctx context.Context, reporter pipeline.BacklogReporter, interval time.Duration) {
+	logger := ctrl.Log.WithName("backlog-poller")
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	poll := func() {
+		stats, err := reporter.QueueBacklog(ctx)
+		if err != nil {
+			logger.V(logging.DEFAULT).Error(err, "Failed to poll broker backlog")
+		}
+		for _, s := range stats {
+			metrics.SetBrokerBacklog(s.QueueID, s.QueueName, float64(s.Depth))
+		}
+	}
+
+	poll()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			poll()
+		}
+	}
 }
 
 func printAllFlags(setupLog logr.Logger) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace github.com/llm-d-incubation/llm-d-async/api => ./api
 replace github.com/llm-d-incubation/llm-d-async/pipeline => ./pipeline
 
 require (
+	cloud.google.com/go/monitoring v1.29.0
 	cloud.google.com/go/pubsub/v2 v2.6.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-logr/logr v1.4.3
@@ -28,6 +29,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.274.0
+	google.golang.org/protobuf v1.36.11
 	k8s.io/client-go v0.34.8
 	sigs.k8s.io/controller-runtime v0.22.5
 	sigs.k8s.io/gateway-api-inference-extension v1.2.1
@@ -117,12 +120,10 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-	google.golang.org/api v0.274.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.81.1 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/iam v1.7.0/go.mod h1:tetWZW1PD/m6vcuY2Zj/aU0eCHNPuxedbnbRTyKXvdY=
+cloud.google.com/go/monitoring v1.29.0 h1:AHhDsFaSax1/4k+qlIDX/SDGe6hggnfXJ9dkgD9qBPY=
+cloud.google.com/go/monitoring v1.29.0/go.mod h1:72NOVjJXHY/HBfoLT0+qlCZBT059+9VXLeAnL2PeeVM=
 cloud.google.com/go/pubsub/v2 v2.6.0 h1:8pjR0id+GTB+krKx5G6AGJoYrHog58w2Q89PCOrfM64=
 cloud.google.com/go/pubsub/v2 v2.6.0/go.mod h1:4anqvV/w8Pcgu2tO0qr2XgsF3GXHowzryfQ5gOnVmWY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -72,6 +72,21 @@ type RequestMergePolicy interface {
 	MergeRequestChannels(channels []RequestChannel) EmbelishedRequestChannel
 }
 
+// QueueBacklogStat reports the broker-side backlog for a single queue.
+type QueueBacklogStat struct {
+	QueueID   string
+	QueueName string
+	Depth     int64
+}
+
+// BacklogReporter is an optional capability for flows backed by a broker that
+// exposes a queryable backlog (e.g. Redis sorted sets, GCP PubSub). Flows whose
+// transport has no persisted queue (e.g. Redis Pub/Sub) do not implement it.
+type BacklogReporter interface {
+	// QueueBacklog returns the current backlog for each configured queue.
+	QueueBacklog(ctx context.Context) ([]QueueBacklogStat, error)
+}
+
 type RequestChannel struct {
 	Channel            chan *api.InternalRequest
 	IGWBaseURL         string

--- a/pkg/async/random_robin_policy.go
+++ b/pkg/async/random_robin_policy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 )
 
 func NewRandomRobinPolicy() pipeline.RequestMergePolicy {
@@ -67,6 +68,7 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 					HttpHeaders:     headers,
 					RequestURL:      requestURL,
 				}
+				metrics.IncQueueDepth(ir.QueueID, ir.RequestQueueName)
 				mergedChannel <- erm
 			}
 

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -46,6 +46,7 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 					if msg.InternalRequest == nil || msg.PublicRequest == nil {
 						continue
 					}
+					metrics.DecQueueDepth(msg.QueueID, msg.RequestQueueName)
 					retryMsg := pipeline.RetryMessage{
 						EmbelishedRequestMessage: msg,
 						BackoffDurationSeconds:   0,
@@ -74,97 +75,105 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 			}
 			queueID := msg.QueueID
 			queueName := msg.RequestQueueName
-			if msg.RetryCount == 0 {
-				metrics.RecordAsyncReq(queueID, queueName)
-			}
-			payloadBytes := validateAndMarshal(requestCtx, resultChannel, msg)
-			if payloadBytes == nil {
-				continue
-			}
+			metrics.DecQueueDepth(queueID, queueName)
 
-			sendInferenceRequest := func() {
-				reqCtx := requestCtx
-				if md := msg.PublicRequest.ReqMetadata(); len(md) > 0 {
-					reqCtx = otel.GetTextMapPropagator().Extract(reqCtx, propagation.MapCarrier(md))
-				}
+			processMessage := func() {
+				metrics.IncInflight(queueID, queueName)
+				defer metrics.DecInflight(queueID, queueName)
 
-				spanAttrs := []attribute.KeyValue{
-					attribute.String(uotel.AttrRequestID, msg.PublicRequest.ReqID()),
-					attribute.Int(uotel.AttrRetryCount, msg.RetryCount),
+				if msg.RetryCount == 0 {
+					metrics.RecordAsyncReq(queueID, queueName)
 				}
-				if queueID != "" {
-					spanAttrs = append(spanAttrs, attribute.String(uotel.AttrQueueID, queueID))
-				}
-				if queueName != "" {
-					spanAttrs = append(spanAttrs, attribute.String(uotel.AttrQueueName, queueName))
-				}
-				reqCtx, span := uotel.StartSpan(reqCtx, "process-request",
-					trace.WithAttributes(spanAttrs...),
-				)
-				defer span.End()
-
-				reqDeadline := time.Now().Add(requestTimeout)
-				if dline := msg.PublicRequest.ReqDeadline(); dline > 0 {
-					if msgDeadline := time.Unix(dline, 0); msgDeadline.Before(reqDeadline) {
-						reqDeadline = msgDeadline
-					}
-				}
-				reqCtx, cancel := context.WithDeadline(reqCtx, reqDeadline)
-				defer cancel()
-
-				logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
-				responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
-
-				if err == nil {
-					metrics.RecordSuccessfulReq(queueID, queueName)
-					select {
-					case resultChannel <- asyncapi.ResultMessage{
-						ID:       msg.PublicRequest.ReqID(),
-						Payload:  string(responseBody),
-						Routing:  msg.InternalRouting,
-						Metadata: msg.PublicRequest.ReqMetadata(),
-					}:
-					case <-requestCtx.Done():
-					}
+				payloadBytes := validateAndMarshal(requestCtx, resultChannel, msg)
+				if payloadBytes == nil {
 					return
 				}
 
-				if requestCtx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-					_, bgSpan := uotel.DetachedContext(reqCtx, "re-enqueue")
-					bgSpan.SetAttributes(attribute.String(uotel.AttrRequestID, msg.PublicRequest.ReqID()))
-					defer bgSpan.End()
-					retryChannel <- pipeline.RetryMessage{
-						EmbelishedRequestMessage: msg,
-						BackoffDurationSeconds:   0,
+				sendInferenceRequest := func() {
+					reqCtx := requestCtx
+					if md := msg.PublicRequest.ReqMetadata(); len(md) > 0 {
+						reqCtx = otel.GetTextMapPropagator().Extract(reqCtx, propagation.MapCarrier(md))
 					}
-					return
-				}
 
-				var inferenceErr asyncapi.InferenceError
-				if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {
-					span.RecordError(err)
-					span.SetStatus(codes.Error, "inference request failed")
-					span.SetAttributes(attribute.String(uotel.AttrErrorCategory, inferenceErrorCategory(err)))
-					metrics.RecordFailedReq(queueID, queueName)
-					select {
-					case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to send request to inference: %s", err.Error())):
-					case <-requestCtx.Done():
+					spanAttrs := []attribute.KeyValue{
+						attribute.String(uotel.AttrRequestID, msg.PublicRequest.ReqID()),
+						attribute.Int(uotel.AttrRetryCount, msg.RetryCount),
 					}
-					return
-				}
+					if queueID != "" {
+						spanAttrs = append(spanAttrs, attribute.String(uotel.AttrQueueID, queueID))
+					}
+					if queueName != "" {
+						spanAttrs = append(spanAttrs, attribute.String(uotel.AttrQueueName, queueName))
+					}
+					reqCtx, span := uotel.StartSpan(reqCtx, "process-request",
+						trace.WithAttributes(spanAttrs...),
+					)
+					defer span.End()
 
-				if inferenceErr.Category().Sheddable() {
-					metrics.RecordSheddedReq(queueID, queueName)
+					reqDeadline := time.Now().Add(requestTimeout)
+					if dline := msg.PublicRequest.ReqDeadline(); dline > 0 {
+						if msgDeadline := time.Unix(dline, 0); msgDeadline.Before(reqDeadline) {
+							reqDeadline = msgDeadline
+						}
+					}
+					reqCtx, cancel := context.WithDeadline(reqCtx, reqDeadline)
+					defer cancel()
+
+					logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
+					responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
+
+					if err == nil {
+						metrics.RecordSuccessfulReq(queueID, queueName)
+						select {
+						case resultChannel <- asyncapi.ResultMessage{
+							ID:       msg.PublicRequest.ReqID(),
+							Payload:  string(responseBody),
+							Routing:  msg.InternalRouting,
+							Metadata: msg.PublicRequest.ReqMetadata(),
+						}:
+						case <-requestCtx.Done():
+						}
+						return
+					}
+
+					if requestCtx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+						_, bgSpan := uotel.DetachedContext(reqCtx, "re-enqueue")
+						bgSpan.SetAttributes(attribute.String(uotel.AttrRequestID, msg.PublicRequest.ReqID()))
+						defer bgSpan.End()
+						retryChannel <- pipeline.RetryMessage{
+							EmbelishedRequestMessage: msg,
+							BackoffDurationSeconds:   0,
+						}
+						return
+					}
+
+					var inferenceErr asyncapi.InferenceError
+					if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {
+						span.RecordError(err)
+						span.SetStatus(codes.Error, "inference request failed")
+						span.SetAttributes(attribute.String(uotel.AttrErrorCategory, inferenceErrorCategory(err)))
+						metrics.RecordFailedReq(queueID, queueName)
+						select {
+						case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to send request to inference: %s", err.Error())):
+						case <-requestCtx.Done():
+						}
+						return
+					}
+
+					if inferenceErr.Category().Sheddable() {
+						metrics.RecordSheddedReq(queueID, queueName)
+					}
+					span.SetAttributes(attribute.String(uotel.AttrErrorCategory, string(inferenceErr.Category())))
+					var retryAfter time.Duration
+					var clientErr *asyncapi.ClientError
+					if errors.As(err, &clientErr) {
+						retryAfter = clientErr.RetryAfter
+					}
+					retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter)
 				}
-				span.SetAttributes(attribute.String(uotel.AttrErrorCategory, string(inferenceErr.Category())))
-				var retryAfter time.Duration
-				var clientErr *asyncapi.ClientError
-				if errors.As(err, &clientErr) {
-					retryAfter = clientErr.RetryAfter
-				}
-				retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter)
+				sendInferenceRequest()
 			}
-			sendInferenceRequest()
+			processMessage()
 		}
 	}
 }

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -812,6 +812,169 @@ func counterValue(cv *prometheus.CounterVec, queueID, queueName string) float64 
 	return testutil.ToFloat64(c)
 }
 
+func gaugeValue(gv *prometheus.GaugeVec, queueID, queueName string) float64 {
+	g, err := gv.GetMetricWithLabelValues(queueID, queueName)
+	if err != nil {
+		return 0
+	}
+	return testutil.ToFloat64(g)
+}
+
+// waitForGauge polls a gauge until it reaches want or the timeout elapses,
+// avoiding a race against the worker's deferred decrement.
+func waitForGauge(t *testing.T, gv *prometheus.GaugeVec, queueID, queueName string, want float64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := gaugeValue(gv, queueID, queueName)
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gauge for (%s,%s) = %f, want %f", queueID, queueName, got, want)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestMetrics_QueueDepthAndInflightBalance verifies the worker's gauge
+// bookkeeping: every message read decrements async_queue_depth (the merge
+// policy is responsible for the increment, simulated here), and
+// async_inflight_requests is bracketed around handling so it returns to zero on
+// every exit path (success, retry, and shutdown drain).
+func TestMetrics_QueueDepthAndInflightBalance(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		netErr     bool
+		drain      bool // cancel consumeCtx before the worker reads, exercising the drain path
+	}{
+		{name: "success decrements depth and clears inflight", statusCode: http.StatusOK},
+		{name: "retry decrements depth and clears inflight", statusCode: http.StatusTooManyRequests},
+		{name: "fatal error decrements depth and clears inflight", netErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queueID := "depth-" + tt.name
+			queueName := queueID
+
+			httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+				if tt.netErr {
+					return nil, fmt.Errorf("connection refused")
+				}
+				return &http.Response{StatusCode: tt.statusCode, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+			})
+			inferenceClient := NewHTTPInferenceClient(httpclient)
+			requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+			retryChannel := make(chan pipeline.RetryMessage, 1)
+			resultChannel := make(chan asyncapi.ResultMessage, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+
+			// Simulate the merge policy's increment for one buffered request.
+			metrics.IncQueueDepth(queueID, queueName)
+			if got := gaugeValue(metrics.QueueDepth, queueID, queueName); got != 1 {
+				t.Fatalf("queue depth before processing = %f, want 1", got)
+			}
+
+			requestChannel <- newEmbR(asyncapi.InternalRouting{
+				QueueID:          queueID,
+				RequestQueueName: queueName,
+			}, asyncapi.RequestMessage{
+				ID:       "depth-msg",
+				Created:  time.Now().Unix(),
+				Deadline: time.Now().Add(100 * time.Second).Unix(),
+				Payload:  map[string]any{"model": "test", "prompt": "hi"},
+			}, "http://localhost:30800/v1/completions", nil)
+
+			// Wait for the terminal outcome so handling has completed.
+			select {
+			case <-resultChannel:
+			case <-retryChannel:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for worker to process message")
+			}
+
+			// Depth must return to 0 (decremented on read) and inflight to 0
+			// (deferred decrement on every exit path).
+			waitForGauge(t, metrics.QueueDepth, queueID, queueName, 0)
+			waitForGauge(t, metrics.InflightRequests, queueID, queueName, 0)
+		})
+	}
+}
+
+// TestMetrics_QueueDepthDecrementsOnDrain verifies the worker's drain path
+// (consumeCtx cancelled) also decrements async_queue_depth for each buffered
+// message it re-enqueues, and never marks them inflight.
+func TestMetrics_QueueDepthDecrementsOnDrain(t *testing.T) {
+	queueID := "depth-drain-qid"
+	queueName := "depth-drain-queue"
+
+	// A blocking client: any message that reaches the normal (in-flight) path
+	// stays there until requestCtx is cancelled, at which point it re-enqueues.
+	// Combined with cancelling consumeCtx, every message ends up on the retry
+	// channel regardless of which path the worker's select happens to take.
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	const n = 3
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, n)
+	retryChannel := make(chan pipeline.RetryMessage, n)
+	resultChannel := make(chan asyncapi.ResultMessage, n)
+
+	consumeCtx, consumeCancel := context.WithCancel(context.Background())
+	requestCtx, requestCancel := context.WithCancel(context.Background())
+
+	// Buffer n messages and account for them as the merge policy would, then
+	// cancel both contexts so the worker drains/re-enqueues every message.
+	for i := 0; i < n; i++ {
+		metrics.IncQueueDepth(queueID, queueName)
+		requestChannel <- newEmbR(asyncapi.InternalRouting{
+			QueueID:          queueID,
+			RequestQueueName: queueName,
+		}, asyncapi.RequestMessage{
+			ID:       fmt.Sprintf("drain-depth-%d", i),
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(5 * time.Minute).Unix(),
+			Payload:  map[string]any{"model": "test", "prompt": "hi"},
+		}, "http://localhost:30800/v1/completions", nil)
+	}
+	consumeCancel()
+	requestCancel()
+
+	done := make(chan struct{})
+	go func() {
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		close(done)
+	}()
+
+	for i := 0; i < n; i++ {
+		select {
+		case <-retryChannel:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for re-enqueued message %d", i)
+		}
+	}
+
+	// Depth must drain to 0 on both the normal and drain read paths, and
+	// inflight must settle back to 0 (the decrement is deferred until after the
+	// re-enqueue send, so poll rather than read once).
+	waitForGauge(t, metrics.QueueDepth, queueID, queueName, 0)
+	waitForGauge(t, metrics.InflightRequests, queueID, queueName, 0)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit after drain")
+	}
+}
+
 func TestMetrics_SuccessfulRequest(t *testing.T) {
 	queueID := "metrics-success-qid"
 	queueName := "metrics-success-queue"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,6 +48,18 @@ var (
 		Help:    "Time from message publish to message being successfully processed.",
 		Buckets: []float64{100, 1000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000},
 	}, queueLabels)
+	QueueDepth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_queue_depth",
+		Help: "Number of requests received from the broker and buffered in-process awaiting an available worker.",
+	}, queueLabels)
+	InflightRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_inflight_requests",
+		Help: "Number of requests currently being processed by workers (dispatched to inference, awaiting a response).",
+	}, queueLabels)
+	BrokerBacklog = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_broker_backlog",
+		Help: "Number of undelivered/pending messages held by the broker queue.",
+	}, queueLabels)
 )
 
 func RecordRetry(queueID, queueName string) {
@@ -78,10 +90,36 @@ func RecordMessageLatency(millis float64, queueID, queueName string) {
 	MessageLatencyTime.WithLabelValues(queueID, queueName).Observe(millis)
 }
 
+// IncQueueDepth increments the count of in-process buffered requests.
+func IncQueueDepth(queueID, queueName string) {
+	QueueDepth.WithLabelValues(queueID, queueName).Inc()
+}
+
+// DecQueueDepth decrements the count of in-process buffered requests.
+func DecQueueDepth(queueID, queueName string) {
+	QueueDepth.WithLabelValues(queueID, queueName).Dec()
+}
+
+// IncInflight increments the count of requests actively processed by workers.
+func IncInflight(queueID, queueName string) {
+	InflightRequests.WithLabelValues(queueID, queueName).Inc()
+}
+
+// DecInflight decrements the count of requests actively processed by workers.
+func DecInflight(queueID, queueName string) {
+	InflightRequests.WithLabelValues(queueID, queueName).Dec()
+}
+
+// SetBrokerBacklog sets the broker-side backlog for a queue.
+func SetBrokerBacklog(queueID, queueName string, n float64) {
+	BrokerBacklog.WithLabelValues(queueID, queueName).Set(n)
+}
+
 // GetCollectors returns all custom collectors for the async processor.
 func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Collector {
 	collectors := []prometheus.Collector{
 		Retries, AsyncReqs, ExceededDeadlineReqs, FailedReqs, SuccessfulReqs, SheddedRequests,
+		QueueDepth, InflightRequests, BrokerBacklog,
 	}
 	if supportsMessageLatency {
 		collectors = append(collectors, MessageLatencyTime)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,6 +20,21 @@ func TestGetAsyncProcessorCollectors_withLatency(t *testing.T) {
 	}
 }
 
+func TestGetAsyncProcessorCollectors_includesGauges(t *testing.T) {
+	for _, withLatency := range []bool{false, true} {
+		collectors := GetAsyncProcessorCollectors(withLatency)
+		for name, gauge := range map[string]prometheus.Collector{
+			"QueueDepth":       QueueDepth,
+			"InflightRequests": InflightRequests,
+			"BrokerBacklog":    BrokerBacklog,
+		} {
+			if !containsCollector(collectors, gauge) {
+				t.Errorf("expected %s gauge to be present (supportsMessageLatency=%v)", name, withLatency)
+			}
+		}
+	}
+}
+
 func containsCollector(collectors []prometheus.Collector, target prometheus.Collector) bool {
 	for _, c := range collectors {
 		if c == target {

--- a/pkg/pubsub/gating_e2e_test.go
+++ b/pkg/pubsub/gating_e2e_test.go
@@ -60,7 +60,7 @@ func TestGating_EndToEnd(t *testing.T) {
 				f(ctx, msg1)
 				return nil
 			}
-			_ = flow.processMessages(ctx, receive, ch, gate)
+			_ = flow.processMessages(ctx, receive, "test-sub", ch, gate)
 		}()
 
 		// Verification: Request 1 should reach the channel
@@ -84,7 +84,7 @@ func TestGating_EndToEnd(t *testing.T) {
 				return nil
 			}
 			// We expect this to return without putting anything in 'ch'
-			_ = flow.processMessages(ctx, receive, ch, gate)
+			_ = flow.processMessages(ctx, receive, "test-sub", ch, gate)
 			deniedChan <- true
 		}()
 
@@ -111,7 +111,7 @@ func TestGating_EndToEnd(t *testing.T) {
 				f(ctx, msg3)
 				return nil
 			}
-			_ = flow.processMessages(ctx, receive, ch, gate)
+			_ = flow.processMessages(ctx, receive, "test-sub", ch, gate)
 		}()
 
 		select {
@@ -137,7 +137,7 @@ func TestGating_EndToEnd(t *testing.T) {
 					f(ctx, msg)
 					return nil
 				}
-				_ = flow.processMessages(context.Background(), receive, ch, gate)
+				_ = flow.processMessages(context.Background(), receive, "test-sub", ch, gate)
 			}()
 
 			select {
@@ -160,7 +160,7 @@ func TestGating_EndToEnd(t *testing.T) {
 				f(ctx, msg3)
 				return nil
 			}
-			_ = flow.processMessages(context.Background(), receive, ch, gate)
+			_ = flow.processMessages(context.Background(), receive, "test-sub", ch, gate)
 			deniedChan <- true
 		}()
 
@@ -183,7 +183,7 @@ func TestGating_EndToEnd(t *testing.T) {
 				f(ctx, msg4)
 				return nil
 			}
-			_ = flow.processMessages(context.Background(), receive, ch, gate)
+			_ = flow.processMessages(context.Background(), receive, "test-sub", ch, gate)
 		}()
 
 		select {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -236,7 +236,9 @@ func (r *PubSubMQFlow) Shutdown() {
 // approximate and lags real time by the metric's sampling interval.
 func (r *PubSubMQFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklogStat, error) {
 	if r.metricClient == nil {
-		return nil, fmt.Errorf("cloud monitoring client unavailable")
+		// Backlog reporting was disabled at startup (already logged when the
+		// client failed to initialize); no-op rather than erroring every poll.
+		return nil, nil
 	}
 	now := time.Now()
 	interval := &monitoringpb.TimeInterval{
@@ -260,7 +262,10 @@ func (r *PubSubMQFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklo
 		ts, err := it.Next()
 		if err != nil {
 			if errors.Is(err, iterator.Done) {
-				// No data point in the window; treat as unknown, skip.
+				// No sample in the window: for a configured subscription this
+				// normally means it has drained. Report 0 so the gauge does not
+				// retain a stale (high) value after the queue empties.
+				stats = append(stats, pipeline.QueueBacklogStat{QueueName: subID})
 				continue
 			}
 			if firstErr == nil {
@@ -270,6 +275,7 @@ func (r *PubSubMQFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklo
 		}
 		points := ts.GetPoints()
 		if len(points) == 0 {
+			stats = append(stats, pipeline.QueueBacklogStat{QueueName: subID})
 			continue
 		}
 		// Points are returned newest-first; the first is the latest sample.
@@ -392,7 +398,7 @@ func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.C
 			continue
 		}
 
-		err := r.processMessages(receiveCtx, sub.Receive, ch, gate)
+		err := r.processMessages(receiveCtx, sub.Receive, subscriberID, ch, gate)
 
 		cancel()
 		// TODO
@@ -405,7 +411,7 @@ func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.C
 
 type receiveFunc func(context.Context, func(context.Context, *pubsub.Message)) error
 
-func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc, ch chan *api.InternalRequest, gate pipeline.DispatchGate) error {
+func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc, subscriberID string, ch chan *api.InternalRequest, gate pipeline.DispatchGate) error {
 	logger := log.FromContext(ctx)
 	return receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 
@@ -417,7 +423,10 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 			return
 		}
 
-		irout := api.InternalRouting{TransportCorrelationID: msg.ID}
+		// Carry the subscription as the request queue label so all per-queue
+		// metrics (throughput, depth, inflight, latency) align with the
+		// async_broker_backlog gauge, which is keyed by subscription ID.
+		irout := api.InternalRouting{TransportCorrelationID: msg.ID, RequestQueueName: subscriberID}
 		if msg.DeliveryAttempt != nil {
 			irout.RetryCount = *msg.DeliveryAttempt - 1
 		}

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -271,6 +271,9 @@ func (r *PubSubMQFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklo
 			if firstErr == nil {
 				firstErr = fmt.Errorf("list time series for subscription %q: %w", subID, err)
 			}
+			// Report 0 rather than skipping so the gauge does not retain a
+			// stale value for this subscription after a failed poll.
+			stats = append(stats, pipeline.QueueBacklogStat{QueueName: subID})
 			continue
 		}
 		points := ts.GetPoints()

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"math"
@@ -10,11 +11,15 @@ import (
 	"sync"
 	"time"
 
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"github.com/llm-d-incubation/llm-d-async/pkg/util"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
@@ -58,6 +63,8 @@ type PubSubMQFlow struct {
 	consumeWg       sync.WaitGroup
 	drainCancel     context.CancelFunc
 	drainWg         sync.WaitGroup
+	metricClient    *monitoring.MetricClient
+	projectID       string
 }
 type RequestChannelData struct {
 	requestChannel pipeline.RequestChannel
@@ -103,6 +110,16 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 		requestChannels: make([]RequestChannelData, 0, len(configs)),
 		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage),
+		projectID:       *projectID,
+	}
+
+	// Cloud Monitoring client for broker-backlog metrics. Best-effort: if it
+	// can't be created (e.g. missing credentials), backlog reporting is
+	// skipped but the flow still operates normally.
+	if metricClient, mErr := monitoring.NewMetricClient(ctx); mErr != nil {
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(mErr, "Failed to create Cloud Monitoring client; broker backlog metrics disabled")
+	} else {
+		p.metricClient = metricClient
 	}
 
 	// Apply functional options
@@ -208,7 +225,63 @@ func (r *PubSubMQFlow) Shutdown() {
 		r.drainCancel()
 	}
 	r.drainWg.Wait()
+	if r.metricClient != nil {
+		_ = r.metricClient.Close()
+	}
 }
+
+// QueueBacklog reports the number of undelivered messages per subscription,
+// sourced from the Cloud Monitoring metric
+// pubsub.googleapis.com/subscription/num_undelivered_messages. The value is
+// approximate and lags real time by the metric's sampling interval.
+func (r *PubSubMQFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklogStat, error) {
+	if r.metricClient == nil {
+		return nil, fmt.Errorf("cloud monitoring client unavailable")
+	}
+	now := time.Now()
+	interval := &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(now.Add(-5 * time.Minute)),
+		EndTime:   timestamppb.New(now),
+	}
+
+	stats := make([]pipeline.QueueBacklogStat, 0, len(r.requestChannels))
+	var firstErr error
+	for _, cd := range r.requestChannels {
+		subID := cd.subscriberID
+		req := &monitoringpb.ListTimeSeriesRequest{
+			Name: "projects/" + r.projectID,
+			Filter: fmt.Sprintf(
+				`metric.type="pubsub.googleapis.com/subscription/num_undelivered_messages" AND resource.labels.subscription_id="%s"`,
+				subID),
+			Interval: interval,
+			View:     monitoringpb.ListTimeSeriesRequest_FULL,
+		}
+		it := r.metricClient.ListTimeSeries(ctx, req)
+		ts, err := it.Next()
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				// No data point in the window; treat as unknown, skip.
+				continue
+			}
+			if firstErr == nil {
+				firstErr = fmt.Errorf("list time series for subscription %q: %w", subID, err)
+			}
+			continue
+		}
+		points := ts.GetPoints()
+		if len(points) == 0 {
+			continue
+		}
+		// Points are returned newest-first; the first is the latest sample.
+		stats = append(stats, pipeline.QueueBacklogStat{
+			QueueName: subID,
+			Depth:     points[0].GetValue().GetInt64Value(),
+		})
+	}
+	return stats, firstErr
+}
+
+var _ pipeline.BacklogReporter = (*PubSubMQFlow)(nil)
 
 func resultWorker(ctx context.Context, publisher *pubsub.Publisher, resultChannel chan api.ResultMessage) {
 	logger := log.FromContext(ctx)

--- a/pkg/pubsub/pubsubimpl_test.go
+++ b/pkg/pubsub/pubsubimpl_test.go
@@ -119,7 +119,7 @@ func TestProcessMessages_QuotaGating(t *testing.T) {
 				}
 			}()
 
-			_ = flow.processMessages(ctx, receive, ch, gate)
+			_ = flow.processMessages(ctx, receive, "test-sub", ch, gate)
 		})
 	}
 }

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -298,6 +298,29 @@ func (r *RedisSortedSetFlow) RequestChannels() []pipeline.RequestChannel {
 	return channels
 }
 
+// QueueBacklog reports the number of pending members in each queue's sorted set.
+func (r *RedisSortedSetFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklogStat, error) {
+	stats := make([]pipeline.QueueBacklogStat, 0, len(r.requestChannels))
+	var firstErr error
+	for _, cd := range r.requestChannels {
+		depth, err := r.rdb.ZCard(ctx, cd.queueName).Result()
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("ZCard on queue %q: %w", cd.queueName, err)
+			}
+			continue
+		}
+		stats = append(stats, pipeline.QueueBacklogStat{
+			QueueID:   cd.queueID,
+			QueueName: cd.queueName,
+			Depth:     depth,
+		})
+	}
+	return stats, firstErr
+}
+
+var _ pipeline.BacklogReporter = (*RedisSortedSetFlow)(nil)
+
 func (r *RedisSortedSetFlow) RetryChannel() chan pipeline.RetryMessage {
 	return r.retryChannel
 }

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -308,6 +308,12 @@ func (r *RedisSortedSetFlow) QueueBacklog(ctx context.Context) ([]pipeline.Queue
 			if firstErr == nil {
 				firstErr = fmt.Errorf("ZCard on queue %q: %w", cd.queueName, err)
 			}
+			// Report 0 rather than skipping so the gauge does not retain a
+			// stale value for this queue after a failed poll.
+			stats = append(stats, pipeline.QueueBacklogStat{
+				QueueID:   cd.queueID,
+				QueueName: cd.queueName,
+			})
 			continue
 		}
 		stats = append(stats, pipeline.QueueBacklogStat{

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -1310,3 +1310,43 @@ func TestQueueBacklog(t *testing.T) {
 		t.Errorf("queue-b backlog = %d, want 1", got["queue-b"])
 	}
 }
+
+// TestQueueBacklogReportsZeroOnError verifies that a per-queue failure reports a
+// 0 sentinel for that queue (rather than skipping it) so the gauge does not
+// retain a stale value, while healthy queues still report their real depth.
+func TestQueueBacklogReportsZeroOnError(t *testing.T) {
+	_, rdb, ctx, cancel := setupTest(t)
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{
+			{queueName: "queue-ok", queueID: "ok"},
+			{queueName: "queue-bad", queueID: "bad"},
+		},
+	}
+
+	rdb.ZAdd(ctx, "queue-ok", redis.Z{Score: 0, Member: "m1"})
+	// Make queue-bad a string so ZCard fails with WRONGTYPE.
+	rdb.Set(ctx, "queue-bad", "not-a-sorted-set", 0)
+
+	stats, err := flow.QueueBacklog(ctx)
+	if err == nil {
+		t.Fatal("QueueBacklog expected an error for the WRONGTYPE queue, got nil")
+	}
+
+	got := make(map[string]int64, len(stats))
+	for _, s := range stats {
+		got[s.QueueName] = s.Depth
+	}
+	if _, ok := got["queue-bad"]; !ok {
+		t.Error("queue-bad missing from stats; want a 0 sentinel instead of being skipped")
+	}
+	if got["queue-bad"] != 0 {
+		t.Errorf("queue-bad backlog = %d, want 0", got["queue-bad"])
+	}
+	if got["queue-ok"] != 1 {
+		t.Errorf("queue-ok backlog = %d, want 1", got["queue-ok"])
+	}
+}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -1274,3 +1274,39 @@ func TestSortedSetFlow_ResultQueueFallsBackToMessageLevel(t *testing.T) {
 		t.Errorf("Expected 1 message in global default queue, got %d", globalLen)
 	}
 }
+
+func TestQueueBacklog(t *testing.T) {
+	_, rdb, ctx, cancel := setupTest(t)
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{
+			{queueName: "queue-a", queueID: "a"},
+			{queueName: "queue-b", queueID: "b"},
+		},
+	}
+
+	// queue-a gets 3 members, queue-b gets 1, an unrelated key is ignored.
+	for i, m := range []string{"m1", "m2", "m3"} {
+		rdb.ZAdd(ctx, "queue-a", redis.Z{Score: float64(i), Member: m})
+	}
+	rdb.ZAdd(ctx, "queue-b", redis.Z{Score: 0, Member: "only"})
+
+	stats, err := flow.QueueBacklog(ctx)
+	if err != nil {
+		t.Fatalf("QueueBacklog returned error: %v", err)
+	}
+
+	got := make(map[string]int64, len(stats))
+	for _, s := range stats {
+		got[s.QueueName] = s.Depth
+	}
+	if got["queue-a"] != 3 {
+		t.Errorf("queue-a backlog = %d, want 3", got["queue-a"])
+	}
+	if got["queue-b"] != 1 {
+		t.Errorf("queue-b backlog = %d, want 1", got["queue-b"])
+	}
+}


### PR DESCRIPTION
## What does this PR do?

feat: add queue depth, in-flight, and broker backlog metrics

  Add three Prometheus gauges to surface live load, following the existing
  llm_d_async subsystem and queue_id/queue_name label conventions:

  - async_queue_depth: requests received from the broker and buffered
    in-process awaiting an available worker. Inc'd in the merge policy
    before enqueue, Dec'd on every worker read (normal and drain paths).
  - async_inflight_requests: requests a worker is actively dispatching to
    inference. Bracketed around per-message handling in the worker so it
    decrements on every exit path.
  - async_broker_backlog: undelivered/pending messages held by the broker,
    populated by an optional pipeline.BacklogReporter capability and a
    poller goroutine in main (--metrics-backlog-poll-interval, default 15s).
    Implemented for the Redis sorted-set flow (ZCard) and GCP PubSub
    (Cloud Monitoring num_undelivered_messages). The Redis Pub/Sub flow has
    no persisted queue and intentionally does not report a backlog.

## How was this tested?

- [ X] Unit tests added/updated
- [ X] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
