### PR TITLE
feat: add gcs_uri multipart RequestTransform plugin (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,18 @@ Transforms are configured with `--transform-config-file`, pointing at a JSON obj
 
 Each entry has a unique `name`, a registered plugin `type`, and opaque `parameters`. Unknown top-level fields are rejected. When the flag is empty, no transforms are loaded and behavior is unchanged.
 
+With the Helm chart, set `ap.transformConfig` to this same object; the chart renders it to a config file and wires `--transform-config-file` automatically:
+
+```yaml
+ap:
+  transformConfig:
+    requestTransforms:
+      - name: "whisper-multipart"
+        type: "gcs_uri_multipart"
+        parameters:
+          providers: ["whisper"]
+```
+
 ### `gcs_uri_multipart` plugin
 
 Rewrites a JSON body into `multipart/form-data` for endpoints that take a signed object URL. Because producers can't put raw media bytes on the broker, the queued `payload` carries a signed URL (e.g. a GCS V4 signed URL) in a `gcs_uri` field.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The architecture adheres to the following core principles:
     - [Per-Queue Dispatch Gates](#per-queue-dispatch-gates)
   - [Request Messages and Consumption](#request-messages-and-consumption)
     - [Request Merge Policy](#request-merge-policy)
+  - [Request Body Transforms](#request-body-transforms)
+    - [`gcs_uri_multipart` plugin](#gcs_uri_multipart-plugin)
   - [Retries](#retries)
   - [Observability](#observability)
     - [OpenTelemetry Tracing](#opentelemetry-tracing)
@@ -346,6 +348,34 @@ Instead of performing a single global merge, the policy groups input channels by
 This per-pool topology provides complete backpressure and queue-level isolation: a slow or saturated pool will block only its own merged channel, leaving other pools completely unaffected and free to process requests.
 
 Currently the only policy supported is `Random Robin Policy` which randomly picks messages from all queues configured for a given pool.
+
+## Request Body Transforms
+
+By default the worker dispatches the OpenAI-style JSON marshalled from a request's `payload`. Some providers need a different body shape at dispatch time — for example multi-modal endpoints (Whisper transcription, OCR) that expect `multipart/form-data` with a `url` field rather than JSON. Request body-transform plugins handle this without special-casing the worker: they rewrite the outgoing body and `Content-Type` based on per-message `metadata`, and the default JSON path is preserved byte-for-byte when no plugin applies.
+
+Transforms are configured with `--transform-config-file`, pointing at a JSON object that groups plugins by direction:
+
+```json
+{
+  "requestTransforms": [
+    {
+      "name": "whisper-multipart",
+      "type": "gcs_uri_multipart",
+      "parameters": { "providers": ["whisper"] }
+    }
+  ]
+}
+```
+
+Each entry has a unique `name`, a registered plugin `type`, and opaque `parameters`. Unknown top-level fields are rejected. When the flag is empty, no transforms are loaded and behavior is unchanged.
+
+### `gcs_uri_multipart` plugin
+
+Rewrites a JSON body into `multipart/form-data` for endpoints that take a signed object URL. Because producers can't put raw media bytes on the broker, the queued `payload` carries a signed URL (e.g. a GCS V4 signed URL) in a `gcs_uri` field.
+
+- **Activation:** the message's `metadata.provider` must match one of the configured `providers`, and the `payload` must contain a non-empty `gcs_uri`. Otherwise the default JSON path is used unchanged.
+- **Transform:** writes the `gcs_uri` value as a `url` form field (a plain field, not a file upload), passes the remaining payload fields through as form fields, and drops `gcs_uri`. A non-empty `file_base64` is rejected as a fatal, non-retryable error (inline media is not supported on this path).
+- **Preflight:** parses the signed URL's expiry (V4 `X-Goog-Date` + `X-Goog-Expires`, or V2 `Expires`); if it expires at or before the message deadline, the request fails fatally before dispatch so the broker doesn't retry a request that cannot succeed.
 
 ## Retries
 

--- a/charts/async-processor/templates/ap-configmap.yaml
+++ b/charts/async-processor/templates/ap-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig }}
+{{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,5 +12,8 @@ data:
   {{- end }}
   {{- if .Values.ap.gcpPubSub.topicsConfig }}
   pubsub-topics.json: {{ .Values.ap.gcpPubSub.topicsConfig | toJson | quote }}
+  {{- end }}
+  {{- if .Values.ap.transformConfig }}
+  transform-config.json: {{ .Values.ap.transformConfig | toJson | quote }}
   {{- end }}
 {{- end }}

--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -92,6 +92,9 @@ spec:
           {{- if .Values.ap.workerPools }}
           - --pool-config-file=/etc/async-processor/config/worker-pools.json
           {{- end }}
+          {{- if .Values.ap.transformConfig }}
+          - --transform-config-file=/etc/async-processor/config/transform-config.json
+          {{- end }}
           - --concurrency={{ .Values.ap.concurrency | default 8 }}
           - --drain-timeout={{ .Values.ap.drainTimeout | default "2m" }}
           - --health-port={{ .Values.ap.health.port | default 8081 }}
@@ -184,9 +187,9 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.tls.secretName }}
+        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.tls.secretName }}
         volumeMounts:
-          {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig }}
+          {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig }}
           - name: ap-config
             mountPath: /etc/async-processor/config
             readOnly: true
@@ -199,9 +202,9 @@ spec:
         {{- end }}
       serviceAccountName: {{ include "async-processor.fullname" . }}
       terminationGracePeriodSeconds: 130
-      {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.tls.secretName }}
+      {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.tls.secretName }}
       volumes:
-        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig }}
+        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig }}
         - name: ap-config
           configMap:
             name: {{ include "async-processor.fullname" . }}-config

