### PR TITLE
feat: add queue residence time metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ The processor exports the following Prometheus metrics on the metrics port (defa
 | `llm_d_async_async_shedded_requests_total` | Counter | Rate-limited/shed requests (429) |
 | `llm_d_async_async_message_latency_time_millis` | Histogram | Message latency (Pub/Sub only) |
 | `llm_d_async_async_inference_latency_time_millis` | Histogram | Time spent calling the inference gateway (IGW), isolating model time from queue time |
+| `llm_d_async_async_queue_residence_time_millis` | Histogram | Time a message spent buffered in-process from broker ingestion until a worker pulled it |
 
 **Labels:**
 
@@ -469,6 +470,7 @@ The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem
 | `llm_d_async_async_request_retries_total` | Counter | Retry attempts |
 | `llm_d_async_async_message_latency_time_millis` | Histogram | End-to-end message latency in milliseconds (publish to successful processing). Only registered when the transport supports message latency (e.g., GCP Pub/Sub). |
 | `llm_d_async_async_inference_latency_time_millis` | Histogram | Time in milliseconds spent calling the inference gateway (IGW), measured around each request attempt. Isolates "model time" from "queue time" and is always registered. |
+| `llm_d_async_async_queue_residence_time_millis` | Histogram | Time in milliseconds a message spent buffered in-process, from broker ingestion until a worker pulled it for processing. Measures the async delay introduced by the system (queue time). Always registered. |
 
 **Labels:**
 
@@ -491,6 +493,9 @@ rate(llm_d_async_async_request_retries_total[5m]) / rate(llm_d_async_async_reque
 
 # p95 inference gateway latency by queue (model time, excluding queue time)
 histogram_quantile(0.95, sum by (queue_name, le) (rate(llm_d_async_async_inference_latency_time_millis_bucket[5m])))
+
+# p95 queue residence time by queue (async delay, excluding model time)
+histogram_quantile(0.95, sum by (queue_name, le) (rate(llm_d_async_async_queue_residence_time_millis_bucket[5m])))
 ```
 
 ## Implementations

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 type QuotaClassification string
@@ -34,6 +35,11 @@ type InternalRouting struct {
 type InternalRequest struct {
 	InternalRouting `json:"-"`
 	PublicRequest   Request
+	// IngestionTime records when the message was pulled from the broker into
+	// the in-process pipeline. It is in-process only: the custom JSON
+	// (un)marshaling does not persist it, so a re-enqueued (retried) message is
+	// re-stamped on its next delivery. Zero when not set (e.g. drained messages).
+	IngestionTime time.Time `json:"-"`
 }
 
 // NewInternalRequest returns an InternalRequest with a non-nil PublicRequest.

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -69,6 +69,9 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 			queueID := msg.QueueID
 			queueName := msg.RequestQueueName
 			metrics.DecQueueDepth(queueID, queueName, msg.WorkerPoolID)
+			if !msg.IngestionTime.IsZero() {
+				metrics.RecordQueueResidenceTime(float64(time.Since(msg.IngestionTime).Milliseconds()), queueID, queueName, msg.WorkerPoolID)
+			}
 
 			processMessage := func() {
 				metrics.IncInflight(queueID, queueName, msg.WorkerPoolID)

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -1013,7 +1013,7 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 
 	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
 
-	requestChannel <- newEmbR(asyncapi.InternalRouting{
+	emb := newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
 		RequestQueueName: queueName,
 	}, asyncapi.RequestMessage{
@@ -1022,6 +1022,10 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 		Deadline: time.Now().Add(100 * time.Second).Unix(),
 		Payload:  map[string]any{"model": "test", "prompt": "hi"},
 	}, "http://localhost:30800/v1/completions", nil)
+	// Stamp ingestion time so the worker records queue residence time, mirroring
+	// what the broker producers do when a message enters the in-process buffer.
+	emb.IngestionTime = time.Now()
+	requestChannel <- emb
 
 	select {
 	case <-resultChannel:
@@ -1037,6 +1041,9 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 	}
 	if got := histogramSampleCount(metrics.InferenceLatencyTime, queueID, queueName); got < 1 {
 		t.Errorf("InferenceLatencyTime(%s,%s) sample count = %d, want >= 1", queueID, queueName, got)
+	}
+	if got := histogramSampleCount(metrics.QueueResidenceTime, queueID, queueName); got < 1 {
+		t.Errorf("QueueResidenceTime(%s,%s) sample count = %d, want >= 1", queueID, queueName, got)
 	}
 	if got := counterValue(metrics.FailedReqs, queueID, queueName); got != 0 {
 		t.Errorf("FailedReqs(%s,%s) = %f, want 0", queueID, queueName, got)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -56,8 +56,27 @@ var (
 	}, queueLabels)
 	QueueResidenceTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_queue_residence_time_millis",
-		Help:    "Time a message spent buffered in-process from broker ingestion until a worker pulled it (the async delay introduced by the system).",
-		Buckets: []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000},
+		Help: "Time a message spent buffered in-process from broker ingestion until a worker pulled it (the async delay introduced by the system).",
+		// Residence time can range from sub-second up to a full day under
+		// sustained backlog, so buckets span 500ms (smallest) to 24h, all in ms.
+		Buckets: []float64{
+			500,      // 500ms
+			1000,     // 1s
+			2000,     // 2s
+			5000,     // 5s
+			10000,    // 10s
+			30000,    // 30s
+			60000,    // 1m
+			120000,   // 2m
+			300000,   // 5m
+			600000,   // 10m
+			1800000,  // 30m
+			3600000,  // 1h
+			7200000,  // 2h
+			21600000, // 6h
+			43200000, // 12h
+			86400000, // 24h
+		},
 	}, queueLabels)
 	QueueDepth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_queue_depth",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -54,6 +54,11 @@ var (
 		Help:    "Time spent calling the inference gateway (IGW), separating model time from queue time.",
 		Buckets: []float64{10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000},
 	}, queueLabels)
+	QueueResidenceTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_queue_residence_time_millis",
+		Help:    "Time a message spent buffered in-process from broker ingestion until a worker pulled it (the async delay introduced by the system).",
+		Buckets: []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000},
+	}, queueLabels)
 	QueueDepth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_queue_depth",
 		Help: "Number of requests received from the broker and buffered in-process awaiting an available worker.",
@@ -101,6 +106,12 @@ func RecordInferenceLatency(millis float64, queueID, queueName, poolName string)
 	InferenceLatencyTime.WithLabelValues(queueID, queueName, poolName).Observe(millis)
 }
 
+// RecordQueueResidenceTime observes the time a message spent buffered in-process
+// from broker ingestion until a worker pulled it.
+func RecordQueueResidenceTime(millis float64, queueID, queueName, poolName string) {
+	QueueResidenceTime.WithLabelValues(queueID, queueName, poolName).Observe(millis)
+}
+
 // IncQueueDepth increments the count of in-process buffered requests.
 func IncQueueDepth(queueID, queueName, poolName string) {
 	QueueDepth.WithLabelValues(queueID, queueName, poolName).Inc()
@@ -130,7 +141,7 @@ func SetBrokerBacklog(queueID, queueName, poolName string, n float64) {
 func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Collector {
 	collectors := []prometheus.Collector{
 		Retries, AsyncReqs, ExceededDeadlineReqs, FailedReqs, SuccessfulReqs, SheddedRequests,
-		QueueDepth, InflightRequests, BrokerBacklog, InferenceLatencyTime,
+		QueueDepth, InflightRequests, BrokerBacklog, InferenceLatencyTime, QueueResidenceTime,
 	}
 	if supportsMessageLatency {
 		collectors = append(collectors, MessageLatencyTime)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -46,6 +46,17 @@ func TestGetAsyncProcessorCollectors_includesInferenceLatency(t *testing.T) {
 	}
 }
 
+func TestGetAsyncProcessorCollectors_includesQueueResidence(t *testing.T) {
+	// Queue residence time is measured in-process and is not gated on broker
+	// support for publish timestamps, so it is always registered.
+	for _, withLatency := range []bool{false, true} {
+		collectors := GetAsyncProcessorCollectors(withLatency)
+		if !containsCollector(collectors, QueueResidenceTime) {
+			t.Errorf("expected QueueResidenceTime to be present (supportsMessageLatency=%v)", withLatency)
+		}
+	}
+}
+
 func containsCollector(collectors []prometheus.Collector, target prometheus.Collector) bool {
 	for _, c := range collectors {
 		if c == target {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -517,6 +517,10 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 		resultChannels.Store(msg.ID, resultsChannel)
 		defer resultChannels.Delete(msg.ID)
 
+		// Stamp ingestion time as the message enters the in-process buffer so the
+		// worker can record queue residence time when it pulls the message.
+		ir.IngestionTime = time.Now()
+
 		ch <- ir
 
 		result := <-resultsChannel

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -477,6 +477,10 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			r.activeReleases.Store(rview.ReqID(), release)
 		}
 
+		// Stamp ingestion time as the message enters the in-process buffer so the
+		// worker can record queue residence time when it pulls the message.
+		ir.IngestionTime = time.Now()
+
 		select {
 		case msgChannel <- ir:
 		case <-ctx.Done():


### PR DESCRIPTION
## What

Adds the **Queue Residence Time** histogram from issue #217, measuring the time a message spends buffered in-process from broker ingestion until a worker pulls it for processing. This isolates the **async delay introduced by the system** (queue time) from model time.

- New metric `llm_d_async_async_queue_residence_time_millis` (Histogram), with the standard `queue_id` / `queue_name` / `pool_name` labels and buckets spanning 1ms–120s.
- Stamped as the message enters the in-process buffer (redis sorted-set and pubsub flows). Retries re-enter via the broker, so each delivery is re-stamped — no stale timestamps across retries.
- Observed at worker pull, guarded on a non-zero ingestion time (drained/untimed messages are skipped).
- Measured in-process, so it is **always registered** (not gated on broker support for publish timestamps).

## Changes

- `api/internal_api.go`: in-process-only `IngestionTime` field on `InternalRequest` (`json:"-"`, never persisted by the custom envelope marshaling).
- `pkg/redis/sortedset_impl.go`, `pkg/pubsub/pubsubimpl.go`: stamp ingestion time as the message enters the in-process channel.
- `pkg/metrics/metrics.go`: define `QueueResidenceTime`, add `RecordQueueResidenceTime`, register the collector.
- `pkg/asyncworker/worker.go`: observe residence time at worker pull.
- Tests: assert the collector is always registered and that a sample is recorded on a successful request.
- `README.md`: document the metric in both metrics tables and add a p95 PromQL example.


## Related

Part of #217.
