### PR TITLE
fix: update image references from async-processor to llm-d-async

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export
 # Image URL to use all building/pushing image targets
 IMAGE_TAG_BASE ?= ghcr.io/llm-d-incubation
 IMG_TAG ?= latest
-IMG ?= $(IMAGE_TAG_BASE)/async-processor:$(IMG_TAG)
+IMG ?= $(IMAGE_TAG_BASE)/llm-d-async:$(IMG_TAG)
 
 # Versioning information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -15,7 +15,7 @@ ap:
       cpu: 500m
       memory: 512Mi
   image:
-    repository: ghcr.io/llm-d-incubation/async-processor
+    repository: ghcr.io/llm-d-incubation/llm-d-async
     tag: 0.6.0
   imagePullPolicy: Always
   concurrency: 8


### PR DESCRIPTION
## What does this PR do?

The CI release workflow derives the image name from the GitHub repository name (llm-d-async), but the Makefile and Helm chart defaulted to the old name async-processor, causing image-not-found errors.

## Why is this change needed?

Bug fix

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [X] Tests pass locally (`make test`)
- [X] Linters pass (`make lint`)
- [X] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