--- a/charts/async-processor/tests/deployment_test.yaml
+++ b/charts/async-processor/tests/deployment_test.yaml
@@ -308,3 +308,28 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --message-queue-impl=gcp-pubsub-gated
+
+  - it: should pass transform-config-file and mount the config when transformConfig is set
+    set:
+      ap.transformConfig:
+        requestTransforms:
+          - name: "gcs-whisper"
+            type: "gcs_uri_multipart"
+            parameters:
+              providers: ["whisper"]
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transform-config-file=/etc/async-processor/config/transform-config.json
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ap-config
+            mountPath: /etc/async-processor/config
+            readOnly: true
+
+  - it: should not pass transform-config-file when transformConfig is empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --transform-config-file=/etc/async-processor/config/transform-config.json

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -29,6 +29,17 @@ ap:
   #   - id: "premium"
   #     workers: 16
   workerPools: []
+  # Request body-transform plugins. When set, rendered to a config file and passed
+  # via --transform-config-file. Object with a requestTransforms array; each entry
+  # has a unique name, a registered plugin type, and opaque parameters. Empty
+  # disables transforms (default JSON dispatch is unchanged).
+  # transformConfig:
+  #   requestTransforms:
+  #     - name: "gcs-whisper"
+  #       type: "gcs_uri_multipart"
+  #       parameters:
+  #         providers: ["whisper"]
+  transformConfig: {}
   otel:
     # OTLP gRPC endpoint for trace collection. Examples:
     #   Dev (Jaeger all-in-one):     "http://jaeger.default.svc.cluster.local:4317"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker"
 	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
+	// Register the built-in request body-transform plugins.
+	_ "github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform/gcsmultipart"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
 	"github.com/llm-d-incubation/llm-d-async/pkg/pubsub"

