### PR TITLE
fix: namespace-scoped PromQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 
 - `prometheus-saturation`:
   - `pool` (**required**): The inference pool name to filter metrics by.
+  - `namespace` (optional): Kubernetes namespace to scope metric queries. Required when multiple namespaces share the same pool name with a shared Prometheus instance.
   - `threshold` (optional): Saturation threshold (0.0-1.0). When saturation >= threshold, budget is 0.0. Default is `0.8`.
   - `fallback` (optional): Fallback saturation value (0.0-1.0) used when the metric source returns an error or empty data. Default is `0.0`.
 
@@ -224,6 +225,7 @@ For more fine-grained control, configure gates per queue in your configuration f
   - `pool` (**required**): The InferencePool name. This must match both the `name` field in
     `inference_pool_ready_pods{name="<pool>"}` (EPP metric) and, for the vLLM fallback,
     the `inference_pool` label on scraped vLLM metrics (added via relabeling from pod labels).
+  - `namespace` (optional): Kubernetes namespace to scope metric queries. Required when multiple namespaces share the same pool name with a shared Prometheus instance.
   - `max_concurrency` (optional): Per-endpoint request capacity (`MaxConcurrency` in the [inference scheduler's saturation detector](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go)). Default is `100` (matching the inference scheduler default).
   - `baseline` (optional): Reserved baseline B. The gate closes when D ≤ B. Default is `0.05`.
   - `fallback` (optional): Fallback budget value (0.0-1.0) returned when all metric sources are unavailable. Default is `0.0` (fail closed).

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -135,6 +135,18 @@ The values file (`docs/guides/e2e-deploy/async-processor-values.yaml`) configure
 - Queue: Redis sorted-set with `redis.url` set directly (chart creates the Secret), configured via `queuesConfig`
 - Gate: `prometheus-budget` with pool=`optimized-baseline`, max_concurrency=100, baseline=0.05 (per-queue)
 - Prometheus URL pointing to the cluster's `llmd-kube-prometheus-stack-prometheus` service
+
+> **Multi-namespace deployments:** If the cluster has multiple inference pools
+> with the same name in different namespaces, the `prometheus-budget` and
+> `prometheus-saturation` gate queries will return ambiguous results. Add
+> `namespace` to `gate_params` to scope the queries:
+> ```yaml
+> gate_params:
+>   pool: "optimized-baseline"
+>   namespace: "my-namespace"    # scope metrics to this namespace
+>   max_concurrency: "100"
+>   baseline: "0.05"
+> ```
 - `modelServerMonitor.enabled: true` — creates a PodMonitor that relabels the `inference_pool`
   pod label into vLLM metrics (required for the dispatch budget gate fallback)
 - `podMonitor.enabled: true` — creates a PodMonitor that scrapes the async-processor's own

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -138,8 +138,9 @@ The values file (`docs/guides/e2e-deploy/async-processor-values.yaml`) configure
 
 > **Multi-namespace deployments:** If the cluster has multiple inference pools
 > with the same name in different namespaces, the `prometheus-budget` and
-> `prometheus-saturation` gate queries will return ambiguous results. Add
-> `namespace` to `gate_params` to scope the queries:
+> `prometheus-saturation` gate queries may match multiple time series and fail
+> with many-to-many matching errors. Add `namespace` to `gate_params` to scope
+> the queries:
 > ```yaml
 > gate_params:
 >   pool: "optimized-baseline"

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -244,12 +244,13 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 		}
 
 		promConfig := promapi.Config{Address: f.prometheusURL}
+		namespace := params["namespace"]
 
-		primary, err := NewFlowControlQueueSizePromQL(promConfig, pool, maxConcurrency)
+		primary, err := NewFlowControlQueueSizePromQL(promConfig, pool, maxConcurrency, namespace)
 		if err != nil {
 			return nil, err
 		}
-		secondary, err := NewVLLMSaturationPromQL(promConfig, pool, maxConcurrency)
+		secondary, err := NewVLLMSaturationPromQL(promConfig, pool, maxConcurrency, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/async/inference/flowcontrol/metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/metric_source_test.go
@@ -165,60 +165,80 @@ func TestNewPromQLMetricSource_InvalidAddress(t *testing.T) {
 
 // PromQL construction tests for budget and saturation source factories
 
-func TestFlowControlQueueSizePromQL_ContainsExpectedMetrics(t *testing.T) {
-	source, err := NewFlowControlQueueSizePromQL(
-		api.Config{Address: "http://localhost:9090"},
-		"my-pool", 100,
-	)
-	require.NoError(t, err)
-	require.Contains(t, source.expr, `inference_extension_flow_control_queue_size{inference_pool="my-pool"}`)
-	require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool"}`)
-	require.Contains(t, source.expr, "* 100")
+func TestFlowControlQueueSizePromQL(t *testing.T) {
+	promConfig := api.Config{Address: "http://localhost:9090"}
+
+	t.Run("ContainsExpectedMetrics", func(t *testing.T) {
+		source, err := NewFlowControlQueueSizePromQL(promConfig, "my-pool", 100, "")
+		require.NoError(t, err)
+		require.Contains(t, source.expr, `inference_extension_flow_control_queue_size{inference_pool="my-pool"}`)
+		require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool"}`)
+		require.Contains(t, source.expr, "* 100")
+		require.NotContains(t, source.expr, "namespace")
+	})
+
+	t.Run("RequiresPool", func(t *testing.T) {
+		_, err := NewFlowControlQueueSizePromQL(promConfig, "", 100, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inference pool name is required")
+	})
+
+	t.Run("WithNamespace", func(t *testing.T) {
+		source, err := NewFlowControlQueueSizePromQL(promConfig, "my-pool", 100, "prod")
+		require.NoError(t, err)
+		require.Contains(t, source.expr, `inference_extension_flow_control_queue_size{inference_pool="my-pool",namespace="prod"}`)
+		require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool",namespace="prod"}`)
+	})
 }
 
-func TestFlowControlQueueSizePromQL_RequiresPool(t *testing.T) {
-	_, err := NewFlowControlQueueSizePromQL(
-		api.Config{Address: "http://localhost:9090"},
-		"", 100,
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "inference pool name is required")
+func TestVLLMSaturationPromQL(t *testing.T) {
+	promConfig := api.Config{Address: "http://localhost:9090"}
+
+	t.Run("ContainsExpectedMetrics", func(t *testing.T) {
+		source, err := NewVLLMSaturationPromQL(promConfig, "my-pool", 100, "")
+		require.NoError(t, err)
+		require.Contains(t, source.expr, `vllm:num_requests_running{inference_pool="my-pool"}`)
+		require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool"}`)
+		require.Contains(t, source.expr, "* 100")
+		require.NotContains(t, source.expr, "namespace")
+	})
+
+	t.Run("RequiresPool", func(t *testing.T) {
+		_, err := NewVLLMSaturationPromQL(promConfig, "", 100, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inference pool name is required")
+	})
+
+	t.Run("WithNamespace", func(t *testing.T) {
+		source, err := NewVLLMSaturationPromQL(promConfig, "my-pool", 100, "prod")
+		require.NoError(t, err)
+		require.Contains(t, source.expr, `vllm:num_requests_running{inference_pool="my-pool",namespace="prod"}`)
+		require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool",namespace="prod"}`)
+	})
 }
 
-func TestVLLMSaturationPromQL_ContainsExpectedMetrics(t *testing.T) {
-	source, err := NewVLLMSaturationPromQL(
-		api.Config{Address: "http://localhost:9090"},
-		"my-pool", 100,
-	)
-	require.NoError(t, err)
-	require.Contains(t, source.expr, `vllm:num_requests_running{inference_pool="my-pool"}`)
-	require.Contains(t, source.expr, `inference_pool_ready_pods{name="my-pool"}`)
-	require.Contains(t, source.expr, "* 100")
-}
+func TestNewSaturationPromQLSourceFromConfig(t *testing.T) {
+	promConfig := api.Config{Address: "http://localhost:9090"}
 
-func TestVLLMSaturationPromQL_RequiresPool(t *testing.T) {
-	_, err := NewVLLMSaturationPromQL(
-		api.Config{Address: "http://localhost:9090"},
-		"", 100,
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "inference pool name is required")
-}
+	t.Run("DefaultQuery", func(t *testing.T) {
+		source, err := NewSaturationPromQLSourceFromConfig(promConfig,
+			map[string]string{"pool": "my-pool"})
+		require.NoError(t, err)
+		require.Contains(t, source.expr, `1 - inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
+		require.NotContains(t, source.expr, "namespace")
+	})
 
-func TestNewSaturationPromQLSourceFromConfig_DefaultQuery(t *testing.T) {
-	source, err := NewSaturationPromQLSourceFromConfig(
-		api.Config{Address: "http://localhost:9090"},
-		map[string]string{"pool": "my-pool"},
-	)
-	require.NoError(t, err)
-	require.Contains(t, source.expr, `1 - inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
-}
+	t.Run("RequiresPool", func(t *testing.T) {
+		_, err := NewSaturationPromQLSourceFromConfig(promConfig, map[string]string{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inference pool name is required")
+	})
 
-func TestNewSaturationPromQLSourceFromConfig_RequiresPool(t *testing.T) {
-	_, err := NewSaturationPromQLSourceFromConfig(
-		api.Config{Address: "http://localhost:9090"},
-		map[string]string{},
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "inference pool name is required")
+	t.Run("WithNamespace", func(t *testing.T) {
+		source, err := NewSaturationPromQLSourceFromConfig(promConfig,
+			map[string]string{"pool": "my-pool", "namespace": "prod"})
+		require.NoError(t, err)
+		require.Contains(t, source.expr, `inference_pool="my-pool"`)
+		require.Contains(t, source.expr, `namespace="prod"`)
+	})
 }

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -62,14 +62,17 @@ func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool stri
 	if maxConcurrency <= 0 {
 		return nil, fmt.Errorf("maxConcurrency must be positive, got %g", maxConcurrency)
 	}
-	label := strconv.Quote(inferencePool)
-	nsFilter := ""
+	queueLabels := map[string]string{"inference_pool": inferencePool}
+	podsLabels := map[string]string{"name": inferencePool}
 	if namespace != "" {
-		nsFilter = fmt.Sprintf(`,namespace=%s`, strconv.Quote(namespace))
+		queueLabels["namespace"] = namespace
+		podsLabels["namespace"] = namespace
 	}
 	query := fmt.Sprintf(
-		`1 - (sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s%s}) / on() (inference_pool_ready_pods{name=%s%s} * %g))`,
-		label, nsFilter, label, nsFilter, maxConcurrency,
+		`1 - (sum by(inference_pool)(%s) / on() (%s * %g))`,
+		buildPromQL("inference_extension_flow_control_queue_size", queueLabels),
+		buildPromQL("inference_pool_ready_pods", podsLabels),
+		maxConcurrency,
 	)
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {
@@ -89,14 +92,17 @@ func NewVLLMSaturationPromQL(promConfig promapi.Config, inferencePool string, ma
 	if maxConcurrency <= 0 {
 		return nil, fmt.Errorf("maxConcurrency must be positive, got %g", maxConcurrency)
 	}
-	label := strconv.Quote(inferencePool)
-	nsFilter := ""
+	vllmLabels := map[string]string{"inference_pool": inferencePool}
+	podsLabels := map[string]string{"name": inferencePool}
 	if namespace != "" {
-		nsFilter = fmt.Sprintf(`,namespace=%s`, strconv.Quote(namespace))
+		vllmLabels["namespace"] = namespace
+		podsLabels["namespace"] = namespace
 	}
 	query := fmt.Sprintf(
-		`1 - (sum(vllm:num_requests_running{inference_pool=%s%s}) / on() (inference_pool_ready_pods{name=%s%s} * %g))`,
-		label, nsFilter, label, nsFilter, maxConcurrency,
+		`1 - (sum(%s) / on() (%s * %g))`,
+		buildPromQL("vllm:num_requests_running", vllmLabels),
+		buildPromQL("inference_pool_ready_pods", podsLabels),
+		maxConcurrency,
 	)
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -34,8 +34,12 @@ func NewSaturationPromQLSourceFromConfig(promConfig promapi.Config, params map[s
 		return nil, fmt.Errorf("inference pool name is required for saturation PromQL")
 	}
 
-	queryExpr := "1 - " + buildPromQL("inference_extension_flow_control_pool_saturation",
-		map[string]string{"inference_pool": inferencePool})
+	labels := map[string]string{"inference_pool": inferencePool}
+	if ns := params["namespace"]; ns != "" {
+		labels["namespace"] = ns
+	}
+
+	queryExpr := "1 - " + buildPromQL("inference_extension_flow_control_pool_saturation", labels)
 	return NewPromQLMetricSource(promConfig, queryExpr)
 }
 
@@ -51,7 +55,7 @@ func NewPromQLMetricSourceFromLabels(promConfig promapi.Config, metricName strin
 // inference_extension_flow_control_queue_size and max_SYS = ready_pods × maxConcurrency is
 // computed dynamically from the inference_pool_ready_pods metric.
 // inferencePool and maxConcurrency are required.
-func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64) (*PromQLMetricSource, error) {
+func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64, namespace string) (*PromQLMetricSource, error) {
 	if inferencePool == "" {
 		return nil, fmt.Errorf("inference pool name is required for flow control queue size PromQL")
 	}
@@ -59,9 +63,13 @@ func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool stri
 		return nil, fmt.Errorf("maxConcurrency must be positive, got %g", maxConcurrency)
 	}
 	label := strconv.Quote(inferencePool)
+	nsFilter := ""
+	if namespace != "" {
+		nsFilter = fmt.Sprintf(`,namespace=%s`, strconv.Quote(namespace))
+	}
 	query := fmt.Sprintf(
-		`1 - (sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s}) / on() (inference_pool_ready_pods{name=%s} * %g))`,
-		label, label, maxConcurrency,
+		`1 - (sum by(inference_pool)(inference_extension_flow_control_queue_size{inference_pool=%s%s}) / on() (inference_pool_ready_pods{name=%s%s} * %g))`,
+		label, nsFilter, label, nsFilter, maxConcurrency,
 	)
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {
@@ -74,7 +82,7 @@ func NewFlowControlQueueSizePromQL(promConfig promapi.Config, inferencePool stri
 // from vLLM and pool metrics, returning D = 1 − (running_requests / (ready_pods × maxConcurrency)).
 // This serves as a fallback when EPP flow control metrics are unavailable.
 // inferencePool and maxConcurrency are required.
-func NewVLLMSaturationPromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64) (*PromQLMetricSource, error) {
+func NewVLLMSaturationPromQL(promConfig promapi.Config, inferencePool string, maxConcurrency float64, namespace string) (*PromQLMetricSource, error) {
 	if inferencePool == "" {
 		return nil, fmt.Errorf("inference pool name is required for vLLM saturation PromQL")
 	}
@@ -82,9 +90,13 @@ func NewVLLMSaturationPromQL(promConfig promapi.Config, inferencePool string, ma
 		return nil, fmt.Errorf("maxConcurrency must be positive, got %g", maxConcurrency)
 	}
 	label := strconv.Quote(inferencePool)
+	nsFilter := ""
+	if namespace != "" {
+		nsFilter = fmt.Sprintf(`,namespace=%s`, strconv.Quote(namespace))
+	}
 	query := fmt.Sprintf(
-		`1 - (sum(vllm:num_requests_running{inference_pool=%s}) / on() (inference_pool_ready_pods{name=%s} * %g))`,
-		label, label, maxConcurrency,
+		`1 - (sum(vllm:num_requests_running{inference_pool=%s%s}) / on() (inference_pool_ready_pods{name=%s%s} * %g))`,
+		label, nsFilter, label, nsFilter, maxConcurrency,
 	)
 	source, err := NewPromQLMetricSource(promConfig, query)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

add a namespace parameter to the budget gates

## Why is this change needed?

without namespace, queries get computed by name, aggregating together results from different namespaces if the name matches!

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

