### PR TITLE
fix: use printf instead of echo to pipe GHCR token in publish script

### DIFF
--- a/scripts/publish-helm-chart.sh
+++ b/scripts/publish-helm-chart.sh
@@ -43,7 +43,7 @@ helm package charts/async-processor -d release/
 
 (cd release && sha256sum "async-processor-${CHART_VERSION}.tgz" >> SHA256SUMS && cat SHA256SUMS)
 
-echo "${GITHUB_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+printf '%s' "${GITHUB_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 helm push "release/async-processor-${CHART_VERSION}.tgz" "${HELM_OCI_REGISTRY}"
 
 echo "Helm chart published: ${HELM_OCI_REGISTRY}/async-processor:${CHART_VERSION}"


### PR DESCRIPTION
## What it do

In `scripts/publish-helm-chart.sh`, pipe the GHCR token to `helm registry login --password-stdin` with `printf '%s'` instead of `echo`.

## Why

- `echo` appends a trailing newline, which becomes part of the piped secret.
- With some `echo` implementations, a token that begins with `-` can be interpreted as a flag (e.g. `-n`/`-e`) rather than printed.
- `printf '%s'` is portable across shells and passes the token verbatim.

Fixes #87

