### PR TITLE
feat(chart): support gcp-pubsub-gated message queue impl

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -61,7 +61,18 @@ spec:
           {{- end }}
           {{- end }}
           {{- else if .Values.ap.gcpPubSub.enabled }}
-          - --message-queue-impl=gcp-pubsub
+          {{- /* Honor an explicit gcp-pubsub* messageQueueImpl; otherwise auto-select
+                 gcp-pubsub-gated when any topic declares a gate_type (per-topic gates
+                 only take effect in gated mode). */}}
+          {{- $mqImpl := "gcp-pubsub" }}
+          {{- if and .Values.ap.messageQueueImpl (hasPrefix "gcp-pubsub" .Values.ap.messageQueueImpl) }}
+          {{- $mqImpl = .Values.ap.messageQueueImpl }}
+          {{- else }}
+          {{- range .Values.ap.gcpPubSub.topicsConfig }}
+          {{- if .gate_type }}{{- $mqImpl = "gcp-pubsub-gated" }}{{- end }}
+          {{- end }}
+          {{- end }}
+          - --message-queue-impl={{ $mqImpl }}
           - --pubsub.result-topic-id={{ .Values.ap.gcpPubSub.resultTopicId }}
           {{- if .Values.ap.gcpPubSub.topicsConfig }}
           - --pubsub.topics-config-file=/etc/async-processor/config/pubsub-topics.json

--- a/charts/async-processor/tests/deployment_test.yaml
+++ b/charts/async-processor/tests/deployment_test.yaml
@@ -258,3 +258,53 @@ tests:
             name: ap-config
             configMap:
               name: RELEASE-NAME-async-processor-config
+
+  - it: should auto-select gcp-pubsub-gated when a topic declares a gate_type
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.resultTopicId: "test-result-topic"
+      ap.gcpPubSub.topicsConfig:
+        - subscriber_id: "sub-1"
+          igw_base_url: "http://igw:80"
+          gate_type: "redis-quota"
+          gate_params:
+            address: "redis:6379"
+            attribute: "team"
+            mode: "concurrency"
+            limit: "5"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub-gated
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub
+
+  - it: should keep plain gcp-pubsub when no topic declares a gate_type
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.resultTopicId: "test-result-topic"
+      ap.gcpPubSub.topicsConfig:
+        - subscriber_id: "sub-1"
+          igw_base_url: "http://igw:80"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub-gated
+
+  - it: should honor an explicit gcp-pubsub-gated messageQueueImpl override
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.requestSubscriberId: "test-sub"
+      ap.gcpPubSub.resultTopicId: "test-topic"
+      ap.messageQueueImpl: "gcp-pubsub-gated"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub-gated

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -70,7 +70,12 @@ ap:
     enabled: true
     port: 9090
     secure: false
-  # messageQueueImpl: "redis-sortedset" # can be "redis-sortedset", "redis-pubsub", or "gcp-pubsub"
+  # Message queue implementation. Supported: "redis-sortedset", "redis-pubsub",
+  # "gcp-pubsub", "gcp-pubsub-gated". Leave empty to auto-select: redis-pubsub by
+  # default, and for GCP Pub/Sub "gcp-pubsub-gated" when any gcpPubSub.topicsConfig
+  # entry declares a gate_type (per-topic gates only take effect in gated mode),
+  # otherwise "gcp-pubsub".
+  messageQueueImpl: ""
   gcpPubSub:
     enabled: false
     requestSubscriberId: ""


### PR DESCRIPTION
## Summary

The chart hardcoded `--message-queue-impl=gcp-pubsub` for the GCP Pub/Sub backend. That mode never wires the dispatch `GateFactory` (only `gcp-pubsub-gated` does, see `cmd/main.go`), so per-topic `gate_type` / `gate_params` declared in `ap.gcpPubSub.topicsConfig` were **silently ignored** — there was no way to enable per-topic gates on Pub/Sub via the chart.

This adds an `ap.messageQueueImpl` value that selects the implementation:
- An explicit `gcp-pubsub*` value is honored as-is.
- Otherwise the chart **auto-selects `gcp-pubsub-gated`** when any `topicsConfig` entry declares a `gate_type`, falling back to `gcp-pubsub`.

The Redis default path is unchanged (empty → `redis-pubsub`; `redis-sortedset` still selectable), mirroring how the Redis branch already keys off `ap.messageQueueImpl`.

## Changes

- `templates/ap-deployments.yaml` — derive the impl from `ap.messageQueueImpl` / topic `gate_type`.
- `values.yaml` — promote the previously-commented `messageQueueImpl` to a real key with docs for all four modes.
- `tests/deployment_test.yaml` — 3 new helm-unittest cases: auto-select gated, plain no-gate, explicit override.

## Verification

- `helm template` renders the expected `--message-queue-impl` for: gated auto-select, plain, explicit override, and the Redis regression case.
- `helm unittest charts/async-processor` → 39/39 pass.
- `helm lint` clean.