### PR TITLE
feat: add inference request latency metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ The processor exports the following Prometheus metrics on the metrics port (defa
 | `llm_d_async_async_exceeded_deadline_requests_total` | Counter | Requests that exceeded their deadline |
 | `llm_d_async_async_shedded_requests_total` | Counter | Rate-limited/shed requests (429) |
 | `llm_d_async_async_message_latency_time_millis` | Histogram | Message latency (Pub/Sub only) |
+| `llm_d_async_async_inference_latency_time_millis` | Histogram | Time spent calling the inference gateway (IGW), isolating model time from queue time |
 
 **Labels:**
 
@@ -467,6 +468,7 @@ The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem
 | `llm_d_async_async_exceeded_deadline_requests_total` | Counter | Requests that exceeded their deadline before completion |
 | `llm_d_async_async_request_retries_total` | Counter | Retry attempts |
 | `llm_d_async_async_message_latency_time_millis` | Histogram | End-to-end message latency in milliseconds (publish to successful processing). Only registered when the transport supports message latency (e.g., GCP Pub/Sub). |
+| `llm_d_async_async_inference_latency_time_millis` | Histogram | Time in milliseconds spent calling the inference gateway (IGW), measured around each request attempt. Isolates "model time" from "queue time" and is always registered. |
 
 **Labels:**
 
@@ -486,6 +488,9 @@ rate(llm_d_async_async_shedded_requests_total[5m])
 
 # Retry ratio by queue
 rate(llm_d_async_async_request_retries_total[5m]) / rate(llm_d_async_async_request_total[5m])
+
+# p95 inference gateway latency by queue (model time, excluding queue time)
+histogram_quantile(0.95, sum by (queue_name, le) (rate(llm_d_async_async_inference_latency_time_millis_bucket[5m])))
 ```
 
 ## Implementations

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.31.0
 	github.com/onsi/gomega v1.42.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.68.1
 	github.com/redis/go-redis/extra/redisotel/v9 v9.20.1
 	github.com/redis/go-redis/v9 v9.20.1
@@ -90,7 +91,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -114,7 +114,9 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 					defer cancel()
 
 					logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
+					inferenceStart := time.Now()
 					responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
+					metrics.RecordInferenceLatency(float64(time.Since(inferenceStart).Milliseconds()), queueID, queueName, msg.WorkerPoolID)
 
 					if err == nil {
 						metrics.RecordSuccessfulReq(queueID, queueName, msg.WorkerPoolID)

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -817,6 +818,18 @@ func counterValue(cv *prometheus.CounterVec, queueID, queueName string) float64 
 	return testutil.ToFloat64(c)
 }
 
+func histogramSampleCount(hv *prometheus.HistogramVec, queueID, queueName string) uint64 {
+	obs, err := hv.GetMetricWithLabelValues(queueID, queueName, "test-pool")
+	if err != nil {
+		return 0
+	}
+	m := &dto.Metric{}
+	if err := obs.(prometheus.Metric).Write(m); err != nil {
+		return 0
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
 func gaugeValue(gv *prometheus.GaugeVec, queueID, queueName string) float64 {
 	g, err := gv.GetMetricWithLabelValues(queueID, queueName, "test-pool")
 	if err != nil {
@@ -1021,6 +1034,9 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 	}
 	if got := counterValue(metrics.SuccessfulReqs, queueID, queueName); got < 1 {
 		t.Errorf("SuccessfulReqs(%s,%s) = %f, want >= 1", queueID, queueName, got)
+	}
+	if got := histogramSampleCount(metrics.InferenceLatencyTime, queueID, queueName); got < 1 {
+		t.Errorf("InferenceLatencyTime(%s,%s) sample count = %d, want >= 1", queueID, queueName, got)
 	}
 	if got := counterValue(metrics.FailedReqs, queueID, queueName); got != 0 {
 		t.Errorf("FailedReqs(%s,%s) = %f, want 0", queueID, queueName, got)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,6 +49,11 @@ var (
 		Help:    "Time from message publish to message being successfully processed.",
 		Buckets: []float64{100, 1000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000},
 	}, queueLabels)
+	InferenceLatencyTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_inference_latency_time_millis",
+		Help:    "Time spent calling the inference gateway (IGW), separating model time from queue time.",
+		Buckets: []float64{10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000},
+	}, queueLabels)
 	QueueDepth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_queue_depth",
 		Help: "Number of requests received from the broker and buffered in-process awaiting an available worker.",
@@ -91,6 +96,11 @@ func RecordMessageLatency(millis float64, queueID, queueName, poolName string) {
 	MessageLatencyTime.WithLabelValues(queueID, queueName, poolName).Observe(millis)
 }
 
+// RecordInferenceLatency observes the time spent calling the inference gateway.
+func RecordInferenceLatency(millis float64, queueID, queueName, poolName string) {
+	InferenceLatencyTime.WithLabelValues(queueID, queueName, poolName).Observe(millis)
+}
+
 // IncQueueDepth increments the count of in-process buffered requests.
 func IncQueueDepth(queueID, queueName, poolName string) {
 	QueueDepth.WithLabelValues(queueID, queueName, poolName).Inc()
@@ -120,7 +130,7 @@ func SetBrokerBacklog(queueID, queueName, poolName string, n float64) {
 func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Collector {
 	collectors := []prometheus.Collector{
 		Retries, AsyncReqs, ExceededDeadlineReqs, FailedReqs, SuccessfulReqs, SheddedRequests,
-		QueueDepth, InflightRequests, BrokerBacklog,
+		QueueDepth, InflightRequests, BrokerBacklog, InferenceLatencyTime,
 	}
 	if supportsMessageLatency {
 		collectors = append(collectors, MessageLatencyTime)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -35,6 +35,17 @@ func TestGetAsyncProcessorCollectors_includesGauges(t *testing.T) {
 	}
 }
 
+func TestGetAsyncProcessorCollectors_includesInferenceLatency(t *testing.T) {
+	// Inference latency is measured in-process and is not gated on broker
+	// support for publish timestamps, so it is always registered.
+	for _, withLatency := range []bool{false, true} {
+		collectors := GetAsyncProcessorCollectors(withLatency)
+		if !containsCollector(collectors, InferenceLatencyTime) {
+			t.Errorf("expected InferenceLatencyTime to be present (supportsMessageLatency=%v)", withLatency)
+		}
+	}
+}
+
 func containsCollector(collectors []prometheus.Collector, target prometheus.Collector) bool {
 	for _, c := range collectors {
 		if c == target {


### PR DESCRIPTION
## What

Adds the **Inference Request Latency** histogram from issue #217, measuring the time spent calling the inference gateway (IGW). This isolates "model time" from "queue time".

- New metric `llm_d_async_async_inference_latency_time_millis` (Histogram), with the standard `queue_id` / `queue_name` / `pool_name` labels and buckets spanning 10ms–120s.
- Recorded around each `client.SendRequest` attempt in the worker, so every IGW call attempt (success, failure, or shed) is observed.
- Unlike message latency, it is measured in-process and is therefore **always registered** (not gated on broker support for publish timestamps).

## Changes

- `pkg/metrics/metrics.go`: define `InferenceLatencyTime`, add `RecordInferenceLatency`, register the collector.
- `pkg/asyncworker/worker.go`: time the `SendRequest` call and observe the latency.
- Tests: assert the collector is always registered and that a sample is recorded on a successful request.
- `README.md`: document the metric in both metrics tables and add a p95 PromQL example.
- `go.mod`: `go mod tidy` promoted `prometheus/client_model` to a direct dependency (used by the new test helper).

## Related

Part of #217.