--- a/pkg/asyncworker/transform/gcsmultipart/gcsmultipart.go
+++ b/pkg/asyncworker/transform/gcsmultipart/gcsmultipart.go
@@ -1,0 +1,258 @@
+// Package gcsmultipart provides a RequestTransform plugin that rewrites the
+// OpenAI-style JSON body into multipart/form-data for multi-modal inference
+// endpoints (e.g. Whisper transcription, OCR) that expect a `url` form field
+// pointing at a signed object URL rather than a JSON payload.
+//
+// Producers can't put raw media bytes on the broker (size limits), so the queued
+// JSON carries a signed object URL (e.g. a GCS V4 signed URL) in a `gcs_uri`
+// field. This plugin, at dispatch time, emits multipart/form-data with that URL
+// as the `url` field and the remaining request fields as form fields. It also
+// performs a deadline-aware preflight: if the signed URL expires before the
+// message deadline, the request is rejected fatally so the broker doesn't retry
+// a request that cannot succeed.
+//
+// The plugin is opt-in: it owns a message only when the per-message `provider`
+// metadata matches one of its configured providers AND the body carries a
+// non-empty `gcs_uri`. Otherwise it leaves the default JSON path untouched.
+package gcsmultipart
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/url"
+	"strconv"
+	"time"
+
+	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+)
+
+// PluginType is the registry key under which this plugin's factory is registered.
+const PluginType = "gcs_uri_multipart"
+
+const (
+	// providerMetadataKey is the per-message metadata key whose value is matched
+	// against the plugin's configured providers.
+	providerMetadataKey = "provider"
+
+	// gcsURIField is the JSON field carrying the signed object URL.
+	gcsURIField = "gcs_uri"
+	// fileBase64Field carries inline media bytes, which this path does not support.
+	fileBase64Field = "file_base64"
+	// urlFormField is the multipart form field the endpoint expects.
+	urlFormField = "url"
+)
+
+var _ transform.RequestTransform = (*Plugin)(nil)
+
+// params is the plugin's configuration, parsed from the factory parameters.
+type params struct {
+	// Providers are the `provider` metadata values this instance handles.
+	Providers []string `json:"providers"`
+}
+
+// Plugin rewrites a JSON body with a gcs_uri into multipart/form-data.
+type Plugin struct {
+	tn        plugins.TypedName
+	providers map[string]struct{}
+}
+
+func init() {
+	plugins.MustRegister(PluginType, New)
+}
+
+// New is the FactoryFunc for the plugin. It requires a non-empty `providers`
+// list in its parameters.
+func New(name string, parameters json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+	var p params
+	if len(parameters) > 0 {
+		dec := json.NewDecoder(bytes.NewReader(parameters))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&p); err != nil {
+			return nil, fmt.Errorf("invalid parameters: %w", err)
+		}
+	}
+	if len(p.Providers) == 0 {
+		return nil, fmt.Errorf("at least one entry in %q is required", "providers")
+	}
+
+	providers := make(map[string]struct{}, len(p.Providers))
+	for _, provider := range p.Providers {
+		if provider == "" {
+			return nil, fmt.Errorf("%q entries must be non-empty", "providers")
+		}
+		providers[provider] = struct{}{}
+	}
+
+	return &Plugin{
+		tn:        plugins.TypedName{Type: PluginType, Name: name},
+		providers: providers,
+	}, nil
+}
+
+// TypedName returns the plugin's type and instance name.
+func (p *Plugin) TypedName() plugins.TypedName { return p.tn }
+
+// owns reports whether this plugin handles a message with the given metadata.
+func (p *Plugin) owns(metadata map[string]string) bool {
+	_, ok := p.providers[metadata[providerMetadataKey]]
+	return ok
+}
+
+// Validate performs a deadline-aware preflight. When the plugin owns the message
+// and the signed URL's expiry can be parsed, it rejects the request fatally if
+// the URL expires at or before the request deadline. Messages the plugin does
+// not own, or whose URL has no parseable expiry, validate successfully.
+func (p *Plugin) Validate(payload []byte, metadata map[string]string, reqDeadline int64) error {
+	if !p.owns(metadata) {
+		return nil
+	}
+	fields, err := decodeFields(payload)
+	if err != nil {
+		return fatalf("failed to parse request body: %v", err)
+	}
+	signedURL := stringField(fields, gcsURIField)
+	if signedURL == "" {
+		return nil
+	}
+
+	expiry, ok := signedURLExpiry(signedURL)
+	if !ok {
+		// No parseable expiry: nothing to preflight, leave it to dispatch.
+		return nil
+	}
+	if !expiry.After(time.Unix(reqDeadline, 0)) {
+		return fatalf("signed URL expires at %s, at or before the request deadline %s",
+			expiry.UTC().Format(time.RFC3339), time.Unix(reqDeadline, 0).UTC().Format(time.RFC3339))
+	}
+	return nil
+}
+
+// Transform rewrites the JSON body into multipart/form-data when the plugin owns
+// the message and a non-empty gcs_uri is present: the gcs_uri value becomes the
+// `url` form field, the remaining fields pass through as form fields, and the
+// gcs_uri/file_base64 fields are dropped. A non-empty file_base64 is rejected
+// fatally (inline media is not supported on this path). Messages the plugin does
+// not own, or that carry no gcs_uri, return handled=false unchanged.
+func (p *Plugin) Transform(payload []byte, metadata map[string]string) (body []byte, contentType string, handled bool, err error) {
+	if !p.owns(metadata) {
+		return nil, "", false, nil
+	}
+	fields, err := decodeFields(payload)
+	if err != nil {
+		return nil, "", false, fatalf("failed to parse request body: %v", err)
+	}
+	signedURL := stringField(fields, gcsURIField)
+	if signedURL == "" {
+		return nil, "", false, nil
+	}
+	if stringField(fields, fileBase64Field) != "" {
+		return nil, "", false, fatalf("%q is not supported on the multipart path", fileBase64Field)
+	}
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	// The signed URL is written as a plain form field, not a file upload.
+	if err := w.WriteField(urlFormField, signedURL); err != nil {
+		return nil, "", false, fatalf("failed to write %q field: %v", urlFormField, err)
+	}
+	for name, raw := range fields {
+		if name == gcsURIField || name == fileBase64Field {
+			continue
+		}
+		if err := w.WriteField(name, asFormValue(raw)); err != nil {
+			return nil, "", false, fatalf("failed to write %q field: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", false, fatalf("failed to finalize multipart body: %v", err)
+	}
+
+	return buf.Bytes(), w.FormDataContentType(), true, nil
+}
+
+// decodeFields parses the JSON body into its top-level fields, preserving each
+// value's raw JSON so non-string fields pass through faithfully.
+func decodeFields(payload []byte) (map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return nil, err
+	}
+	return fields, nil
+}
+
+// stringField returns the value of a JSON string field, or "" if the field is
+// absent or not a string.
+func stringField(fields map[string]json.RawMessage, name string) string {
+	raw, ok := fields[name]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// asFormValue renders a raw JSON value as a multipart form field value: JSON
+// strings are unquoted, everything else (numbers, booleans, objects, arrays) is
+// passed through as its JSON encoding.
+func asFormValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+// signedURLExpiry extracts the absolute expiry time of a signed object URL.
+// It supports V4 signing (X-Goog-Date + X-Goog-Expires seconds) and V2 signing
+// (Expires as Unix seconds). It returns ok=false if no expiry can be determined.
+func signedURLExpiry(signedURL string) (time.Time, bool) {
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return time.Time{}, false
+	}
+	q := u.Query()
+
+	// V4: X-Goog-Date (yyyymmddThhmmssZ) + X-Goog-Expires (seconds).
+	if date := q.Get("X-Goog-Date"); date != "" {
+		if expires := q.Get("X-Goog-Expires"); expires != "" {
+			start, err := time.Parse("20060102T150405Z", date)
+			if err != nil {
+				return time.Time{}, false
+			}
+			secs, err := strconv.Atoi(expires)
+			if err != nil {
+				return time.Time{}, false
+			}
+			return start.Add(time.Duration(secs) * time.Second), true
+		}
+	}
+
+	// V2: Expires as absolute Unix seconds.
+	if expires := q.Get("Expires"); expires != "" {
+		secs, err := strconv.ParseInt(expires, 10, 64)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return time.Unix(secs, 0), true
+	}
+
+	return time.Time{}, false
+}
+
+// fatalf builds a non-retryable invalid-request error. The worker treats any
+// transform error as fatal; the explicit category documents intent and is robust
+// to future changes in error handling.
+func fatalf(format string, args ...any) error {
+	return &asyncapi.ClientError{
+		ErrorCategory: asyncapi.ErrCategoryInvalidReq,
+		Message:       fmt.Sprintf(format, args...),
+	}
+}

--- a/pkg/asyncworker/transform/gcsmultipart/gcsmultipart_test.go
+++ b/pkg/asyncworker/transform/gcsmultipart/gcsmultipart_test.go
@@ -1,0 +1,274 @@
+package gcsmultipart
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"strings"
+	"testing"
+	"time"
+
+	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+)
+
+// newPlugin builds a plugin instance for the given providers via the factory.
+func newPlugin(t *testing.T, providers ...string) *Plugin {
+	t.Helper()
+	raw, err := json.Marshal(params{Providers: providers})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := New("test", raw, plugins.NewHandle(context.Background()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p.(*Plugin)
+}
+
+// v4SignedURL returns a GCS V4 signed URL that expires at the given time.
+func v4SignedURL(expiry time.Time) string {
+	start := expiry.Add(-time.Hour).UTC()
+	return fmt.Sprintf(
+		"https://storage.googleapis.com/bucket/object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Date=%s&X-Goog-Expires=%d&X-Goog-Signature=deadbeef",
+		start.Format("20060102T150405Z"), int(expiry.Sub(start).Seconds()),
+	)
+}
+
+// parseParts parses a multipart body into a name->values map and records which
+// parts were sent as file uploads (i.e. carry a filename).
+func parseParts(t *testing.T, contentType string, body []byte) (map[string][]string, map[string]string) {
+	t.Helper()
+	mediaType, parsms, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("ParseMediaType(%q): %v", contentType, err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("media type = %q, want multipart/form-data", mediaType)
+	}
+	if parsms["boundary"] == "" {
+		t.Fatal("multipart Content-Type has no boundary")
+	}
+
+	fields := map[string][]string{}
+	files := map[string]string{}
+	r := multipart.NewReader(strings.NewReader(string(body)), parsms["boundary"])
+	for {
+		part, err := r.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart: %v", err)
+		}
+		buf, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read part %q: %v", part.FormName(), err)
+		}
+		fields[part.FormName()] = append(fields[part.FormName()], string(buf))
+		if fn := part.FileName(); fn != "" {
+			files[part.FormName()] = fn
+		}
+	}
+	return fields, files
+}
+
+func TestTransform_BuildsMultipart(t *testing.T) {
+	p := newPlugin(t, "whisper")
+	payload := []byte(`{"model":"whisper-1","gcs_uri":"https://signed/url?sig=x","language":"en"}`)
+
+	body, contentType, handled, err := p.Transform(payload, map[string]string{"provider": "whisper"})
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if !handled {
+		t.Fatal("handled = false, want true")
+	}
+	if !strings.HasPrefix(contentType, "multipart/form-data; boundary=") {
+		t.Fatalf("contentType = %q, want multipart/form-data with boundary", contentType)
+	}
+
+	fields, files := parseParts(t, contentType, body)
+	if got := fields["url"]; len(got) != 1 || got[0] != "https://signed/url?sig=x" {
+		t.Errorf("url field = %v, want the signed URL", got)
+	}
+	if got := fields["model"]; len(got) != 1 || got[0] != "whisper-1" {
+		t.Errorf("model field = %v, want [whisper-1]", got)
+	}
+	if got := fields["language"]; len(got) != 1 || got[0] != "en" {
+		t.Errorf("language field = %v, want [en]", got)
+	}
+	if _, ok := fields["gcs_uri"]; ok {
+		t.Error("gcs_uri must be dropped from the multipart body")
+	}
+	if len(files) != 0 {
+		t.Errorf("expected no file-upload parts, got %v", files)
+	}
+}
+
+func TestTransform_PassesThroughNonStringFields(t *testing.T) {
+	p := newPlugin(t, "whisper")
+	payload := []byte(`{"gcs_uri":"https://signed/url","temperature":0.5,"stream":true}`)
+
+	body, contentType, handled, err := p.Transform(payload, map[string]string{"provider": "whisper"})
+	if err != nil || !handled {
+		t.Fatalf("Transform: handled=%v err=%v", handled, err)
+	}
+	fields, _ := parseParts(t, contentType, body)
+	if got := fields["temperature"]; len(got) != 1 || got[0] != "0.5" {
+		t.Errorf("temperature field = %v, want [0.5]", got)
+	}
+	if got := fields["stream"]; len(got) != 1 || got[0] != "true" {
+		t.Errorf("stream field = %v, want [true]", got)
+	}
+}
+
+func TestTransform_NotHandled(t *testing.T) {
+	p := newPlugin(t, "whisper")
+	tests := []struct {
+		name     string
+		payload  string
+		metadata map[string]string
+	}{
+		{"provider mismatch", `{"gcs_uri":"https://signed/url"}`, map[string]string{"provider": "other"}},
+		{"no provider", `{"gcs_uri":"https://signed/url"}`, nil},
+		{"no gcs_uri", `{"model":"whisper-1"}`, map[string]string{"provider": "whisper"}},
+		{"empty gcs_uri", `{"gcs_uri":""}`, map[string]string{"provider": "whisper"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _, handled, err := p.Transform([]byte(tc.payload), tc.metadata)
+			if err != nil {
+				t.Fatalf("Transform: unexpected error %v", err)
+			}
+			if handled {
+				t.Error("handled = true, want false")
+			}
+			if body != nil {
+				t.Errorf("body = %q, want nil", body)
+			}
+		})
+	}
+}
+
+func TestTransform_RejectsFileBase64(t *testing.T) {
+	p := newPlugin(t, "whisper")
+	payload := []byte(`{"gcs_uri":"https://signed/url","file_base64":"QUJD"}`)
+
+	_, _, handled, err := p.Transform(payload, map[string]string{"provider": "whisper"})
+	if handled {
+		t.Error("handled = true, want false on rejection")
+	}
+	assertFatal(t, err)
+}
+
+func TestValidate(t *testing.T) {
+	p := newPlugin(t, "whisper")
+	whisper := map[string]string{"provider": "whisper"}
+	deadline := time.Now().Add(time.Hour)
+
+	tests := []struct {
+		name      string
+		payload   string
+		metadata  map[string]string
+		wantError bool
+	}{
+		{"future expiry ok", fmt.Sprintf(`{"gcs_uri":%q}`, v4SignedURL(deadline.Add(time.Hour))), whisper, false},
+		{"expired before deadline", fmt.Sprintf(`{"gcs_uri":%q}`, v4SignedURL(deadline.Add(-time.Minute))), whisper, true},
+		{"no gcs_uri", `{"model":"whisper-1"}`, whisper, false},
+		{"provider mismatch", fmt.Sprintf(`{"gcs_uri":%q}`, v4SignedURL(deadline.Add(-time.Minute))), map[string]string{"provider": "other"}, false},
+		{"unparseable expiry", `{"gcs_uri":"https://signed/url?sig=x"}`, whisper, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.Validate([]byte(tc.payload), tc.metadata, deadline.Unix())
+			if tc.wantError {
+				assertFatal(t, err)
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate: unexpected error %v", err)
+			}
+		})
+	}
+}
+
+func TestNew_ParamValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantError bool
+	}{
+		{"valid", `{"providers":["whisper"]}`, false},
+		{"valid multiple", `{"providers":["whisper","ocr"]}`, false},
+		{"empty providers", `{"providers":[]}`, true},
+		{"missing providers", `{}`, true},
+		{"no parameters", ``, true},
+		{"empty provider string", `{"providers":[""]}`, true},
+		{"unknown field", `{"providers":["whisper"],"foo":1}`, true},
+		{"malformed json", `{"providers":`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New("test", json.RawMessage(tc.raw), plugins.NewHandle(context.Background()))
+			if tc.wantError && err == nil {
+				t.Error("New = nil error, want error")
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("New = %v, want nil error", err)
+			}
+		})
+	}
+}
+
+func TestSignedURLExpiry(t *testing.T) {
+	ref := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		url  string
+		want time.Time
+		ok   bool
+	}{
+		{"v4", "https://x/o?X-Goog-Date=20260618T110000Z&X-Goog-Expires=3600", ref, true},
+		{"v2", fmt.Sprintf("https://x/o?Expires=%d", ref.Unix()), ref, true},
+		{"none", "https://x/o?sig=abc", time.Time{}, false},
+		{"v4 bad date", "https://x/o?X-Goog-Date=nope&X-Goog-Expires=3600", time.Time{}, false},
+		{"v4 bad expires", "https://x/o?X-Goog-Date=20260618T110000Z&X-Goog-Expires=abc", time.Time{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := signedURLExpiry(tc.url)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && !got.Equal(tc.want) {
+				t.Errorf("expiry = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluginRegistered(t *testing.T) {
+	if _, ok := plugins.Lookup(PluginType); !ok {
+		t.Errorf("plugin type %q not registered via init()", PluginType)
+	}
+}
+
+// assertFatal asserts err is a non-retryable invalid-request ClientError.
+func assertFatal(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var ce *asyncapi.ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error %v is not a *ClientError", err)
+	}
+	if !ce.Category().Fatal() {
+		t.Errorf("error category %q is not fatal", ce.Category())
+	}
+}


### PR DESCRIPTION
## What

Implements #256: the first concrete request body-transform plugin, `gcs_uri_multipart`, built on the framework from #257.

Multi-modal inference endpoints (Whisper transcription, OCR) expect `multipart/form-data` with a `url` field pointing at a signed object URL, not the OpenAI-style JSON the pipeline produces. Producers can't put raw media bytes on the broker (size limits), so the queued payload carries a signed URL (e.g. a GCS V4 signed URL) in a `gcs_uri` field, and the worker must rewrite the body into multipart right before dispatch — respecting signed-URL expiry on retries.

## Changes

- **`pkg/asyncworker/transform/gcsmultipart/`** — the plugin (registered via `init()`/`MustRegister`):
  - **Activation:** owns a message only when `metadata.provider` matches a configured provider **and** the payload has a non-empty `gcs_uri`; otherwise the default JSON path is preserved byte-for-byte.
  - **Transform:** writes `gcs_uri` as a `url` form field (a plain field, **not** a file upload), passes the remaining payload fields through as form fields, drops `gcs_uri`, and rejects a non-empty `file_base64` as a fatal/non-retryable invalid-request error. Returns the multipart `Content-Type` (with boundary).
  - **Validate (deadline-aware preflight):** parses the signed URL's expiry (V4 `X-Goog-Date` + `X-Goog-Expires`, or V2 `Expires`) and fails fatally before dispatch if it expires at or before the request deadline, so the broker doesn't retry a request that cannot succeed. Best-effort: no parseable expiry → no rejection. **No new dependency** (stdlib `net/url`/`time`).
- **`cmd/main.go`** — blank import to register the built-in plugin.
- **`README.md`** — new "Request Body Transforms" section documenting `--transform-config-file`, the config shape, and the `gcs_uri_multipart` plugin.

## Config

```json
{
  "requestTransforms": [
    { "name": "whisper-multipart", "type": "gcs_uri_multipart", "parameters": { "providers": ["whisper"] } }
  ]
}
```

## Testing

Table-driven unit tests covering the acceptance criteria from #256:

- Outgoing body is `multipart/form-data`; includes `url=<signed url>`; carries the other request fields; does **not** include a multipart file upload; `gcs_uri` is dropped.
- `file_base64` is rejected (fatal); provider mismatch / missing `gcs_uri` → not handled (default JSON path).
- An already-expired (relative to deadline) signed URL fails fatally without a retry; future expiry / no-expiry pass.
- Factory parameter validation; signed-URL expiry parsing (V4/V2/none/malformed); plugin self-registration.

`go build ./...` (incl. `-tags integration`), `go test -count=2 ./pkg/asyncworker/... ./cmd/...`, and `golangci-lint` all pass. (The `test/e2e` suite requires a live cluster and is not run here.)

Closes #256.
