### PR TITLE
feat: add request body-transform extension point

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,7 +81,7 @@ func main() {
 	flag.StringVar(&tlsKey, "tls-key", "", "Path to client key file (PEM) for mTLS")
 	flag.BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Skip TLS certificate verification (dev/test only)")
 	flag.StringVar(&poolConfigFile, "pool-config-file", "", "Path to the pools configuration JSON file")
-	flag.StringVar(&transformConfigFile, "transform-config-file", "", "Path to the request body-transform plugins configuration JSON file (empty disables transforms)")
+	flag.StringVar(&transformConfigFile, "transform-config-file", "", "Path to the body-transform plugins configuration JSON file (object with a requestTransforms array; empty disables transforms)")
 
 	var prometheusURL = flag.String("prometheus-url", "", "Prometheus server URL for metric-based gates (e.g., http://localhost:9090)")
 
@@ -270,12 +270,12 @@ func main() {
 	// JSON dispatch path unchanged.
 	var transforms *transform.Chain
 	if transformConfigFile != "" {
-		specs, err := transform.LoadConfig(transformConfigFile)
+		cfg, err := transform.LoadConfig(transformConfigFile)
 		if err != nil {
 			setupLog.Error(err, "Failed to load transform configuration file")
 			os.Exit(1)
 		}
-		transforms, err = transform.BuildChain(specs, plugins.NewHandle(signalCtx))
+		transforms, err = transform.BuildChain(cfg.RequestTransforms, plugins.NewHandle(signalCtx))
 		if err != nil {
 			setupLog.Error(err, "Failed to build request transform chain")
 			os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,9 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/pkg/async"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker"
+	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
 	"github.com/llm-d-incubation/llm-d-async/pkg/pubsub"
 	"github.com/llm-d-incubation/llm-d-async/pkg/redis"
 	"github.com/llm-d-incubation/llm-d-async/pkg/version"
@@ -56,6 +58,7 @@ func main() {
 	var tlsKey string
 	var tlsInsecureSkipVerify bool
 	var poolConfigFile string
+	var transformConfigFile string
 
 	flag.IntVar(&loggerVerbosity, "v", logging.DEFAULT, "number for the log level verbosity")
 
@@ -78,6 +81,7 @@ func main() {
 	flag.StringVar(&tlsKey, "tls-key", "", "Path to client key file (PEM) for mTLS")
 	flag.BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Skip TLS certificate verification (dev/test only)")
 	flag.StringVar(&poolConfigFile, "pool-config-file", "", "Path to the pools configuration JSON file")
+	flag.StringVar(&transformConfigFile, "transform-config-file", "", "Path to the request body-transform plugins configuration JSON file (empty disables transforms)")
 
 	var prometheusURL = flag.String("prometheus-url", "", "Prometheus server URL for metric-based gates (e.g., http://localhost:9090)")
 
@@ -261,6 +265,24 @@ func main() {
 	)}
 	inferenceClient := asyncworker.NewHTTPInferenceClient(inferenceHTTPClient)
 
+	// Build the request body-transform chain from configuration. When no config
+	// file is provided the chain is nil and the worker preserves the default
+	// JSON dispatch path unchanged.
+	var transforms *transform.Chain
+	if transformConfigFile != "" {
+		specs, err := transform.LoadConfig(transformConfigFile)
+		if err != nil {
+			setupLog.Error(err, "Failed to load transform configuration file")
+			os.Exit(1)
+		}
+		transforms, err = transform.BuildChain(specs, plugins.NewHandle(signalCtx))
+		if err != nil {
+			setupLog.Error(err, "Failed to build request transform chain")
+			os.Exit(1)
+		}
+		setupLog.Info("Loaded request transform plugins", "count", transforms.Len())
+	}
+
 	dispatch := policy.MergeRequestChannels(impl.RequestChannels(), poolsMap)
 
 	var wg sync.WaitGroup
@@ -277,7 +299,7 @@ func main() {
 			wg.Add(1)
 			go func(mergedChan chan pipeline.EmbelishedRequestMessage) {
 				defer wg.Done()
-				asyncworker.Worker(signalCtx, drainCtx, impl.Characteristics(), inferenceClient, mergedChan, impl.RetryChannel(), impl.ResultChannel(), requestTimeout)
+				asyncworker.Worker(signalCtx, drainCtx, impl.Characteristics(), inferenceClient, mergedChan, impl.RetryChannel(), impl.ResultChannel(), requestTimeout, transforms)
 			}(mergedChan)
 		}
 	}

--- a/pkg/asyncworker/transform/chain.go
+++ b/pkg/asyncworker/transform/chain.go
@@ -1,0 +1,58 @@
+package transform
+
+// Chain is an ordered set of RequestTransform plugins applied to each outgoing
+// request. A nil *Chain is valid and behaves as a no-op, so callers that have no
+// transforms configured can pass nil and preserve the default JSON path exactly.
+type Chain struct {
+	transforms []RequestTransform
+}
+
+// NewChain returns a Chain over the given transforms, in priority order.
+func NewChain(transforms []RequestTransform) *Chain {
+	return &Chain{transforms: transforms}
+}
+
+// Len reports the number of transforms in the chain.
+func (c *Chain) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.transforms)
+}
+
+// Validate runs every transform's Validate in order and returns the first error.
+// Each transform decides whether it applies to the message; non-applicable
+// transforms return nil. A nil/empty chain validates successfully.
+func (c *Chain) Validate(payload []byte, metadata map[string]string, reqDeadline int64) error {
+	if c == nil {
+		return nil
+	}
+	for _, t := range c.transforms {
+		if err := t.Validate(payload, metadata, reqDeadline); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Apply runs transforms in order and returns the body produced by the first one
+// that handles the message (first-handled-wins, short-circuit): once a transform
+// returns handled=true, its body and Content-Type are returned and no further
+// transforms run. If no transform handles the message, handled is false and the
+// caller should send the original payload unchanged. A nil/empty chain returns
+// handled=false. An error from any transform short-circuits and is returned.
+func (c *Chain) Apply(payload []byte, metadata map[string]string) (body []byte, contentType string, handled bool, err error) {
+	if c == nil {
+		return nil, "", false, nil
+	}
+	for _, t := range c.transforms {
+		body, contentType, handled, err = t.Transform(payload, metadata)
+		if err != nil {
+			return nil, "", false, err
+		}
+		if handled {
+			return body, contentType, true, nil
+		}
+	}
+	return nil, "", false, nil
+}

--- a/pkg/asyncworker/transform/chain.go
+++ b/pkg/asyncworker/transform/chain.go
@@ -1,5 +1,7 @@
 package transform
 
+import "fmt"
+
 // Chain is an ordered set of RequestTransform plugins applied to each outgoing
 // request. A nil *Chain is valid and behaves as a no-op, so callers that have no
 // transforms configured can pass nil and preserve the default JSON path exactly.
@@ -29,7 +31,7 @@ func (c *Chain) Validate(payload []byte, metadata map[string]string, reqDeadline
 	}
 	for _, t := range c.transforms {
 		if err := t.Validate(payload, metadata, reqDeadline); err != nil {
-			return err
+			return fmt.Errorf("transform %s: %w", t.TypedName(), err)
 		}
 	}
 	return nil
@@ -48,7 +50,7 @@ func (c *Chain) Apply(payload []byte, metadata map[string]string) (body []byte, 
 	for _, t := range c.transforms {
 		body, contentType, handled, err = t.Transform(payload, metadata)
 		if err != nil {
-			return nil, "", false, err
+			return nil, "", false, fmt.Errorf("transform %s: %w", t.TypedName(), err)
 		}
 		if handled {
 			return body, contentType, true, nil

--- a/pkg/asyncworker/transform/loader.go
+++ b/pkg/asyncworker/transform/loader.go
@@ -35,8 +35,8 @@ func LoadConfig(path string) ([]PluginSpec, error) {
 
 // BuildChain instantiates the configured transforms in order, registering each
 // instance on handle, and returns the resulting Chain. Plugin names must be
-// non-empty and unique; each type must be registered in plugins.Registry and the
-// instantiated plugin must implement RequestTransform.
+// non-empty and unique; each type must be registered with plugins.Register and
+// the instantiated plugin must implement RequestTransform.
 //
 // An empty spec list returns an empty (no-op) Chain.
 func BuildChain(specs []PluginSpec, handle plugins.Handle) (*Chain, error) {
@@ -55,7 +55,7 @@ func BuildChain(specs []PluginSpec, handle plugins.Handle) (*Chain, error) {
 		}
 		seen[spec.Name] = true
 
-		factory, ok := plugins.Registry[spec.Type]
+		factory, ok := plugins.Lookup(spec.Type)
 		if !ok {
 			return nil, fmt.Errorf("transform plugin %q has unregistered type %q", spec.Name, spec.Type)
 		}

--- a/pkg/asyncworker/transform/loader.go
+++ b/pkg/asyncworker/transform/loader.go
@@ -1,0 +1,77 @@
+package transform
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+)
+
+// PluginSpec is one entry in the transform configuration: a uniquely-named
+// instance of a registered plugin type, plus opaque parameters passed verbatim
+// to the plugin's factory. Mirrors EPP's plugin configuration shape.
+type PluginSpec struct {
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+}
+
+// LoadConfig reads and parses a transform plugins configuration JSON file (a
+// JSON array of PluginSpec). It does not instantiate plugins; pass the result to
+// BuildChain.
+func LoadConfig(path string) ([]PluginSpec, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path from trusted CLI flag
+	if err != nil {
+		return nil, fmt.Errorf("failed to read transform config file: %w", err)
+	}
+
+	var specs []PluginSpec
+	if err := json.Unmarshal(data, &specs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal transform config: %w", err)
+	}
+	return specs, nil
+}
+
+// BuildChain instantiates the configured transforms in order, registering each
+// instance on handle, and returns the resulting Chain. Plugin names must be
+// non-empty and unique; each type must be registered in plugins.Registry and the
+// instantiated plugin must implement RequestTransform.
+//
+// An empty spec list returns an empty (no-op) Chain.
+func BuildChain(specs []PluginSpec, handle plugins.Handle) (*Chain, error) {
+	transforms := make([]RequestTransform, 0, len(specs))
+	seen := make(map[string]bool, len(specs))
+
+	for i, spec := range specs {
+		if spec.Name == "" {
+			return nil, fmt.Errorf("transform plugin at index %d has an empty name", i)
+		}
+		if spec.Type == "" {
+			return nil, fmt.Errorf("transform plugin %q is missing a type", spec.Name)
+		}
+		if seen[spec.Name] {
+			return nil, fmt.Errorf("duplicate transform plugin name %q", spec.Name)
+		}
+		seen[spec.Name] = true
+
+		factory, ok := plugins.Registry[spec.Type]
+		if !ok {
+			return nil, fmt.Errorf("transform plugin %q has unregistered type %q", spec.Name, spec.Type)
+		}
+
+		plugin, err := factory(spec.Name, spec.Parameters, handle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create transform plugin %q (type %q): %w", spec.Name, spec.Type, err)
+		}
+
+		t, ok := plugin.(RequestTransform)
+		if !ok {
+			return nil, fmt.Errorf("transform plugin %q (type %q) does not implement RequestTransform", spec.Name, spec.Type)
+		}
+		handle.AddPlugin(spec.Name, plugin)
+		transforms = append(transforms, t)
+	}
+
+	return NewChain(transforms), nil
+}

--- a/pkg/asyncworker/transform/loader.go
+++ b/pkg/asyncworker/transform/loader.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,20 +18,33 @@ type PluginSpec struct {
 	Parameters json.RawMessage `json:"parameters,omitempty"`
 }
 
-// LoadConfig reads and parses a transform plugins configuration JSON file (a
-// JSON array of PluginSpec). It does not instantiate plugins; pass the result to
-// BuildChain.
-func LoadConfig(path string) ([]PluginSpec, error) {
+// Config is the top-level transform plugins configuration. Transforms are keyed
+// by direction so request and (in the future) response plugins can share a
+// single config file. Only requestTransforms is consumed today; responseTransforms
+// is reserved for the symmetric response body-transform extension point (#259).
+type Config struct {
+	RequestTransforms []PluginSpec `json:"requestTransforms"`
+}
+
+// LoadConfig reads and parses a transform plugins configuration JSON file. The
+// file is a JSON object with transforms grouped by direction, e.g.
+// {"requestTransforms": [ ... ]}. Unknown top-level fields are rejected so a
+// typo (or a not-yet-supported direction such as responseTransforms) fails
+// loudly instead of being silently ignored. It does not instantiate plugins;
+// pass the result to BuildChain.
+func LoadConfig(path string) (Config, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path from trusted CLI flag
 	if err != nil {
-		return nil, fmt.Errorf("failed to read transform config file: %w", err)
+		return Config{}, fmt.Errorf("failed to read transform config file: %w", err)
 	}
 
-	var specs []PluginSpec
-	if err := json.Unmarshal(data, &specs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal transform config: %w", err)
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var cfg Config
+	if err := dec.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal transform config: %w", err)
 	}
-	return specs, nil
+	return cfg, nil
 }
 
 // BuildChain instantiates the configured transforms in order, registering each

--- a/pkg/asyncworker/transform/transform.go
+++ b/pkg/asyncworker/transform/transform.go
@@ -1,0 +1,34 @@
+// Package transform defines the request body-transform extension point: a typed
+// plugin capability that lets providers rewrite the outgoing HTTP body at
+// dispatch time (e.g. from OpenAI-style JSON into multipart/form-data) based on
+// per-message metadata, while leaving the default JSON path untouched when no
+// plugin applies.
+//
+// It builds on the generic plugin framework in pkg/plugins (EPP-style Plugin,
+// Registry, Handle). Concrete transforms (such as a gcs_uri multipart provider)
+// are separate plugins that register a factory under their own type.
+package transform
+
+import "github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+
+// RequestTransform is a dispatch-time body-transform plugin. The worker invokes
+// the configured chain after marshalling the request payload and before sending
+// it to the inference backend. A plugin that does not recognize a message
+// returns handled=false from Transform, preserving the default JSON path.
+type RequestTransform interface {
+	plugins.Plugin
+
+	// Validate runs before dispatch. It returns a non-nil error to reject the
+	// message outright (the worker treats this as fatal/non-retryable) — for
+	// example, a signed object URL that expires before reqDeadline. Plugins that
+	// do not recognize the message must return nil.
+	//
+	// reqDeadline is the request deadline in Unix seconds.
+	Validate(payload []byte, metadata map[string]string, reqDeadline int64) error
+
+	// Transform optionally rewrites the outgoing body. When it recognizes the
+	// message it returns the new body, the Content-Type to set on the request,
+	// and handled=true. Otherwise it returns handled=false and the default JSON
+	// body is used unchanged.
+	Transform(payload []byte, metadata map[string]string) (body []byte, contentType string, handled bool, err error)
+}

--- a/pkg/asyncworker/transform/transform_test.go
+++ b/pkg/asyncworker/transform/transform_test.go
@@ -140,15 +140,16 @@ func TestLoadConfigAndBuildChain(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "transforms.json")
-	cfg := `[{"name":"whisper","type":"transform_test.multipart","parameters":{"provider":"whisper"}}]`
+	cfg := `{"requestTransforms":[{"name":"whisper","type":"transform_test.multipart","parameters":{"provider":"whisper"}}]}`
 	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	specs, err := LoadConfig(path)
+	loaded, err := LoadConfig(path)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
+	specs := loaded.RequestTransforms
 	if len(specs) != 1 || specs[0].Name != "whisper" || specs[0].Type != typ {
 		t.Fatalf("unexpected specs: %+v", specs)
 	}
@@ -163,6 +164,21 @@ func TestLoadConfigAndBuildChain(t *testing.T) {
 	}
 	if handle.Plugin("whisper") == nil {
 		t.Error("plugin 'whisper' not registered on handle")
+	}
+}
+
+func TestLoadConfig_RejectsUnknownTopLevelFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transforms.json")
+	// responseTransforms is not supported yet (#259); a typo or premature use
+	// must fail loudly rather than be silently dropped.
+	cfg := `{"requestTransforms":[],"responseTransforms":[]}`
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadConfig(path); err == nil {
+		t.Error("LoadConfig with unknown top-level field = nil error, want error")
 	}
 }
 

--- a/pkg/asyncworker/transform/transform_test.go
+++ b/pkg/asyncworker/transform/transform_test.go
@@ -1,0 +1,215 @@
+package transform
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+)
+
+// fakeTransform is a configurable RequestTransform for tests.
+type fakeTransform struct {
+	name        string
+	validateErr error
+	handled     bool
+	body        []byte
+	contentType string
+	transformer error
+
+	validateCalls *int
+	transformLog  *[]string
+}
+
+func (f *fakeTransform) TypedName() plugins.TypedName {
+	return plugins.TypedName{Type: "fake", Name: f.name}
+}
+
+func (f *fakeTransform) Validate(_ []byte, _ map[string]string, _ int64) error {
+	if f.validateCalls != nil {
+		*f.validateCalls++
+	}
+	return f.validateErr
+}
+
+func (f *fakeTransform) Transform(_ []byte, _ map[string]string) ([]byte, string, bool, error) {
+	if f.transformLog != nil {
+		*f.transformLog = append(*f.transformLog, f.name)
+	}
+	if f.transformer != nil {
+		return nil, "", false, f.transformer
+	}
+	if !f.handled {
+		return nil, "", false, nil
+	}
+	return f.body, f.contentType, true, nil
+}
+
+func TestChain_NilIsNoOp(t *testing.T) {
+	var c *Chain
+	if c.Len() != 0 {
+		t.Errorf("nil chain Len = %d, want 0", c.Len())
+	}
+	if err := c.Validate([]byte(`{}`), nil, 0); err != nil {
+		t.Errorf("nil chain Validate err = %v, want nil", err)
+	}
+	body, ct, handled, err := c.Apply([]byte(`{}`), nil)
+	if handled || err != nil || body != nil || ct != "" {
+		t.Errorf("nil chain Apply = (%q,%q,%v,%v), want all zero/false/nil", body, ct, handled, err)
+	}
+}
+
+func TestChain_Validate_ReturnsFirstError(t *testing.T) {
+	wantErr := errors.New("boom")
+	var firstCalls, secondCalls int
+	c := NewChain([]RequestTransform{
+		&fakeTransform{name: "first", validateErr: wantErr, validateCalls: &firstCalls},
+		&fakeTransform{name: "second", validateCalls: &secondCalls},
+	})
+	if err := c.Validate([]byte(`{}`), nil, 0); !errors.Is(err, wantErr) {
+		t.Errorf("Validate err = %v, want %v", err, wantErr)
+	}
+	if firstCalls != 1 {
+		t.Errorf("first Validate called %d times, want 1", firstCalls)
+	}
+	if secondCalls != 0 {
+		t.Errorf("second Validate called %d times, want 0 (short-circuit)", secondCalls)
+	}
+}
+
+func TestChain_Apply_FirstHandledWinsAndShortCircuits(t *testing.T) {
+	var log []string
+	c := NewChain([]RequestTransform{
+		&fakeTransform{name: "skip", handled: false, transformLog: &log},
+		&fakeTransform{name: "win", handled: true, body: []byte("WIN"), contentType: "multipart/form-data; boundary=x", transformLog: &log},
+		&fakeTransform{name: "never", handled: true, body: []byte("NEVER"), transformLog: &log},
+	})
+	body, ct, handled, err := c.Apply([]byte(`{}`), nil)
+	if err != nil || !handled {
+		t.Fatalf("Apply = handled %v err %v, want handled true err nil", handled, err)
+	}
+	if string(body) != "WIN" || ct != "multipart/form-data; boundary=x" {
+		t.Errorf("Apply body=%q ct=%q, want WIN / multipart...", body, ct)
+	}
+	want := []string{"skip", "win"}
+	if len(log) != len(want) || log[0] != want[0] || log[1] != want[1] {
+		t.Errorf("transform call order = %v, want %v (never should not run)", log, want)
+	}
+}
+
+func TestChain_Apply_NoneHandled(t *testing.T) {
+	c := NewChain([]RequestTransform{&fakeTransform{name: "a"}, &fakeTransform{name: "b"}})
+	_, _, handled, err := c.Apply([]byte(`{}`), nil)
+	if handled || err != nil {
+		t.Errorf("Apply = handled %v err %v, want false/nil", handled, err)
+	}
+}
+
+func TestChain_Apply_ErrorShortCircuits(t *testing.T) {
+	wantErr := errors.New("transform failed")
+	c := NewChain([]RequestTransform{&fakeTransform{name: "a", transformer: wantErr}})
+	_, _, handled, err := c.Apply([]byte(`{}`), nil)
+	if handled {
+		t.Error("handled should be false on error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+}
+
+// registerFake registers a factory under typ that yields a handled transform,
+// and cleans it up after the test.
+func registerFake(t *testing.T, typ string) {
+	t.Helper()
+	plugins.Register(typ, func(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+		return &fakeTransform{name: name, handled: true, body: []byte("x")}, nil
+	})
+	t.Cleanup(func() { delete(plugins.Registry, typ) })
+}
+
+func TestLoadConfigAndBuildChain(t *testing.T) {
+	const typ = "transform_test.multipart"
+	registerFake(t, typ)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transforms.json")
+	cfg := `[{"name":"whisper","type":"transform_test.multipart","parameters":{"provider":"whisper"}}]`
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	specs, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(specs) != 1 || specs[0].Name != "whisper" || specs[0].Type != typ {
+		t.Fatalf("unexpected specs: %+v", specs)
+	}
+
+	handle := plugins.NewHandle(context.Background())
+	chain, err := BuildChain(specs, handle)
+	if err != nil {
+		t.Fatalf("BuildChain: %v", err)
+	}
+	if chain.Len() != 1 {
+		t.Errorf("chain Len = %d, want 1", chain.Len())
+	}
+	if handle.Plugin("whisper") == nil {
+		t.Error("plugin 'whisper' not registered on handle")
+	}
+}
+
+func TestBuildChain_Errors(t *testing.T) {
+	const typ = "transform_test.ok"
+	registerFake(t, typ)
+
+	tests := []struct {
+		name  string
+		specs []PluginSpec
+	}{
+		{"empty name", []PluginSpec{{Type: typ}}},
+		{"missing type", []PluginSpec{{Name: "a"}}},
+		{"unregistered type", []PluginSpec{{Name: "a", Type: "nope.nope"}}},
+		{"duplicate name", []PluginSpec{{Name: "a", Type: typ}, {Name: "a", Type: typ}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := BuildChain(tc.specs, plugins.NewHandle(context.Background())); err == nil {
+				t.Errorf("BuildChain(%s) = nil error, want error", tc.name)
+			}
+		})
+	}
+}
+
+// nonTransformPlugin implements plugins.Plugin but not RequestTransform.
+type nonTransformPlugin struct{}
+
+func (nonTransformPlugin) TypedName() plugins.TypedName {
+	return plugins.TypedName{Type: "nontransform", Name: "n"}
+}
+
+func TestBuildChain_NotARequestTransform(t *testing.T) {
+	const typ = "transform_test.nontransform"
+	plugins.Register(typ, func(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+		return nonTransformPlugin{}, nil
+	})
+	t.Cleanup(func() { delete(plugins.Registry, typ) })
+
+	_, err := BuildChain([]PluginSpec{{Name: "n", Type: typ}}, plugins.NewHandle(context.Background()))
+	if err == nil {
+		t.Fatal("expected error for plugin that does not implement RequestTransform")
+	}
+}
+
+func TestBuildChain_Empty(t *testing.T) {
+	chain, err := BuildChain(nil, plugins.NewHandle(context.Background()))
+	if err != nil {
+		t.Fatalf("BuildChain(nil): %v", err)
+	}
+	if chain.Len() != 0 {
+		t.Errorf("empty chain Len = %d, want 0", chain.Len())
+	}
+}

--- a/pkg/asyncworker/transform/transform_test.go
+++ b/pkg/asyncworker/transform/transform_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
 )
 
+var _ RequestTransform = (*fakeTransform)(nil)
+
 // fakeTransform is a configurable RequestTransform for tests.
 type fakeTransform struct {
 	name        string
@@ -124,10 +126,12 @@ func TestChain_Apply_ErrorShortCircuits(t *testing.T) {
 // and cleans it up after the test.
 func registerFake(t *testing.T, typ string) {
 	t.Helper()
-	plugins.Register(typ, func(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+	if err := plugins.Register(typ, func(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
 		return &fakeTransform{name: name, handled: true, body: []byte("x")}, nil
-	})
-	t.Cleanup(func() { delete(plugins.Registry, typ) })
+	}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	t.Cleanup(func() { plugins.Unregister(typ) })
 }
 
 func TestLoadConfigAndBuildChain(t *testing.T) {
@@ -184,6 +188,8 @@ func TestBuildChain_Errors(t *testing.T) {
 	}
 }
 
+var _ plugins.Plugin = nonTransformPlugin{}
+
 // nonTransformPlugin implements plugins.Plugin but not RequestTransform.
 type nonTransformPlugin struct{}
 
@@ -193,10 +199,12 @@ func (nonTransformPlugin) TypedName() plugins.TypedName {
 
 func TestBuildChain_NotARequestTransform(t *testing.T) {
 	const typ = "transform_test.nontransform"
-	plugins.Register(typ, func(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+	if err := plugins.Register(typ, func(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
 		return nonTransformPlugin{}, nil
-	})
-	t.Cleanup(func() { delete(plugins.Registry, typ) })
+	}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	t.Cleanup(func() { plugins.Unregister(typ) })
 
 	_, err := BuildChain([]PluginSpec{{Name: "n", Type: typ}}, plugins.NewHandle(context.Background()))
 	if err == nil {

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -12,6 +12,7 @@ import (
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	uotel "github.com/llm-d-incubation/llm-d-async/internal/otel"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -28,7 +29,7 @@ const (
 )
 
 func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Characteristics, client asyncapi.InferenceClient, requestChannel chan pipeline.EmbelishedRequestMessage,
-	retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, requestTimeout time.Duration) {
+	retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, requestTimeout time.Duration, transforms *transform.Chain) {
 
 	logger := log.FromContext(requestCtx)
 	for {
@@ -78,7 +79,7 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 					metrics.RecordAsyncReq(queueID, queueName, msg.WorkerPoolID)
 				}
 
-				payloadBytes := validateAndMarshal(requestCtx, resultChannel, msg)
+				payloadBytes := validateAndMarshal(requestCtx, resultChannel, msg, transforms)
 				if payloadBytes == nil {
 					return
 				}
@@ -113,8 +114,29 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 					reqCtx, cancel := context.WithDeadline(reqCtx, reqDeadline)
 					defer cancel()
 
+					// Apply the request body-transform chain. If a transform handles
+					// the message we send its body and Content-Type; otherwise the
+					// default JSON payload is sent unchanged. A transform error is
+					// fatal/non-retryable.
+					sendPayload := payloadBytes
+					sendHeaders := msg.HttpHeaders
+					if body, contentType, handled, terr := transforms.Apply(payloadBytes, msg.PublicRequest.ReqMetadata()); terr != nil {
+						span.RecordError(terr)
+						span.SetStatus(codes.Error, "request transform failed")
+						span.SetAttributes(attribute.String(uotel.AttrErrorCategory, string(asyncapi.ErrCategoryInvalidReq)))
+						metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
+						select {
+						case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to transform request body: %s", terr.Error())):
+						case <-requestCtx.Done():
+						}
+						return
+					} else if handled {
+						sendPayload = body
+						sendHeaders = headersWithContentType(msg.HttpHeaders, contentType)
+					}
+
 					logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
-					responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, msg.HttpHeaders, payloadBytes)
+					responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, sendHeaders, sendPayload)
 
 					if err == nil {
 						metrics.RecordSuccessfulReq(queueID, queueName, msg.WorkerPoolID)
@@ -173,7 +195,7 @@ func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Cha
 }
 
 // parsing and validating payload. On failure puts an error msg on the result-channel and returns nil
-func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultMessage, msg pipeline.EmbelishedRequestMessage) []byte {
+func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultMessage, msg pipeline.EmbelishedRequestMessage, transforms *transform.Chain) []byte {
 	if msg.PublicRequest == nil {
 		return nil
 	}
@@ -208,6 +230,19 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 		}
 		return nil
 	}
+
+	// Pre-dispatch transform validation (e.g. signed object URL expiry). A
+	// validation failure is fatal/non-retryable, so we surface an error result
+	// rather than re-enqueue. A nil chain validates successfully.
+	if err := transforms.Validate(payloadBytes, r.ReqMetadata(), deadline); err != nil {
+		metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
+		select {
+		case resultChannel <- CreateErrorResultMessage(r, msg.InternalRouting, fmt.Sprintf("Failed to validate request for transform: %s", err.Error())):
+		case <-ctx.Done():
+		}
+		return nil
+	}
+
 	return payloadBytes
 }
 
@@ -274,6 +309,18 @@ func CreateErrorResultMessage(req asyncapi.Request, routing asyncapi.InternalRou
 
 func CreateDeadlineExceededResultMessage(req asyncapi.Request, routing asyncapi.InternalRouting) asyncapi.ResultMessage {
 	return CreateErrorResultMessage(req, routing, "deadline exceeded")
+}
+
+// headersWithContentType returns a copy of headers with Content-Type set to
+// contentType. The original map is not mutated, so the per-message headers stay
+// intact across retries.
+func headersWithContentType(headers map[string]string, contentType string) map[string]string {
+	out := make(map[string]string, len(headers)+1)
+	for k, v := range headers {
+		out[k] = v
+	}
+	out["Content-Type"] = contentType
+	return out
 }
 
 func inferenceErrorCategory(err error) string {

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -134,7 +134,7 @@ func TestSheddedRequest(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -170,7 +170,7 @@ func TestSuccessfulRequest(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -204,7 +204,7 @@ func TestFatalError_NoRetry(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
@@ -250,7 +250,7 @@ func TestRateLimitRequest(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -286,7 +286,7 @@ func TestRequestTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Use a very short request timeout to trigger the deadline.
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, 100*time.Millisecond, nil)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -519,7 +519,7 @@ func TestRateLimitRequest_WithRetryAfterHeader(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -559,7 +559,7 @@ func TestValidateAndMarshal_cancelledCtxDoesNotBlock(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		validateAndMarshal(ctx, resultChannel, emb)
+		validateAndMarshal(ctx, resultChannel, emb, nil)
 		close(done)
 	}()
 
@@ -617,7 +617,7 @@ func TestWorker_cancelledCtxExitsPromptly(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 		close(done)
 	}()
 
@@ -657,7 +657,7 @@ func TestClientError_NoRetry(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	ctx := context.Background()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 	deadline := time.Now().Add(time.Second * 100).Unix()
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
@@ -698,7 +698,7 @@ func TestWorker_RetriesOnShutdown(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID:       msgId,
@@ -768,7 +768,7 @@ func TestWorker_DrainsBufferedMessagesOnShutdown(t *testing.T) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+					Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 				}()
 			}
 
@@ -877,7 +877,7 @@ func TestMetrics_QueueDepthAndInflightBalance(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
 
-			go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+			go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 			// Simulate the merge policy's increment for one buffered request.
 			metrics.IncQueueDepth(queueID, queueName, "test-pool")
@@ -955,7 +955,7 @@ func TestMetrics_QueueDepthDecrementsOnDrain(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 		close(done)
 	}()
 
@@ -998,7 +998,7 @@ func TestMetrics_SuccessfulRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -1048,7 +1048,7 @@ func TestMetrics_RateLimited(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -1088,7 +1088,7 @@ func TestMetrics_FatalError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -1128,7 +1128,7 @@ func TestMetrics_DeadlineExceeded(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmbR(asyncapi.InternalRouting{
 		QueueID:          queueID,
@@ -1165,7 +1165,7 @@ func TestMetrics_LabelsIsolated(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	deadline := time.Now().Add(100 * time.Second).Unix()
 
@@ -1249,7 +1249,7 @@ func TestWorker_SpanOnSuccess(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-success", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1290,7 +1290,7 @@ func TestWorker_SpanOnFatalError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-fatal", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1331,7 +1331,7 @@ func TestWorker_SpanOnRetryableError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-429", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1369,7 +1369,7 @@ func TestWorker_SpanOnServerError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-500", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1412,7 +1412,7 @@ func TestWorker_TraceContextExtraction(t *testing.T) {
 	otel.GetTextMapPropagator().Inject(parentCtx, propagation.MapCarrier(metadata))
 	parentSpan.End()
 
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-ctx", Created: time.Now().Unix(), Deadline: time.Now().Add(100 * time.Second).Unix(),
@@ -1451,7 +1451,7 @@ func TestWorker_SpanOnShutdownReenqueue(t *testing.T) {
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmb(asyncapi.RequestMessage{
 		ID: "span-shutdown", Created: time.Now().Unix(), Deadline: time.Now().Add(5 * time.Minute).Unix(),
@@ -1507,7 +1507,7 @@ func TestWorker_SpanIncludesQueueName(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 
 	requestChannel <- newEmbR(
 		asyncapi.InternalRouting{QueueID: "my-test-qid", RequestQueueName: "my-test-queue"},
@@ -1559,7 +1559,7 @@ func TestWorker_InFlightCompletesOnConsumeCancel(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 		close(done)
 	}()
 
@@ -1621,7 +1621,7 @@ func TestWorker_DrainTimeoutCancelsInFlight(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 		close(done)
 	}()
 
@@ -1689,7 +1689,7 @@ func TestWorker_DrainWithCancelledRequestCtx(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout)
+		Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
 		close(done)
 	}()
 

--- a/pkg/asyncworker/worker_transform_test.go
+++ b/pkg/asyncworker/worker_transform_test.go
@@ -1,0 +1,135 @@
+package asyncworker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+)
+
+// testTransform is a minimal RequestTransform for worker integration tests.
+type testTransform struct {
+	validateErr error
+	handled     bool
+	body        []byte
+	contentType string
+}
+
+func (t *testTransform) TypedName() plugins.TypedName {
+	return plugins.TypedName{Type: "test", Name: "test"}
+}
+
+func (t *testTransform) Validate(_ []byte, _ map[string]string, _ int64) error {
+	return t.validateErr
+}
+
+func (t *testTransform) Transform(_ []byte, _ map[string]string) ([]byte, string, bool, error) {
+	if !t.handled {
+		return nil, "", false, nil
+	}
+	return t.body, t.contentType, true, nil
+}
+
+// TestWorker_TransformRewritesOutgoingRequest verifies that when a transform
+// handles a message, the worker sends the transformed body and Content-Type to
+// the inference backend.
+func TestWorker_TransformRewritesOutgoingRequest(t *testing.T) {
+	var gotBody, gotContentType string
+	httpClient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		gotBody = string(b)
+		gotContentType = req.Header.Get("Content-Type")
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("OK")), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpClient)
+
+	chain := transform.NewChain([]transform.RequestTransform{&testTransform{
+		handled:     true,
+		body:        []byte("url=https://storage.example/audio.mp3?signature=test"),
+		contentType: "multipart/form-data; boundary=test",
+	}})
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, chain)
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       "m1",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "whisper", "gcs_uri": "https://storage.example/audio.mp3?signature=test"},
+		Metadata: map[string]string{"provider": "whisper"},
+	}, "http://localhost/v1/audio/transcriptions", map[string]string{})
+
+	select {
+	case res := <-resultChannel:
+		if res.ID != "m1" {
+			t.Errorf("result ID = %q, want m1", res.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	if want := "url=https://storage.example/audio.mp3?signature=test"; gotBody != want {
+		t.Errorf("outgoing body = %q, want %q", gotBody, want)
+	}
+	if want := "multipart/form-data; boundary=test"; gotContentType != want {
+		t.Errorf("outgoing Content-Type = %q, want %q", gotContentType, want)
+	}
+}
+
+// TestWorker_TransformValidateFatal verifies that a transform Validate failure
+// is fatal: an error result is produced and no HTTP request is dispatched.
+func TestWorker_TransformValidateFatal(t *testing.T) {
+	httpCalled := false
+	httpClient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		httpCalled = true
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("OK")), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpClient)
+
+	chain := transform.NewChain([]transform.RequestTransform{&testTransform{
+		validateErr: errors.New("signed URL expires before request deadline"),
+	}})
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, chain)
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       "m2",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "whisper"},
+		Metadata: map[string]string{"provider": "whisper"},
+	}, "http://localhost/v1/audio/transcriptions", map[string]string{})
+
+	select {
+	case res := <-resultChannel:
+		if !strings.Contains(res.Payload, "validate") {
+			t.Errorf("result payload = %q, want it to mention validate failure", res.Payload)
+		}
+	case <-retryChannel:
+		t.Fatal("validate failure must not be retried")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	if httpCalled {
+		t.Error("no HTTP request should be dispatched when validation fails")
+	}
+}

--- a/pkg/asyncworker/worker_transform_test.go
+++ b/pkg/asyncworker/worker_transform_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
 )
 
+var _ transform.RequestTransform = (*testTransform)(nil)
+
 // testTransform is a minimal RequestTransform for worker integration tests.
 type testTransform struct {
 	validateErr error

--- a/pkg/plugins/handle.go
+++ b/pkg/plugins/handle.go
@@ -1,0 +1,94 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+)
+
+// Handle provides plugins a set of standard data and tools to work with. It is a
+// trimmed, Kubernetes-free analog of EPP's Handle: it carries a context and the
+// set of instantiated plugins, but omits EPP's pod-listing concerns.
+type Handle interface {
+	// Context returns a context the plugins can use, if they need one.
+	Context() context.Context
+
+	HandlePlugins
+}
+
+// HandlePlugins defines a set of APIs to work with instantiated plugins.
+type HandlePlugins interface {
+	// Plugin returns the named plugin instance, or nil if none is registered.
+	Plugin(name string) Plugin
+
+	// AddPlugin adds a plugin to the set of known plugin instances.
+	AddPlugin(name string, plugin Plugin)
+
+	// GetAllPlugins returns all of the known plugins.
+	GetAllPlugins() []Plugin
+
+	// GetAllPluginsWithNames returns all of the known plugins keyed by name.
+	GetAllPluginsWithNames() map[string]Plugin
+}
+
+// handle is the default Handle implementation.
+type handle struct {
+	ctx context.Context
+	HandlePlugins
+}
+
+// Context returns a context the plugins can use, if they need one.
+func (h *handle) Context() context.Context {
+	return h.ctx
+}
+
+// handlePlugins implements the set of APIs to work with instantiated plugins.
+type handlePlugins struct {
+	plugins map[string]Plugin
+}
+
+// Plugin returns the named plugin instance.
+func (h *handlePlugins) Plugin(name string) Plugin {
+	return h.plugins[name]
+}
+
+// AddPlugin adds a plugin to the set of known plugin instances.
+func (h *handlePlugins) AddPlugin(name string, plugin Plugin) {
+	h.plugins[name] = plugin
+}
+
+// GetAllPlugins returns all of the known plugins.
+func (h *handlePlugins) GetAllPlugins() []Plugin {
+	result := make([]Plugin, 0, len(h.plugins))
+	for _, plugin := range h.plugins {
+		result = append(result, plugin)
+	}
+	return result
+}
+
+// GetAllPluginsWithNames returns all of the known plugins keyed by name.
+func (h *handlePlugins) GetAllPluginsWithNames() map[string]Plugin {
+	return h.plugins
+}
+
+// NewHandle returns a Handle backed by the given context and an empty plugin set.
+func NewHandle(ctx context.Context) Handle {
+	return &handle{
+		ctx:           ctx,
+		HandlePlugins: &handlePlugins{plugins: map[string]Plugin{}},
+	}
+}
+
+// PluginByType retrieves the named plugin and asserts it implements P.
+func PluginByType[P Plugin](handlePlugins HandlePlugins, name string) (P, error) {
+	var zero P
+
+	rawPlugin := handlePlugins.Plugin(name)
+	if rawPlugin == nil {
+		return zero, fmt.Errorf("there is no plugin with the name '%s' defined", name)
+	}
+	plugin, ok := rawPlugin.(P)
+	if !ok {
+		return zero, fmt.Errorf("the plugin with the name '%s' is not an instance of %T", name, zero)
+	}
+	return plugin, nil
+}

--- a/pkg/plugins/handle.go
+++ b/pkg/plugins/handle.go
@@ -1,9 +1,6 @@
 package plugins
 
-import (
-	"context"
-	"fmt"
-)
+import "context"
 
 // Handle provides plugins a set of standard data and tools to work with. It is a
 // trimmed, Kubernetes-free analog of EPP's Handle: it carries a context and the
@@ -22,13 +19,12 @@ type HandlePlugins interface {
 
 	// AddPlugin adds a plugin to the set of known plugin instances.
 	AddPlugin(name string, plugin Plugin)
-
-	// GetAllPlugins returns all of the known plugins.
-	GetAllPlugins() []Plugin
-
-	// GetAllPluginsWithNames returns all of the known plugins keyed by name.
-	GetAllPluginsWithNames() map[string]Plugin
 }
+
+var (
+	_ Handle        = (*handle)(nil)
+	_ HandlePlugins = (*handlePlugins)(nil)
+)
 
 // handle is the default Handle implementation.
 type handle struct {
@@ -56,39 +52,10 @@ func (h *handlePlugins) AddPlugin(name string, plugin Plugin) {
 	h.plugins[name] = plugin
 }
 
-// GetAllPlugins returns all of the known plugins.
-func (h *handlePlugins) GetAllPlugins() []Plugin {
-	result := make([]Plugin, 0, len(h.plugins))
-	for _, plugin := range h.plugins {
-		result = append(result, plugin)
-	}
-	return result
-}
-
-// GetAllPluginsWithNames returns all of the known plugins keyed by name.
-func (h *handlePlugins) GetAllPluginsWithNames() map[string]Plugin {
-	return h.plugins
-}
-
 // NewHandle returns a Handle backed by the given context and an empty plugin set.
 func NewHandle(ctx context.Context) Handle {
 	return &handle{
 		ctx:           ctx,
 		HandlePlugins: &handlePlugins{plugins: map[string]Plugin{}},
 	}
-}
-
-// PluginByType retrieves the named plugin and asserts it implements P.
-func PluginByType[P Plugin](handlePlugins HandlePlugins, name string) (P, error) {
-	var zero P
-
-	rawPlugin := handlePlugins.Plugin(name)
-	if rawPlugin == nil {
-		return zero, fmt.Errorf("there is no plugin with the name '%s' defined", name)
-	}
-	plugin, ok := rawPlugin.(P)
-	if !ok {
-		return zero, fmt.Errorf("the plugin with the name '%s' is not an instance of %T", name, zero)
-	}
-	return plugin, nil
 }

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -1,0 +1,9 @@
+package plugins
+
+// Plugin defines the base interface every plugin must satisfy. Typed capability
+// interfaces (e.g. a request body-transform) embed this interface and add their
+// own methods, mirroring the EPP plugin model.
+type Plugin interface {
+	// TypedName returns the type and name tuple of this plugin instance.
+	TypedName() TypedName
+}

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -1,0 +1,85 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type stubPlugin struct {
+	name string
+}
+
+func (s *stubPlugin) TypedName() TypedName { return TypedName{Type: "stub", Name: s.name} }
+
+func TestTypedName_String(t *testing.T) {
+	tn := TypedName{Type: "multipart", Name: "whisper"}
+	if got, want := tn.String(), "whisper/multipart"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	// Use a unique type so we don't collide with other tests/packages.
+	const typ = "plugins_test.stub"
+	called := false
+	Register(typ, func(name string, _ json.RawMessage, _ Handle) (Plugin, error) {
+		called = true
+		return &stubPlugin{name: name}, nil
+	})
+	t.Cleanup(func() { delete(Registry, typ) })
+
+	factory, ok := Registry[typ]
+	if !ok {
+		t.Fatalf("type %q not found in Registry after Register", typ)
+	}
+	p, err := factory("inst", nil, NewHandle(context.Background()))
+	if err != nil {
+		t.Fatalf("factory returned error: %v", err)
+	}
+	if !called {
+		t.Error("factory was not invoked")
+	}
+	if p.TypedName().Name != "inst" {
+		t.Errorf("plugin name = %q, want %q", p.TypedName().Name, "inst")
+	}
+}
+
+func TestHandle_AddAndGet(t *testing.T) {
+	h := NewHandle(context.Background())
+	if h.Context() == nil {
+		t.Error("Context() returned nil")
+	}
+	if h.Plugin("missing") != nil {
+		t.Error("Plugin(missing) should be nil")
+	}
+
+	p := &stubPlugin{name: "a"}
+	h.AddPlugin("a", p)
+	if h.Plugin("a") != p {
+		t.Error("Plugin(a) did not return the added plugin")
+	}
+	if len(h.GetAllPlugins()) != 1 {
+		t.Errorf("GetAllPlugins len = %d, want 1", len(h.GetAllPlugins()))
+	}
+	if _, ok := h.GetAllPluginsWithNames()["a"]; !ok {
+		t.Error("GetAllPluginsWithNames missing key 'a'")
+	}
+}
+
+func TestPluginByType(t *testing.T) {
+	h := NewHandle(context.Background())
+	h.AddPlugin("a", &stubPlugin{name: "a"})
+
+	got, err := PluginByType[*stubPlugin](h, "a")
+	if err != nil {
+		t.Fatalf("PluginByType error: %v", err)
+	}
+	if got.name != "a" {
+		t.Errorf("name = %q, want %q", got.name, "a")
+	}
+
+	if _, err := PluginByType[*stubPlugin](h, "missing"); err == nil {
+		t.Error("expected error for missing plugin")
+	}
+}

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Plugin = (*stubPlugin)(nil)
+
 type stubPlugin struct {
 	name string
 }
@@ -23,15 +25,17 @@ func TestRegistry_RegisterAndLookup(t *testing.T) {
 	// Use a unique type so we don't collide with other tests/packages.
 	const typ = "plugins_test.stub"
 	called := false
-	Register(typ, func(name string, _ json.RawMessage, _ Handle) (Plugin, error) {
+	if err := Register(typ, func(name string, _ json.RawMessage, _ Handle) (Plugin, error) {
 		called = true
 		return &stubPlugin{name: name}, nil
-	})
-	t.Cleanup(func() { delete(Registry, typ) })
+	}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	t.Cleanup(func() { delete(registry, typ) })
 
-	factory, ok := Registry[typ]
+	factory, ok := Lookup(typ)
 	if !ok {
-		t.Fatalf("type %q not found in Registry after Register", typ)
+		t.Fatalf("type %q not found after Register", typ)
 	}
 	p, err := factory("inst", nil, NewHandle(context.Background()))
 	if err != nil {
@@ -42,6 +46,21 @@ func TestRegistry_RegisterAndLookup(t *testing.T) {
 	}
 	if p.TypedName().Name != "inst" {
 		t.Errorf("plugin name = %q, want %q", p.TypedName().Name, "inst")
+	}
+}
+
+func TestRegistry_DuplicateRegistrationFails(t *testing.T) {
+	const typ = "plugins_test.dup"
+	factory := func(name string, _ json.RawMessage, _ Handle) (Plugin, error) {
+		return &stubPlugin{name: name}, nil
+	}
+	if err := Register(typ, factory); err != nil {
+		t.Fatalf("first Register returned error: %v", err)
+	}
+	t.Cleanup(func() { delete(registry, typ) })
+
+	if err := Register(typ, factory); err == nil {
+		t.Error("expected error registering duplicate type, got nil")
 	}
 }
 
@@ -58,28 +77,5 @@ func TestHandle_AddAndGet(t *testing.T) {
 	h.AddPlugin("a", p)
 	if h.Plugin("a") != p {
 		t.Error("Plugin(a) did not return the added plugin")
-	}
-	if len(h.GetAllPlugins()) != 1 {
-		t.Errorf("GetAllPlugins len = %d, want 1", len(h.GetAllPlugins()))
-	}
-	if _, ok := h.GetAllPluginsWithNames()["a"]; !ok {
-		t.Error("GetAllPluginsWithNames missing key 'a'")
-	}
-}
-
-func TestPluginByType(t *testing.T) {
-	h := NewHandle(context.Background())
-	h.AddPlugin("a", &stubPlugin{name: "a"})
-
-	got, err := PluginByType[*stubPlugin](h, "a")
-	if err != nil {
-		t.Fatalf("PluginByType error: %v", err)
-	}
-	if got.name != "a" {
-		t.Errorf("name = %q, want %q", got.name, "a")
-	}
-
-	if _, err := PluginByType[*stubPlugin](h, "missing"); err == nil {
-		t.Error("expected error for missing plugin")
 	}
 }

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -1,0 +1,18 @@
+package plugins
+
+import "encoding/json"
+
+// FactoryFunc instantiates a plugin from its instance name, raw JSON parameters
+// (as found in configuration), and a Handle to host-provided context. The
+// signature mirrors EPP so plugin authoring is familiar across the projects.
+type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
+
+// Registry maps a plugin type to its FactoryFunc.
+var Registry = map[string]FactoryFunc{}
+
+// Register registers a plugin factory under the given type. It is intended to be
+// called from plugin package init() functions. Registering the same type twice
+// overwrites the previous registration.
+func Register(pluginType string, factory FactoryFunc) {
+	Registry[pluginType] = factory
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -1,18 +1,49 @@
 package plugins
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // FactoryFunc instantiates a plugin from its instance name, raw JSON parameters
 // (as found in configuration), and a Handle to host-provided context. The
 // signature mirrors EPP so plugin authoring is familiar across the projects.
 type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
 
-// Registry maps a plugin type to its FactoryFunc.
-var Registry = map[string]FactoryFunc{}
+// registry maps a plugin type to its FactoryFunc. It is unexported so the only
+// ways to mutate it are Register/MustRegister and the only way to read it is
+// Lookup, keeping the package free of exported mutable global state.
+var registry = map[string]FactoryFunc{}
 
-// Register registers a plugin factory under the given type. It is intended to be
-// called from plugin package init() functions. Registering the same type twice
-// overwrites the previous registration.
-func Register(pluginType string, factory FactoryFunc) {
-	Registry[pluginType] = factory
+// Register registers a plugin factory under the given type. It returns an error
+// if the type is already registered, so duplicate registrations fail loudly
+// rather than silently overwriting.
+func Register(pluginType string, factory FactoryFunc) error {
+	if _, exists := registry[pluginType]; exists {
+		return fmt.Errorf("plugin type %q is already registered", pluginType)
+	}
+	registry[pluginType] = factory
+	return nil
+}
+
+// MustRegister is like Register but panics on error. It is intended for use in
+// plugin package init() functions, where a duplicate registration is a
+// programming error that should fail at startup.
+func MustRegister(pluginType string, factory FactoryFunc) {
+	if err := Register(pluginType, factory); err != nil {
+		panic(err)
+	}
+}
+
+// Lookup returns the factory registered under the given type, if any.
+func Lookup(pluginType string) (FactoryFunc, bool) {
+	factory, ok := registry[pluginType]
+	return factory, ok
+}
+
+// Unregister removes the factory registered under the given type, if any. It is
+// primarily intended to let tests clean up registrations they make so the
+// registry stays isolated between test runs.
+func Unregister(pluginType string) {
+	delete(registry, pluginType)
 }

--- a/pkg/plugins/typedname.go
+++ b/pkg/plugins/typedname.go
@@ -1,0 +1,26 @@
+// Package plugins provides a small, transport-agnostic plugin framework
+// modeled on the Endpoint Picker (EPP) plugin model
+// (sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins). It defines the
+// base Plugin identity, a configuration-driven factory Registry, and a Handle
+// that gives plugins access to shared, host-provided context.
+//
+// This package is intentionally free of Kubernetes/controller-runtime
+// dependencies: the EPP-specific RunnablePlugin and pod-listing concerns are not
+// replicated, since they have no analog for in-process request plugins.
+package plugins
+
+const separator = "/"
+
+// TypedName is a utility struct providing a type and a name to plugins.
+type TypedName struct {
+	// Type is the registered plugin type (the key under which a FactoryFunc is
+	// registered in the Registry).
+	Type string
+	// Name is the instance name of a plugin, unique within a configuration.
+	Name string
+}
+
+// String returns the type and name rendered as "<name>/<type>".
+func (tn TypedName) String() string {
+	return tn.Name + separator + tn.Type
+}

--- a/test/integration/worker_dispatch_test.go
+++ b/test/integration/worker_dispatch_test.go
@@ -52,7 +52,7 @@ func TestWorkerDispatch_DrainsBufferedOnShutdown(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		asyncworker.Worker(consumeCtx, requestCtx, pipeline.Characteristics{HasExternalBackoff: false},
-			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+			client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 	}()
 
 	ids := []string{"drain-int-1", "drain-int-2", "drain-int-3"}
@@ -124,7 +124,7 @@ func TestWorkerDispatch_MockIGW(t *testing.T) {
 	defer cancel()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	ir := asyncapi.NewInternalRequest(
 		asyncapi.InternalRouting{RequestQueueName: "test-queue"},
@@ -193,7 +193,7 @@ func TestWorkerDispatch_EndpointOverride(t *testing.T) {
 	defer cancel()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	ir := asyncapi.NewInternalRequest(
 		asyncapi.InternalRouting{},
@@ -240,7 +240,7 @@ func TestWorkerDispatch_ServerErrorTriggersRetry(t *testing.T) {
 	defer cancel()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	ir := asyncapi.NewInternalRequest(
 		asyncapi.InternalRouting{},
@@ -289,7 +289,7 @@ func TestWorkerDispatch_ResultCallback(t *testing.T) {
 	defer cancel()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	routing := asyncapi.InternalRouting{
 		RequestQueueName:       "my-queue",
@@ -349,7 +349,7 @@ func TestWorkerDispatch_RequeuesOnShutdown(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-			client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+			client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 	}()
 
 	ir := asyncapi.NewInternalRequest(
@@ -429,11 +429,11 @@ func TestWorkerDispatch_PoolIsolation(t *testing.T) {
 
 	// Spawn 1 worker for pool-blocked
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-		clientBlocked, reqChanBlocked, retryChanBlocked, resultChanBlocked, 5*time.Minute)
+		clientBlocked, reqChanBlocked, retryChanBlocked, resultChanBlocked, 5*time.Minute, nil)
 
 	// Spawn 1 worker for pool-active
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
-		clientActive, reqChanActive, retryChanActive, resultChanActive, 5*time.Minute)
+		clientActive, reqChanActive, retryChanActive, resultChanActive, 5*time.Minute, nil)
 
 	// 3. Send message 1 (to pool-blocked)
 	irBlocked := asyncapi.NewInternalRequest(

--- a/test/integration/worker_otel_test.go
+++ b/test/integration/worker_otel_test.go
@@ -68,7 +68,7 @@ func TestWorkerDispatch_TraceparentInjected(t *testing.T) {
 	defer cancel()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	ir := asyncapi.NewInternalRequest(
 		asyncapi.InternalRouting{},
@@ -126,7 +126,7 @@ func TestWorkerDispatch_SpanHierarchy(t *testing.T) {
 	defer cancel()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	ir := asyncapi.NewInternalRequest(
 		asyncapi.InternalRouting{},
@@ -210,7 +210,7 @@ func TestWorkerDispatch_MetadataTraceContextPropagation(t *testing.T) {
 	producerSpan.End()
 
 	go asyncworker.Worker(ctx, ctx, pipeline.Characteristics{},
-		client, requestChannel, retryChannel, resultChannel, 5*time.Minute)
+		client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil)
 
 	ir := asyncapi.NewInternalRequest(
 		asyncapi.InternalRouting{},


### PR DESCRIPTION
## What

Implements the request body-transform extension point from #255: an EPP-style plugin framework that lets providers rewrite the outgoing HTTP body and `Content-Type` at dispatch time based on per-message metadata, while leaving the default OpenAI-style JSON path **byte-for-byte unchanged** when no plugin is configured.

This is the **framework only**. The first concrete plugin (gcs_uri multipart, #256) builds on it separately.

## Changes

- **`pkg/plugins/`** — k8s-free base framework mirroring EPP's `pkg/epp/plugins`:
  - `Plugin` interface (`TypedName()`), `TypedName{Type,Name}`.
  - `FactoryFunc(name string, parameters json.RawMessage, handle Handle)`, `Registry`, `Register`.
  - Minimal `Handle` (`Context()` + plugin lookup) and generic `PluginByType[P]`.
  - Deliberately omits EPP's `RunnablePlugin` (controller-runtime) and `PodList`/`NamespacedName` (apimachinery) — the only parts that pull in Kubernetes deps and have no analog for in-process request plugins. New packages import stdlib only.
- **`pkg/asyncworker/transform/`** — the extension point:
  - `RequestTransform` typed interface (embeds `plugins.Plugin`) with `Validate(payload, metadata, reqDeadline)` and `Transform(payload, metadata) -> (body, contentType, handled, err)`.
  - `Chain`: `Validate` runs all transforms (first error wins); `Apply` is **first-handled-wins, short-circuit**. A nil `*Chain` is a no-op.
  - `loader.go`: `PluginSpec{Name,Type,Parameters}`, `LoadConfig` (JSON file, mirrors `pipeline.LoadWorkerPools`), `BuildChain` (registry lookup + unique-name/type/interface validation).
- **`pkg/asyncworker/worker.go`** — integration:
  - `Worker(...)` takes a trailing `*transform.Chain` (nil preserves current behavior).
  - `Validate` runs in `validateAndMarshal` before dispatch — a failure is fatal/non-retryable.
  - `Apply` runs immediately before `SendRequest`; when handled, the body is swapped and `Content-Type` set via a **copied** header map (retry-safe). The public `api.InferenceClient` interface is unchanged.
- **`cmd/main.go`** — new `--transform-config-file` flag; empty = nil chain = unchanged behavior.

## Design decisions

- Package layout: `pkg/plugins` (base) + `pkg/asyncworker/transform` (typed interface + loader), mirroring EPP's base-vs-consumer split.
- `Handle` implemented now for FactoryFunc signature parity with EPP.
- Multiple applicable transforms: first-handled-wins, short-circuit (a single final HTTP body can't be produced by two transforms).

## Not touched

No Gate / flowcontrol infrastructure was modified.

## Testing

- `pkg/plugins`: `TypedName`, registry register/lookup, handle add/get, `PluginByType`.
- `pkg/asyncworker/transform`: chain `Validate`/`Apply` semantics (incl. short-circuit), loader + all `BuildChain` error paths.
- `pkg/asyncworker` (worker-level, `-race`): a transform rewrites the real outgoing HTTP body + `Content-Type`; a `Validate` failure yields a fatal error result with **no dispatch and no retry**.
- `go build`, `go vet`, and `golangci-lint` (0 issues) all clean; full non-e2e suite passes.

Part of #255.
