### PR TITLE
Unify and refactor gating interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 - `constant`: Always returns budget 1.0 (fully open) - no throttling.
 - `redis`: Queries Redis for dispatch budget (managed by external system).
 - `redis-quota`: Per-attribute quota management via Redis.
+- `local-max-concurrency`: Limits the number of concurrent in-flight requests processed from a queue locally using thread-safe, in-process state.
 - `composite`: Combines multiple gates. Returns the minimum budget across all inner dispatch gates and acquires quota across all inner attribute gates (all or nothing).
 - `prometheus-saturation`: Queries Prometheus for pool saturation metric. The gate closes (returns `0.0`) when saturation ≥ threshold; when open it returns `(1 - saturation) - (1 - threshold)`, i.e. the margin below the threshold.
 - `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_SYS)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
@@ -238,6 +239,9 @@ For more fine-grained control, configure gates per queue in your configuration f
   - `window` (optional): The time window for rate limiting (e.g., `1m`, `10s`). Default is `1m`.
   - `prefix` (optional): Redis key prefix. Default is `quota:`.
   - `gating_mode` (optional): `blocking` or `classifying`. In `classifying` mode, the gate never blocks but tags the message with its quota status ("reserved" or "overflow") in the internal metadata. Default is `blocking`.
+
+- `local-max-concurrency`:
+  - `limit` (**required**): The maximum number of concurrent requests allowed in-flight for this queue. Must be a positive integer.
 
 - `prometheus-saturation`:
   - `pool` (**required**): The inference pool name to filter metrics by.

--- a/api/api.go
+++ b/api/api.go
@@ -66,8 +66,3 @@ type ResultMessage struct {
 	Routing  InternalRouting   `json:"-"`
 	Metadata map[string]string `json:"-"`
 }
-
-// ResultMessageExpand is an extended ResultMessage that carries additional context.
-type ResultMessageExpand struct {
-	ResultMessage
-}

--- a/api/api.go
+++ b/api/api.go
@@ -66,3 +66,8 @@ type ResultMessage struct {
 	Routing  InternalRouting   `json:"-"`
 	Metadata map[string]string `json:"-"`
 }
+
+// ResultMessageExpand is an extended ResultMessage that carries additional context.
+type ResultMessageExpand struct {
+	ResultMessage
+}

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -40,6 +40,40 @@ type InternalRequest struct {
 	// (un)marshaling does not persist it, so a re-enqueued (retried) message is
 	// re-stamped on its next delivery. Zero when not set (e.g. drained messages).
 	IngestionTime time.Time `json:"-"`
+
+	// releases holds cleanup and release functions registered by stateful gates
+	// (e.g., reservation counters or quota allocations) during the request's
+	// lifecycle. These are executed in reverse order on Release() or discarded
+	// if RollbackReleases() is invoked.
+	releases []func()
+}
+
+func (r *InternalRequest) AttachRelease(f func()) {
+	if f != nil {
+		r.releases = append(r.releases, f)
+	}
+}
+
+func (r *InternalRequest) Release() {
+	for i := len(r.releases) - 1; i >= 0; i-- {
+		if r.releases[i] != nil {
+			r.releases[i]()
+		}
+	}
+	r.releases = nil
+}
+
+func (r *InternalRequest) Releases() []func() {
+	return r.releases
+}
+
+func (r *InternalRequest) RollbackReleases(snapshot int) {
+	for i := len(r.releases) - 1; i >= snapshot; i-- {
+		if r.releases[i] != nil {
+			r.releases[i]()
+		}
+	}
+	r.releases = r.releases[:snapshot]
 }
 
 // NewInternalRequest returns an InternalRequest with a non-nil PublicRequest.

--- a/pipeline/gate.go
+++ b/pipeline/gate.go
@@ -6,26 +6,37 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/api"
 )
 
+// VerdictAction represents the action to take after evaluating admission gates.
+type VerdictAction int
+
+const (
+	// ActionContinue allows the request to be dispatched.
+	ActionContinue VerdictAction = iota
+	// ActionDrop permanently discards the request and optionally returns a result.
+	ActionDrop
+	// ActionRefuse temporarily rejects the request and requests redelivery/re-enqueue.
+	ActionRefuse
+)
+
 // Verdict carries the outcome of a gating decision.
 type Verdict struct {
-	Terminate bool
-	Redeliver bool
-	Result    *api.ResultMessageExpand
+	Action VerdictAction
+	Result *api.ResultMessage
 }
 
 // Continue returns a verdict to proceed.
 func Continue() Verdict {
-	return Verdict{}
+	return Verdict{Action: ActionContinue}
 }
 
 // Drop returns a verdict to terminate the request permanently.
-func Drop(result *api.ResultMessageExpand) Verdict {
-	return Verdict{Terminate: true, Result: result}
+func Drop(result *api.ResultMessage) Verdict {
+	return Verdict{Action: ActionDrop, Result: result}
 }
 
 // Refuse returns a verdict to temporarily reject and redeliver/re-enqueue the request.
 func Refuse() Verdict {
-	return Verdict{Redeliver: true}
+	return Verdict{Action: ActionRefuse}
 }
 
 // Gate defines a unified interface for system capacity and request admission control.
@@ -46,7 +57,7 @@ func ApplyChain(ctx context.Context, msg *api.InternalRequest, gates []Gate) (Ve
 	snapshot := len(msg.Releases())
 	for _, gate := range gates {
 		verdict, err := gate.Apply(ctx, msg)
-		if err != nil || verdict.Terminate || verdict.Redeliver {
+		if err != nil || verdict.Action != ActionContinue {
 			msg.RollbackReleases(snapshot)
 			return verdict, err
 		}

--- a/pipeline/gate.go
+++ b/pipeline/gate.go
@@ -6,49 +6,76 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/api"
 )
 
-// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
-type DispatchGate interface {
-	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
-	// the fraction of system capacity available for new requests.
+// Verdict carries the outcome of a gating decision.
+type Verdict struct {
+	Terminate bool
+	Redeliver bool
+	Result    *api.ResultMessageExpand
+}
+
+// Continue returns a verdict to proceed.
+func Continue() Verdict {
+	return Verdict{}
+}
+
+// Drop returns a verdict to terminate the request permanently.
+func Drop(result *api.ResultMessageExpand) Verdict {
+	return Verdict{Terminate: true, Result: result}
+}
+
+// Refuse returns a verdict to temporarily reject and redeliver/re-enqueue the request.
+func Refuse() Verdict {
+	return Verdict{Redeliver: true}
+}
+
+// Gate defines a unified interface for system capacity and request admission control.
+type Gate interface {
+	// Budget returns the system dispatch capacity budget in the range [0.0, 1.0].
+	// budget represents the fraction of system capacity available for new requests.
 	// A value of 0.0 indicates no available capacity (system at max allowed).
 	// A value of 1.0 indicates full capacity available (system is idle).
 	// The system always returns a valid value, even in case of internal error.
 	Budget(ctx context.Context) float64
+	// Apply applies the gating logic to a request.
+	Apply(ctx context.Context, msg *api.InternalRequest) (Verdict, error)
 }
 
-// AcquireResult contains the outcome of an AttributeGate.Acquire attempt.
-type AcquireResult struct {
-	// Allowed is true if the request should proceed.
-	Allowed bool
-	// Classification indicates the quota status of the request.
-	Classification api.QuotaClassification
-	// Release is a function to be called when processing is complete.
-	// It may be nil if no quota was acquired.
-	Release func()
+// ApplyChain runs a series of gates sequentially. If any gate fails or indicates a non-continue
+// verdict, the chain terminates immediately and rolls back any state acquired by previous gates in the chain.
+func ApplyChain(ctx context.Context, msg *api.InternalRequest, gates []Gate) (Verdict, error) {
+	snapshot := len(msg.Releases())
+	for _, gate := range gates {
+		verdict, err := gate.Apply(ctx, msg)
+		if err != nil || verdict.Terminate || verdict.Redeliver {
+			msg.RollbackReleases(snapshot)
+			return verdict, err
+		}
+	}
+	return Continue(), nil
 }
 
-// AttributeGate defines the interface to determine if a request is allowed based on its attributes.
-type AttributeGate interface {
-	// Acquire attempts to acquire quota for the given attributes.
-	// If the gate does not support the given attributes or is not a quota gate,
-	// it should return Allowed=true and ClassificationNone.
-	Acquire(ctx context.Context, attributes map[string]string) (AcquireResult, error)
-}
-
-// GateFactory defines the interface for creating DispatchGate instances.
+// GateFactory defines the interface for creating Gate instances.
 type GateFactory interface {
-	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
+	CreateGate(gateType string, params map[string]string) (Gate, error)
 }
 
-var _ DispatchGate = DispatchGateFunc(nil)
+var _ Gate = DispatchGateFunc(nil)
 
-// DispatchGateFunc is a function type that implements DispatchGate.
+// DispatchGateFunc is a function type that implements Gate.
 type DispatchGateFunc func(context.Context) float64
 
 func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
 	return f(ctx)
 }
 
-func ConstOpenGate() DispatchGate {
+func (f DispatchGateFunc) Apply(ctx context.Context, msg *api.InternalRequest) (Verdict, error) {
+	if f(ctx) <= 0.0 {
+		return Refuse(), nil
+	}
+	return Continue(), nil
+}
+
+// ConstOpenGate returns a gate that is always open and has full capacity.
+func ConstOpenGate() Gate {
 	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
 }

--- a/pipeline/gate.go
+++ b/pipeline/gate.go
@@ -1,0 +1,54 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+)
+
+// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
+type DispatchGate interface {
+	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
+	// the fraction of system capacity available for new requests.
+	// A value of 0.0 indicates no available capacity (system at max allowed).
+	// A value of 1.0 indicates full capacity available (system is idle).
+	// The system always returns a valid value, even in case of internal error.
+	Budget(ctx context.Context) float64
+}
+
+// AcquireResult contains the outcome of an AttributeGate.Acquire attempt.
+type AcquireResult struct {
+	// Allowed is true if the request should proceed.
+	Allowed bool
+	// Classification indicates the quota status of the request.
+	Classification api.QuotaClassification
+	// Release is a function to be called when processing is complete.
+	// It may be nil if no quota was acquired.
+	Release func()
+}
+
+// AttributeGate defines the interface to determine if a request is allowed based on its attributes.
+type AttributeGate interface {
+	// Acquire attempts to acquire quota for the given attributes.
+	// If the gate does not support the given attributes or is not a quota gate,
+	// it should return Allowed=true and ClassificationNone.
+	Acquire(ctx context.Context, attributes map[string]string) (AcquireResult, error)
+}
+
+// GateFactory defines the interface for creating DispatchGate instances.
+type GateFactory interface {
+	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
+}
+
+var _ DispatchGate = DispatchGateFunc(nil)
+
+// DispatchGateFunc is a function type that implements DispatchGate.
+type DispatchGateFunc func(context.Context) float64
+
+func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
+	return f(ctx)
+}
+
+func ConstOpenGate() DispatchGate {
+	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -27,52 +27,6 @@ type Characteristics struct {
 	SupportsMessageLatency bool
 }
 
-// DispatchGate defines the interface to determine whether there is enough capacity to forward a request.
-type DispatchGate interface {
-	// Budget returns the Dispatch Budget in the range [0.0, 1.0], representing
-	// the fraction of system capacity available for new requests.
-	// A value of 0.0 indicates no available capacity (system at max allowed).
-	// A value of 1.0 indicates full capacity available (system is idle).
-	// The system always returns a valid value, even in case of internal error.
-	Budget(ctx context.Context) float64
-}
-
-// AcquireResult contains the outcome of an AttributeGate.Acquire attempt.
-type AcquireResult struct {
-	// Allowed is true if the request should proceed.
-	Allowed bool
-	// Classification indicates the quota status of the request.
-	Classification api.QuotaClassification
-	// Release is a function to be called when processing is complete.
-	// It may be nil if no quota was acquired.
-	Release func()
-}
-
-// AttributeGate defines the interface to determine if a request is allowed based on its attributes.
-type AttributeGate interface {
-	// Acquire attempts to acquire quota for the given attributes.
-	// If the gate does not support the given attributes or is not a quota gate,
-	// it should return Allowed=true and ClassificationNone.
-	Acquire(ctx context.Context, attributes map[string]string) (AcquireResult, error)
-}
-
-// GateFactory defines the interface for creating DispatchGate instances.
-type GateFactory interface {
-	CreateGate(gateType string, params map[string]string) (DispatchGate, error)
-}
-
-var _ DispatchGate = DispatchGateFunc(nil)
-
-// DispatchGateFunc is a function type that implements DispatchGate.
-type DispatchGateFunc func(context.Context) float64
-
-func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
-	return f(ctx)
-}
-
-func ConstOpenGate() DispatchGate {
-	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
-}
 
 type RequestMergePolicy interface {
 	MergeRequestChannels(channels []RequestChannel, pools map[string]WorkerPoolConfig) PoolDispatch

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -27,7 +27,6 @@ type Characteristics struct {
 	SupportsMessageLatency bool
 }
 
-
 type RequestMergePolicy interface {
 	MergeRequestChannels(channels []RequestChannel, pools map[string]WorkerPoolConfig) PoolDispatch
 }
@@ -53,7 +52,7 @@ type RequestChannel struct {
 	IGWBaseURL         string
 	InferenceObjective string
 	RequestPathURL     string
-	Gate               DispatchGate
+	Gate               Gate
 	WorkerPoolID       string
 }
 

--- a/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/binary_metric_dispatch_gate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	promapi "github.com/prometheus/client_golang/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,7 +32,7 @@ var prometheusURL = flag.String("gate.prometheus.url", "", "Prometheus URL for n
 var gmpProjectID = flag.String("gate.pmetric.gmp.project-id", "", "Project ID for Google Managed Prometheus")
 var prometheusQueryModelName = flag.String("gate.prometheus.model-name", "", "metrics name to use for avg_queue_size")
 
-var _ pipeline.DispatchGate = (*BinaryMetricDispatchGate)(nil)
+var _ pipeline.Gate = (*BinaryMetricDispatchGate)(nil)
 
 // BinaryMetricDispatchGate implements DispatchGate using a MetricSource.
 // It returns 0.0 (no capacity) if the metric value is non-zero,
@@ -66,6 +67,14 @@ func (g *BinaryMetricDispatchGate) Budget(ctx context.Context) float64 {
 		return 1.0
 	}
 	return 0.0
+}
+
+// Apply implements pipeline.Gate.
+func (g *BinaryMetricDispatchGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	if g.Budget(ctx) <= 0.0 {
+		return pipeline.Refuse(), nil
+	}
+	return pipeline.Continue(), nil
 }
 
 // AverageQueueSizeGate creates a BinaryMetricDispatchGate from command-line flags.

--- a/pkg/async/inference/flowcontrol/composite_gate.go
+++ b/pkg/async/inference/flowcontrol/composite_gate.go
@@ -23,22 +23,21 @@ import (
 	pipeline "github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
-var _ pipeline.DispatchGate = (*CompositeGate)(nil)
-var _ pipeline.AttributeGate = (*CompositeGate)(nil)
+var _ pipeline.Gate = (*CompositeGate)(nil)
 
-// CompositeGate combines multiple DispatchGates and/or AttributeGates.
-// It returns the minimum budget across all inner DispatchGates.
-// It acquires quota across all inner AttributeGates (all or nothing).
+// CompositeGate combines multiple pipeline.Gates.
+// It returns the minimum budget across all inner Gates.
+// It applies all inner gates (all or nothing) to incoming requests.
 type CompositeGate struct {
-	gates []pipeline.DispatchGate
+	gates []pipeline.Gate
 }
 
 // NewCompositeGate creates a CompositeGate with the given inner gates.
-func NewCompositeGate(gates ...pipeline.DispatchGate) *CompositeGate {
+func NewCompositeGate(gates ...pipeline.Gate) *CompositeGate {
 	return &CompositeGate{gates: gates}
 }
 
-// Budget implements DispatchGate.
+// Budget implements pipeline.Gate.
 // Returns the minimum budget across all inner gates.
 // If there are no inner gates, it returns 1.0.
 func (c *CompositeGate) Budget(ctx context.Context) float64 {
@@ -56,45 +55,8 @@ func (c *CompositeGate) Budget(ctx context.Context) float64 {
 	return minBudget
 }
 
-// Acquire implements AttributeGate.
-// It attempts to acquire quota across all inner AttributeGates.
-// If any gate denies the request or fails, it releases the quota acquired from previous gates.
-func (c *CompositeGate) Acquire(ctx context.Context, attributes map[string]string) (pipeline.AcquireResult, error) {
-	var releases []func()
-	releaseAll := func() {
-		for i := len(releases) - 1; i >= 0; i-- {
-			releases[i]()
-		}
-	}
-
-	finalClassification := api.ClassificationNone
-	for _, gate := range c.gates {
-		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			res, err := attrGate.Acquire(ctx, attributes)
-			if err != nil {
-				releaseAll()
-				return pipeline.AcquireResult{}, err
-			}
-			if !res.Allowed {
-				releaseAll()
-				return pipeline.AcquireResult{Allowed: false, Classification: api.ClassificationOverflow}, nil
-			}
-			if res.Release != nil {
-				releases = append(releases, res.Release)
-			}
-
-			// Aggregate classification: Overflow dominates.
-			if res.Classification == api.ClassificationOverflow {
-				finalClassification = api.ClassificationOverflow
-			} else if res.Classification == api.ClassificationReserved && finalClassification == api.ClassificationNone {
-				finalClassification = api.ClassificationReserved
-			}
-		}
-	}
-
-	return pipeline.AcquireResult{
-		Allowed:        true,
-		Classification: finalClassification,
-		Release:        releaseAll,
-	}, nil
+// Apply implements pipeline.Gate.
+// It runs ApplyChain across all inner gates.
+func (c *CompositeGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	return pipeline.ApplyChain(ctx, msg, c.gates)
 }

--- a/pkg/async/inference/flowcontrol/composite_gate_test.go
+++ b/pkg/async/inference/flowcontrol/composite_gate_test.go
@@ -47,7 +47,7 @@ func (m *mockGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipelin
 	if m.classification != "" {
 		msg.Classification = m.classification
 	}
-	if m.verdict.Terminate || m.verdict.Redeliver {
+	if m.verdict.Action != pipeline.ActionContinue {
 		return m.verdict, nil
 	}
 	msg.AttachRelease(func() {
@@ -85,8 +85,7 @@ func TestCompositeGate_Apply(t *testing.T) {
 		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
 		res, err := gate.Apply(context.Background(), msg)
 		assert.NoError(t, err)
-		assert.False(t, res.Terminate)
-		assert.False(t, res.Redeliver)
+		assert.Equal(t, pipeline.ActionContinue, res.Action)
 	})
 
 	t.Run("All continue", func(t *testing.T) {
@@ -97,8 +96,7 @@ func TestCompositeGate_Apply(t *testing.T) {
 		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
 		res, err := gate.Apply(context.Background(), msg)
 		assert.NoError(t, err)
-		assert.False(t, res.Terminate)
-		assert.False(t, res.Redeliver)
+		assert.Equal(t, pipeline.ActionContinue, res.Action)
 
 		msg.Release()
 		assert.Equal(t, 1, gate1.releaseCounter)
@@ -114,7 +112,7 @@ func TestCompositeGate_Apply(t *testing.T) {
 		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
 		res, err := gate.Apply(context.Background(), msg)
 		assert.NoError(t, err)
-		assert.True(t, res.Redeliver)
+		assert.Equal(t, pipeline.ActionRefuse, res.Action)
 
 		assert.Equal(t, 1, gate1.calls)
 		assert.Equal(t, 1, gate2.calls)

--- a/pkg/async/inference/flowcontrol/composite_gate_test.go
+++ b/pkg/async/inference/flowcontrol/composite_gate_test.go
@@ -26,40 +26,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockDispatchGate struct {
-	budget float64
+type mockGate struct {
+	budget         float64
+	verdict        pipeline.Verdict
+	err            error
+	calls          int
+	releaseCounter int
+	classification api.QuotaClassification
 }
 
-func (m *mockDispatchGate) Budget(ctx context.Context) float64 {
+func (m *mockGate) Budget(ctx context.Context) float64 {
 	return m.budget
 }
 
-type mockAttributeGate struct {
-	mockDispatchGate
-	allowed        bool
-	classification api.QuotaClassification
-	err            error
-	calls          int
-	release        bool
-}
-
-func (m *mockAttributeGate) Acquire(ctx context.Context, attributes map[string]string) (pipeline.AcquireResult, error) {
+func (m *mockGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
 	m.calls++
 	if m.err != nil {
-		return pipeline.AcquireResult{}, m.err
+		return pipeline.Verdict{}, m.err
 	}
-	if !m.allowed {
-		return pipeline.AcquireResult{Allowed: false, Classification: api.ClassificationOverflow}, nil
+	if m.classification != "" {
+		msg.Classification = m.classification
 	}
-	class := m.classification
-	if class == "" {
-		class = api.ClassificationReserved
+	if m.verdict.Terminate || m.verdict.Redeliver {
+		return m.verdict, nil
 	}
-	return pipeline.AcquireResult{
-		Allowed:        true,
-		Classification: class,
-		Release:        func() { m.release = true },
-	}, nil
+	msg.AttachRelease(func() {
+		m.releaseCounter++
+	})
+	return m.verdict, nil
 }
 
 func TestCompositeGate_Budget(t *testing.T) {
@@ -70,99 +64,75 @@ func TestCompositeGate_Budget(t *testing.T) {
 
 	t.Run("Minimum budget", func(t *testing.T) {
 		gate := NewCompositeGate(
-			&mockDispatchGate{budget: 0.8},
-			&mockDispatchGate{budget: 0.3},
-			&mockDispatchGate{budget: 0.9},
+			&mockGate{budget: 0.8},
+			&mockGate{budget: 0.3},
+			&mockGate{budget: 0.9},
 		)
 		assert.Equal(t, 0.3, gate.Budget(context.Background()))
 	})
 
 	t.Run("Single gate", func(t *testing.T) {
 		gate := NewCompositeGate(
-			&mockDispatchGate{budget: 0.5},
+			&mockGate{budget: 0.5},
 		)
 		assert.Equal(t, 0.5, gate.Budget(context.Background()))
 	})
 }
 
-func TestCompositeGate_Acquire(t *testing.T) {
-	t.Run("No attribute gates", func(t *testing.T) {
-		gate := NewCompositeGate(
-			&mockDispatchGate{budget: 0.5},
-		)
-		res, err := gate.Acquire(context.Background(), nil)
-		assert.True(t, res.Allowed)
+func TestCompositeGate_Apply(t *testing.T) {
+	t.Run("No inner gates", func(t *testing.T) {
+		gate := NewCompositeGate()
+		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
+		res, err := gate.Apply(context.Background(), msg)
 		assert.NoError(t, err)
-		assert.NotNil(t, res.Release)
-		res.Release()
+		assert.False(t, res.Terminate)
+		assert.False(t, res.Redeliver)
 	})
 
-	t.Run("All allowed", func(t *testing.T) {
-		gate1 := &mockAttributeGate{allowed: true}
-		gate2 := &mockAttributeGate{allowed: true}
+	t.Run("All continue", func(t *testing.T) {
+		gate1 := &mockGate{verdict: pipeline.Continue()}
+		gate2 := &mockGate{verdict: pipeline.Continue()}
 		gate := NewCompositeGate(gate1, gate2)
 
-		res, err := gate.Acquire(context.Background(), nil)
-		assert.True(t, res.Allowed)
+		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
+		res, err := gate.Apply(context.Background(), msg)
 		assert.NoError(t, err)
-		assert.NotNil(t, res.Release)
+		assert.False(t, res.Terminate)
+		assert.False(t, res.Redeliver)
 
-		res.Release()
-		assert.True(t, gate1.release)
-		assert.True(t, gate2.release)
+		msg.Release()
+		assert.Equal(t, 1, gate1.releaseCounter)
+		assert.Equal(t, 1, gate2.releaseCounter)
 	})
 
-	t.Run("One denied", func(t *testing.T) {
-		gate1 := &mockAttributeGate{allowed: true}
-		gate2 := &mockAttributeGate{allowed: false}
-		gate3 := &mockAttributeGate{allowed: true}
+	t.Run("One redeliver", func(t *testing.T) {
+		gate1 := &mockGate{verdict: pipeline.Continue()}
+		gate2 := &mockGate{verdict: pipeline.Refuse()}
+		gate3 := &mockGate{verdict: pipeline.Continue()}
 		gate := NewCompositeGate(gate1, gate2, gate3)
 
-		res, err := gate.Acquire(context.Background(), nil)
-		assert.False(t, res.Allowed)
+		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
+		res, err := gate.Apply(context.Background(), msg)
 		assert.NoError(t, err)
-		assert.Nil(t, res.Release)
+		assert.True(t, res.Redeliver)
 
 		assert.Equal(t, 1, gate1.calls)
 		assert.Equal(t, 1, gate2.calls)
-		assert.Equal(t, 0, gate3.calls) // Short circuits
-		assert.True(t, gate1.release)   // gate1 was released because gate2 denied
+		assert.Equal(t, 0, gate3.calls)          // Short circuit
+		assert.Equal(t, 1, gate1.releaseCounter) // Rollback called for gate1
 	})
 
 	t.Run("Error in gate", func(t *testing.T) {
-		gate1 := &mockAttributeGate{allowed: true}
-		gate2 := &mockAttributeGate{err: errors.New("test error")}
+		gate1 := &mockGate{verdict: pipeline.Continue()}
+		gate2 := &mockGate{err: errors.New("test error")}
 		gate := NewCompositeGate(gate1, gate2)
 
-		res, err := gate.Acquire(context.Background(), nil)
-		assert.False(t, res.Allowed)
+		msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req"})
+		_, err := gate.Apply(context.Background(), msg)
 		assert.Error(t, err)
-		assert.Nil(t, res.Release)
 
 		assert.Equal(t, 1, gate1.calls)
 		assert.Equal(t, 1, gate2.calls)
-		assert.True(t, gate1.release) // gate1 was released because gate2 errored
-	})
-}
-
-func TestCompositeGate_Classification(t *testing.T) {
-	t.Run("Reserved aggregation", func(t *testing.T) {
-		gate1 := &mockAttributeGate{allowed: true, classification: api.ClassificationReserved}
-		gate2 := &mockAttributeGate{allowed: true, classification: api.ClassificationNone}
-		gate := NewCompositeGate(gate1, gate2)
-
-		res, err := gate.Acquire(context.Background(), nil)
-		assert.NoError(t, err)
-		assert.Equal(t, api.ClassificationReserved, res.Classification)
-	})
-
-	t.Run("Overflow aggregation", func(t *testing.T) {
-		gate1 := &mockAttributeGate{allowed: true, classification: api.ClassificationReserved}
-		gate2 := &mockAttributeGate{allowed: true, classification: api.ClassificationOverflow}
-		gate := NewCompositeGate(gate1, gate2)
-
-		res, err := gate.Acquire(context.Background(), nil)
-		assert.NoError(t, err)
-		assert.Equal(t, api.ClassificationOverflow, res.Classification)
+		assert.Equal(t, 1, gate1.releaseCounter) // Rollback called for gate1
 	})
 }

--- a/pkg/async/inference/flowcontrol/dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/dispatch_gate.go
@@ -19,21 +19,30 @@ package flowcontrol
 import (
 	"context"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 )
 
-var _ pipeline.DispatchGate = DispatchGateFunc(nil)
+var _ pipeline.Gate = DispatchGateFunc(nil)
 
-// DispatchGateFunc is a function type that implements DispatchGate.
+// DispatchGateFunc is a function type that implements Gate.
 // This allows any function with the signature func(context.Context) float64
-// to be used as a DispatchGate.
+// to be used as a Gate.
 type DispatchGateFunc func(context.Context) float64
 
-// Budget implements DispatchGate by calling the function itself.
+// Budget implements Gate by calling the function itself.
 func (f DispatchGateFunc) Budget(ctx context.Context) float64 {
 	return f(ctx)
 }
 
-func ConstOpenGate() pipeline.DispatchGate {
+// Apply implements Gate.
+func (f DispatchGateFunc) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	if f(ctx) <= 0.0 {
+		return pipeline.Refuse(), nil
+	}
+	return pipeline.Continue(), nil
+}
+
+func ConstOpenGate() pipeline.Gate {
 	return DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
 }

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -94,7 +94,7 @@ func (f *GateFactory) Close() error {
 //     Params: query (required), fallback (default 0.0)
 //
 // For unsupported or unknown gate types, returns ConstOpenGate as a safe default.
-func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pipeline.DispatchGate, error) {
+func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pipeline.Gate, error) {
 	switch gateType {
 	case "composite":
 		gatesJSON := params["gates"]
@@ -112,7 +112,7 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			return nil, fmt.Errorf("composite gate failed to parse 'gates' parameter: %w", err)
 		}
 
-		var innerGates []pipeline.DispatchGate
+		var innerGates []pipeline.Gate
 		for _, cfg := range configs {
 			gate, err := f.CreateGate(cfg.GateType, cfg.GateParams)
 			if err != nil {
@@ -333,6 +333,20 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 		var ms MetricSource = NewScrapeMetricSource(cfg)
 		ms = cachedSource(ms, f.cacheTTL)
 		return NewMetricDispatchGate(ms, baseline, fallback), nil
+
+	case "local-max-concurrency":
+		limitStr := params["limit"]
+		if limitStr == "" {
+			return nil, fmt.Errorf("local-max-concurrency gate requires a 'limit' parameter")
+		}
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return nil, fmt.Errorf("local-max-concurrency gate requires a valid integer 'limit': %w", err)
+		}
+		if limit <= 0 {
+			return nil, fmt.Errorf("local-max-concurrency limit must be greater than 0, got %d", limit)
+		}
+		return NewLocalConcurrencyGate(limit), nil
 
 	default:
 		// Unknown gate types default to open gate

--- a/pkg/async/inference/flowcontrol/local_concurrency_gate.go
+++ b/pkg/async/inference/flowcontrol/local_concurrency_gate.go
@@ -1,0 +1,65 @@
+package flowcontrol
+
+import (
+	"context"
+	"sync"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+)
+
+var _ pipeline.Gate = (*LocalConcurrencyGate)(nil)
+
+// LocalConcurrencyGate limits the number of concurrent in-flight requests
+// processed from a single queue locally.
+type LocalConcurrencyGate struct {
+	mu       sync.Mutex
+	limit    int
+	inFlight int
+}
+
+// NewLocalConcurrencyGate creates a new LocalConcurrencyGate with the specified limit.
+func NewLocalConcurrencyGate(limit int) *LocalConcurrencyGate {
+	return &LocalConcurrencyGate{
+		limit: limit,
+	}
+}
+
+// Budget implements pipeline.Gate.
+// Returns the fraction of available capacity in [0.0, 1.0].
+func (g *LocalConcurrencyGate) Budget(ctx context.Context) float64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.limit <= 0 {
+		return 0.0
+	}
+	if g.inFlight >= g.limit {
+		return 0.0
+	}
+	return float64(g.limit-g.inFlight) / float64(g.limit)
+}
+
+// Apply implements pipeline.Gate.
+// Returns VerdictContinue if request fits in budget, VerdictRefuse with redeliver otherwise.
+func (g *LocalConcurrencyGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.limit <= 0 {
+		return pipeline.Refuse(), nil
+	}
+
+	if g.inFlight >= g.limit {
+		return pipeline.Refuse(), nil
+	}
+
+	g.inFlight++
+	msg.AttachRelease(func() {
+		g.mu.Lock()
+		g.inFlight--
+		g.mu.Unlock()
+	})
+
+	return pipeline.Continue(), nil
+}

--- a/pkg/async/inference/flowcontrol/local_concurrency_gate_test.go
+++ b/pkg/async/inference/flowcontrol/local_concurrency_gate_test.go
@@ -1,0 +1,136 @@
+package flowcontrol
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalConcurrencyGate_ApplyAndRelease(t *testing.T) {
+	gate := NewLocalConcurrencyGate(3)
+	ctx := context.Background()
+
+	// 1. Initial Budget is 1.0
+	assert.Equal(t, 1.0, gate.Budget(ctx))
+
+	// 2. Allow 3 requests
+	r1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
+	verdict, err := gate.Apply(ctx, r1)
+	require.NoError(t, err)
+	assert.False(t, verdict.Terminate)
+	assert.False(t, verdict.Redeliver)
+
+	r2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
+	verdict, err = gate.Apply(ctx, r2)
+	require.NoError(t, err)
+	assert.False(t, verdict.Terminate)
+	assert.False(t, verdict.Redeliver)
+
+	r3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
+	verdict, err = gate.Apply(ctx, r3)
+	require.NoError(t, err)
+	assert.False(t, verdict.Terminate)
+	assert.False(t, verdict.Redeliver)
+
+	// Budget should now be 0.0
+	assert.Equal(t, 0.0, gate.Budget(ctx))
+
+	// 3. Fourth request should be blocked/refused with redeliver=true
+	r4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
+	verdict, err = gate.Apply(ctx, r4)
+	require.NoError(t, err)
+	assert.True(t, verdict.Redeliver)
+
+	// 4. Release request 1
+	r1.Release()
+
+	// Budget should now be 1/3 (0.333...)
+	assert.InDelta(t, 0.333333, gate.Budget(ctx), 1e-4)
+
+	// Now fourth request can be admitted
+	verdict, err = gate.Apply(ctx, r4)
+	require.NoError(t, err)
+	assert.False(t, verdict.Terminate)
+	assert.False(t, verdict.Redeliver)
+
+	// Budget is back to 0.0
+	assert.Equal(t, 0.0, gate.Budget(ctx))
+
+	// Release remaining requests
+	r2.Release()
+	r3.Release()
+	r4.Release()
+
+	// Budget should be back to 1.0
+	assert.Equal(t, 1.0, gate.Budget(ctx))
+}
+
+func TestLocalConcurrencyGate_InvalidLimits(t *testing.T) {
+	ctx := context.Background()
+
+	// Zero limit
+	gate0 := NewLocalConcurrencyGate(0)
+	assert.Equal(t, 0.0, gate0.Budget(ctx))
+	r := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
+	verdict, err := gate0.Apply(ctx, r)
+	require.NoError(t, err)
+	assert.True(t, verdict.Redeliver)
+
+	// Negative limit
+	gateNeg := NewLocalConcurrencyGate(-5)
+	assert.Equal(t, 0.0, gateNeg.Budget(ctx))
+	verdict, err = gateNeg.Apply(ctx, r)
+	require.NoError(t, err)
+	assert.True(t, verdict.Redeliver)
+}
+
+func TestLocalConcurrencyGate_Concurrency(t *testing.T) {
+	limit := 50
+	gate := NewLocalConcurrencyGate(limit)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	requests := make([]*api.InternalRequest, 100)
+
+	// Simulate 100 concurrent requests trying to enter
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			req := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
+			verdict, err := gate.Apply(ctx, req)
+			if err == nil && !verdict.Redeliver {
+				requests[idx] = req
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Count how many requests were admitted (should be exactly limit)
+	admittedCount := 0
+	for _, r := range requests {
+		if r != nil {
+			admittedCount++
+		}
+	}
+	assert.Equal(t, limit, admittedCount)
+
+	// Now concurrently release all admitted requests
+	for i := 0; i < 100; i++ {
+		if requests[i] != nil {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				requests[idx].Release()
+			}(i)
+		}
+	}
+	wg.Wait()
+
+	// Budget should be fully recovered to 1.0
+	assert.Equal(t, 1.0, gate.Budget(ctx))
+}

--- a/pkg/async/inference/flowcontrol/local_concurrency_gate_test.go
+++ b/pkg/async/inference/flowcontrol/local_concurrency_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,20 +22,17 @@ func TestLocalConcurrencyGate_ApplyAndRelease(t *testing.T) {
 	r1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
 	verdict, err := gate.Apply(ctx, r1)
 	require.NoError(t, err)
-	assert.False(t, verdict.Terminate)
-	assert.False(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict.Action)
 
 	r2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
 	verdict, err = gate.Apply(ctx, r2)
 	require.NoError(t, err)
-	assert.False(t, verdict.Terminate)
-	assert.False(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict.Action)
 
 	r3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
 	verdict, err = gate.Apply(ctx, r3)
 	require.NoError(t, err)
-	assert.False(t, verdict.Terminate)
-	assert.False(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict.Action)
 
 	// Budget should now be 0.0
 	assert.Equal(t, 0.0, gate.Budget(ctx))
@@ -43,7 +41,7 @@ func TestLocalConcurrencyGate_ApplyAndRelease(t *testing.T) {
 	r4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
 	verdict, err = gate.Apply(ctx, r4)
 	require.NoError(t, err)
-	assert.True(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionRefuse, verdict.Action)
 
 	// 4. Release request 1
 	r1.Release()
@@ -54,8 +52,7 @@ func TestLocalConcurrencyGate_ApplyAndRelease(t *testing.T) {
 	// Now fourth request can be admitted
 	verdict, err = gate.Apply(ctx, r4)
 	require.NoError(t, err)
-	assert.False(t, verdict.Terminate)
-	assert.False(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict.Action)
 
 	// Budget is back to 0.0
 	assert.Equal(t, 0.0, gate.Budget(ctx))
@@ -78,14 +75,14 @@ func TestLocalConcurrencyGate_InvalidLimits(t *testing.T) {
 	r := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
 	verdict, err := gate0.Apply(ctx, r)
 	require.NoError(t, err)
-	assert.True(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionRefuse, verdict.Action)
 
 	// Negative limit
 	gateNeg := NewLocalConcurrencyGate(-5)
 	assert.Equal(t, 0.0, gateNeg.Budget(ctx))
 	verdict, err = gateNeg.Apply(ctx, r)
 	require.NoError(t, err)
-	assert.True(t, verdict.Redeliver)
+	assert.Equal(t, pipeline.ActionRefuse, verdict.Action)
 }
 
 func TestLocalConcurrencyGate_Concurrency(t *testing.T) {
@@ -103,7 +100,7 @@ func TestLocalConcurrencyGate_Concurrency(t *testing.T) {
 			defer wg.Done()
 			req := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{})
 			verdict, err := gate.Apply(ctx, req)
-			if err == nil && !verdict.Redeliver {
+			if err == nil && verdict.Action == pipeline.ActionContinue {
 				requests[idx] = req
 			}
 		}(i)

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var _ pipeline.DispatchGate = (*MetricDispatchGate)(nil)
+var _ pipeline.Gate = (*MetricDispatchGate)(nil)
 
 // MetricDispatchGate implements DispatchGate by querying a MetricSource for a
 // budget value D and returning D − threshold, clamped to [0.0, 1.0].
@@ -94,4 +95,12 @@ func (g *MetricDispatchGate) Budget(ctx context.Context) float64 {
 		return 0.0
 	}
 	return math.Min(1.0, math.Max(0.0, value-g.threshold))
+}
+
+// Apply implements pipeline.Gate.
+func (g *MetricDispatchGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	if g.Budget(ctx) <= 0.0 {
+		return pipeline.Refuse(), nil
+	}
+	return pipeline.Continue(), nil
 }

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -57,7 +57,7 @@ type PubSubMQFlow struct {
 	requestChannels []RequestChannelData
 	retryChannel    chan pipeline.RetryMessage
 	resultChannel   chan api.ResultMessage
-	gate            pipeline.DispatchGate
+	gate            pipeline.Gate
 	gateFactory     pipeline.GateFactory
 	workerPools     []pipeline.WorkerPoolConfig
 	consumeCancel   context.CancelFunc
@@ -70,7 +70,7 @@ type PubSubMQFlow struct {
 type RequestChannelData struct {
 	requestChannel pipeline.RequestChannel
 	subscriberID   string
-	gate           pipeline.DispatchGate
+	gate           pipeline.Gate
 }
 
 // PubSubOption is a functional option for configuring PubSubMQFlow
@@ -169,7 +169,7 @@ func NewGCPPubSubMQFlow(opts ...PubSubOption) *PubSubMQFlow {
 		}
 
 		// Determine gate for this topic
-		var gate pipeline.DispatchGate
+		var gate pipeline.Gate
 		if p.gateFactory != nil && cfg.GateType != "" {
 			// Use factory to create per-topic gate
 			var err error
@@ -416,7 +416,7 @@ func addMsgToRetryQueue(ctx context.Context, retryChannel chan pipeline.RetryMes
 	}
 }
 
-func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID, poolID string, ch chan *api.InternalRequest, gate pipeline.DispatchGate) {
+func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.Client, subscriberID, poolID string, ch chan *api.InternalRequest, gate pipeline.Gate) {
 	logger := log.FromContext(ctx)
 
 	sub := pubSubClient.Subscriber(subscriberID)
@@ -464,7 +464,7 @@ func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.C
 
 type receiveFunc func(context.Context, func(context.Context, *pubsub.Message)) error
 
-func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc, subscriberID string, poolID string, ch chan *api.InternalRequest, gate pipeline.DispatchGate) error {
+func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc, subscriberID string, poolID string, ch chan *api.InternalRequest, gate pipeline.Gate) error {
 	logger := log.FromContext(ctx)
 	return receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 
@@ -483,39 +483,63 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 		if msg.DeliveryAttempt != nil {
 			irout.RetryCount = *msg.DeliveryAttempt - 1
 		}
-		ir := api.NewInternalRequest(irout, &body)
-
-		// Per-attribute gating
-		var release func()
-		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			res, err := attrGate.Acquire(ctx, msg.Attributes)
-			if err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to acquire attribute quota")
-				msg.Nack()
-				return
-			}
-			if !res.Allowed {
-				logger.V(logutil.DEBUG).Info("Quota exceeded, delaying Nack", "msgID", msg.ID, "delay", quotaExceededNackDelay)
-				go func() {
-					select {
-					case <-time.After(quotaExceededNackDelay):
-						msg.Nack()
-					case <-ctx.Done():
-						msg.Nack()
-					}
-				}()
-				return
-			}
-			release = res.Release
-			ir.Classification = res.Classification
-		} else {
-			release = func() {}
+		if body.Metadata == nil {
+			body.Metadata = make(map[string]string)
 		}
-		defer release()
+		for k, v := range msg.Attributes {
+			body.Metadata[k] = v
+		}
+
+		ir := api.NewInternalRequest(irout, &body)
+		defer ir.Release()
 
 		resultsChannel := make(chan bool, 1)
 		resultChannels.Store(msg.ID, resultsChannel)
 		defer resultChannels.Delete(msg.ID)
+
+		// Apply gate
+		verdict, err := gate.Apply(ctx, ir)
+		if err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Gating failed")
+			msg.Nack()
+			return
+		}
+
+		if verdict.Redeliver {
+			logger.V(logutil.DEBUG).Info("Quota exceeded or capacity full, delaying Nack", "msgID", msg.ID, "delay", quotaExceededNackDelay)
+			go func() {
+				select {
+				case <-time.After(quotaExceededNackDelay):
+					msg.Nack()
+				case <-ctx.Done():
+					msg.Nack()
+				}
+			}()
+			return
+		}
+
+		if verdict.Terminate {
+			var resultMsg api.ResultMessage
+			if verdict.Result != nil {
+				resultMsg = verdict.Result.ResultMessage
+			} else {
+				resultMsg = api.ResultMessage{
+					ID:      body.ID,
+					Payload: `{"status": "dropped"}`,
+				}
+			}
+			resultMsg.Routing = ir.InternalRouting
+			r.resultChannel <- resultMsg
+
+			// Wait for the result worker to finish publishing and signal true
+			result := <-resultsChannel
+			if !result {
+				msg.Nack()
+			} else {
+				msg.Ack()
+			}
+			return
+		}
 
 		// Stamp ingestion time as the message enters the in-process buffer so the
 		// worker can record queue residence time when it pulls the message.

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -505,7 +505,7 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 			return
 		}
 
-		if verdict.Redeliver {
+		if verdict.Action == pipeline.ActionRefuse {
 			logger.V(logutil.DEBUG).Info("Quota exceeded or capacity full, delaying Nack", "msgID", msg.ID, "delay", quotaExceededNackDelay)
 			go func() {
 				select {
@@ -518,10 +518,10 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 			return
 		}
 
-		if verdict.Terminate {
+		if verdict.Action == pipeline.ActionDrop {
 			var resultMsg api.ResultMessage
 			if verdict.Result != nil {
-				resultMsg = verdict.Result.ResultMessage
+				resultMsg = *verdict.Result
 			} else {
 				resultMsg = api.ResultMessage{
 					ID:      body.ID,

--- a/pkg/pubsub/pubsubimpl_test.go
+++ b/pkg/pubsub/pubsubimpl_test.go
@@ -20,13 +20,13 @@ type mockAttributeGate struct {
 }
 
 func (m *mockAttributeGate) Budget(ctx context.Context) float64 { return 1.0 }
-func (m *mockAttributeGate) Acquire(ctx context.Context, attrs map[string]string) (pipeline.AcquireResult, error) {
+func (m *mockAttributeGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
 	m.acquireCalled = true
-	return pipeline.AcquireResult{
-		Allowed:        m.allowed,
-		Classification: api.ClassificationReserved,
-		Release:        func() { m.releaseCalled = true },
-	}, nil
+	if !m.allowed {
+		return pipeline.Refuse(), nil
+	}
+	msg.AttachRelease(func() { m.releaseCalled = true })
+	return pipeline.Continue(), nil
 }
 
 func TestProcessMessages_QuotaGating(t *testing.T) {

--- a/pkg/redis/dispatch_gate.go
+++ b/pkg/redis/dispatch_gate.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	goredis "github.com/redis/go-redis/v9"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
-var _ pipeline.DispatchGate = (*RedisDispatchGate)(nil)
+var _ pipeline.Gate = (*RedisDispatchGate)(nil)
 
 // RedisDispatchGate implements pipeline.DispatchGate by reading the budget
 // from a Redis key. This allows external systems to dynamically control
@@ -57,4 +58,12 @@ func (g *RedisDispatchGate) Budget(ctx context.Context) float64 {
 		return 1.0
 	}
 	return budget
+}
+
+// Apply implements pipeline.Gate.
+func (g *RedisDispatchGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	if g.Budget(ctx) <= 0.0 {
+		return pipeline.Refuse(), nil
+	}
+	return pipeline.Continue(), nil
 }

--- a/pkg/redis/quota_gate.go
+++ b/pkg/redis/quota_gate.go
@@ -11,8 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var _ pipeline.DispatchGate = (*RedisQuotaGate)(nil)
-var _ pipeline.AttributeGate = (*RedisQuotaGate)(nil)
+var _ pipeline.Gate = (*RedisQuotaGate)(nil)
 
 type QuotaMode string
 
@@ -61,12 +60,12 @@ func (g *RedisQuotaGate) Budget(ctx context.Context) float64 {
 	return 1.0
 }
 
-// Acquire implements api.AttributeGate.
-func (g *RedisQuotaGate) Acquire(ctx context.Context, attributes map[string]string) (pipeline.AcquireResult, error) {
-	val, ok := attributes[g.attribute]
+// Apply implements pipeline.Gate.
+func (g *RedisQuotaGate) Apply(ctx context.Context, msg *api.InternalRequest) (pipeline.Verdict, error) {
+	val, ok := msg.PublicRequest.ReqMetadata()[g.attribute]
 	if !ok {
-		// If the attribute is missing, we allow it by default (or we could reject it).
-		return pipeline.AcquireResult{Allowed: true, Classification: api.ClassificationNone}, nil
+		// If the attribute is missing, we allow it by default.
+		return pipeline.Continue(), nil
 	}
 
 	key := fmt.Sprintf("%s%s:%s", g.prefix, g.attribute, val)
@@ -81,23 +80,26 @@ func (g *RedisQuotaGate) Acquire(ctx context.Context, attributes map[string]stri
 	case QuotaModeRateLimit:
 		classification, release, err = g.acquireRateLimit(ctx, key)
 	default:
-		return pipeline.AcquireResult{Allowed: true, Classification: api.ClassificationNone}, nil
+		return pipeline.Continue(), nil
 	}
 
 	if err != nil {
-		return pipeline.AcquireResult{}, err
+		return pipeline.Verdict{}, err
 	}
 
-	allowed := true
 	if g.gatingMode == GatingModeBlocking {
-		allowed = (classification == api.ClassificationReserved)
+		if classification != api.ClassificationReserved {
+			msg.Classification = classification
+			return pipeline.Refuse(), nil
+		}
 	}
 
-	return pipeline.AcquireResult{
-		Allowed:        allowed,
-		Classification: classification,
-		Release:        release,
-	}, nil
+	msg.Classification = classification
+	if release != nil {
+		msg.AttachRelease(release)
+	}
+
+	return pipeline.Continue(), nil
 }
 
 func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (api.QuotaClassification, func(), error) {

--- a/pkg/redis/quota_gate_test.go
+++ b/pkg/redis/quota_gate_test.go
@@ -22,33 +22,37 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed
-	res, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res.Allowed || res.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res.Allowed, res.Classification, err)
+	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
+	verdict1, err := gate.Apply(ctx, msg1)
+	if err != nil || verdict1.Redeliver || verdict1.Terminate || msg1.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict1, msg1.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed
-	res2, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res2.Allowed || res2.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res2.Allowed, res2.Classification, err)
+	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
+	verdict2, err := gate.Apply(ctx, msg2)
+	if err != nil || verdict2.Redeliver || verdict2.Terminate || msg2.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict2, msg2.Classification, err)
 	}
 
-	// 3rd acquisition - Denied
-	res3, err := gate.Acquire(ctx, attrs)
-	if err != nil || res3.Allowed || res3.Classification != api.ClassificationOverflow {
-		t.Fatalf("Expected allowed=false overflow, got %v %v, err: %v", res3.Allowed, res3.Classification, err)
+	// 3rd acquisition - Denied (Redeliver)
+	msg3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req3", Metadata: attrs})
+	verdict3, err := gate.Apply(ctx, msg3)
+	if err != nil || !verdict3.Redeliver || msg3.Classification != api.ClassificationOverflow {
+		t.Fatalf("Expected redeliver overflow, got %v classification %v, err: %v", verdict3, msg3.Classification, err)
 	}
 
 	// Release one
-	res.Release()
+	msg1.Release()
 
 	// 4th acquisition - Allowed again
-	res4, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res4.Allowed || res4.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved after release, got %v %v, err: %v", res4.Allowed, res4.Classification, err)
+	msg4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req4", Metadata: attrs})
+	verdict4, err := gate.Apply(ctx, msg4)
+	if err != nil || verdict4.Redeliver || verdict4.Terminate || msg4.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved after release, got %v classification %v, err: %v", verdict4, msg4.Classification, err)
 	}
 
-	res2.Release()
+	msg2.Release()
 }
 
 func TestRedisQuotaGate_RateLimit(t *testing.T) {
@@ -64,30 +68,34 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed
-	res, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res.Allowed || res.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res.Allowed, res.Classification, err)
+	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
+	verdict1, err := gate.Apply(ctx, msg1)
+	if err != nil || verdict1.Redeliver || verdict1.Terminate || msg1.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict1, msg1.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed
-	res2, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res2.Allowed || res2.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res2.Allowed, res2.Classification, err)
+	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
+	verdict2, err := gate.Apply(ctx, msg2)
+	if err != nil || verdict2.Redeliver || verdict2.Terminate || msg2.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict2, msg2.Classification, err)
 	}
 
 	// 3rd acquisition - Denied
-	res3, err := gate.Acquire(ctx, attrs)
-	if err != nil || res3.Allowed || res3.Classification != api.ClassificationOverflow {
-		t.Fatalf("Expected allowed=false overflow, got %v %v, err: %v", res3.Allowed, res3.Classification, err)
+	msg3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req3", Metadata: attrs})
+	verdict3, err := gate.Apply(ctx, msg3)
+	if err != nil || !verdict3.Redeliver || msg3.Classification != api.ClassificationOverflow {
+		t.Fatalf("Expected redeliver overflow, got %v classification %v, err: %v", verdict3, msg3.Classification, err)
 	}
 
 	// Wait for window to pass
 	time.Sleep(1100 * time.Millisecond)
 
 	// 4th acquisition - Allowed again
-	res4, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res4.Allowed || res4.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved after window, got %v %v, err: %v", res4.Allowed, res4.Classification, err)
+	msg4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req4", Metadata: attrs})
+	verdict4, err := gate.Apply(ctx, msg4)
+	if err != nil || verdict4.Redeliver || verdict4.Terminate || msg4.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved after window, got %v classification %v, err: %v", verdict4, msg4.Classification, err)
 	}
 }
 
@@ -105,15 +113,17 @@ func TestRedisQuotaGate_Classifying(t *testing.T) {
 	attrs := map[string]string{"userid": "user1"}
 
 	// 1st acquisition - Allowed and Reserved
-	res, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res.Allowed || res.Classification != api.ClassificationReserved {
-		t.Fatalf("Expected allowed=true reserved, got %v %v, err: %v", res.Allowed, res.Classification, err)
+	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
+	verdict1, err := gate.Apply(ctx, msg1)
+	if err != nil || verdict1.Redeliver || verdict1.Terminate || msg1.Classification != api.ClassificationReserved {
+		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict1, msg1.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed but Overflow
-	res2, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res2.Allowed || res2.Classification != api.ClassificationOverflow {
-		t.Fatalf("Expected allowed=true overflow, got %v %v, err: %v", res2.Allowed, res2.Classification, err)
+	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
+	verdict2, err := gate.Apply(ctx, msg2)
+	if err != nil || verdict2.Redeliver || verdict2.Terminate || msg2.Classification != api.ClassificationOverflow {
+		t.Fatalf("Expected continue overflow in classifying mode, got %v classification %v, err: %v", verdict2, msg2.Classification, err)
 	}
 }
 
@@ -128,8 +138,9 @@ func TestRedisQuotaGate_MissingAttribute(t *testing.T) {
 	ctx := context.Background()
 	attrs := map[string]string{"teamid": "team1"} // missing 'userid'
 
-	res, err := gate.Acquire(ctx, attrs)
-	if err != nil || !res.Allowed || res.Classification != api.ClassificationNone {
-		t.Fatalf("Expected allowed=true none for missing attribute, got %v %v, err: %v", res.Allowed, res.Classification, err)
+	msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
+	verdict, err := gate.Apply(ctx, msg)
+	if err != nil || verdict.Redeliver || verdict.Terminate || msg.Classification != api.ClassificationNone {
+		t.Fatalf("Expected continue none for missing attribute, got %v classification %v, err: %v", verdict, msg.Classification, err)
 	}
 }

--- a/pkg/redis/quota_gate_test.go
+++ b/pkg/redis/quota_gate_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -24,21 +25,21 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	// 1st acquisition - Allowed
 	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
 	verdict1, err := gate.Apply(ctx, msg1)
-	if err != nil || verdict1.Redeliver || verdict1.Terminate || msg1.Classification != api.ClassificationReserved {
+	if err != nil || verdict1.Action != pipeline.ActionContinue || msg1.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict1, msg1.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed
 	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
 	verdict2, err := gate.Apply(ctx, msg2)
-	if err != nil || verdict2.Redeliver || verdict2.Terminate || msg2.Classification != api.ClassificationReserved {
+	if err != nil || verdict2.Action != pipeline.ActionContinue || msg2.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict2, msg2.Classification, err)
 	}
 
 	// 3rd acquisition - Denied (Redeliver)
 	msg3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req3", Metadata: attrs})
 	verdict3, err := gate.Apply(ctx, msg3)
-	if err != nil || !verdict3.Redeliver || msg3.Classification != api.ClassificationOverflow {
+	if err != nil || verdict3.Action != pipeline.ActionRefuse || msg3.Classification != api.ClassificationOverflow {
 		t.Fatalf("Expected redeliver overflow, got %v classification %v, err: %v", verdict3, msg3.Classification, err)
 	}
 
@@ -48,7 +49,7 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	// 4th acquisition - Allowed again
 	msg4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req4", Metadata: attrs})
 	verdict4, err := gate.Apply(ctx, msg4)
-	if err != nil || verdict4.Redeliver || verdict4.Terminate || msg4.Classification != api.ClassificationReserved {
+	if err != nil || verdict4.Action != pipeline.ActionContinue || msg4.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved after release, got %v classification %v, err: %v", verdict4, msg4.Classification, err)
 	}
 
@@ -70,21 +71,21 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	// 1st acquisition - Allowed
 	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
 	verdict1, err := gate.Apply(ctx, msg1)
-	if err != nil || verdict1.Redeliver || verdict1.Terminate || msg1.Classification != api.ClassificationReserved {
+	if err != nil || verdict1.Action != pipeline.ActionContinue || msg1.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict1, msg1.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed
 	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
 	verdict2, err := gate.Apply(ctx, msg2)
-	if err != nil || verdict2.Redeliver || verdict2.Terminate || msg2.Classification != api.ClassificationReserved {
+	if err != nil || verdict2.Action != pipeline.ActionContinue || msg2.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict2, msg2.Classification, err)
 	}
 
 	// 3rd acquisition - Denied
 	msg3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req3", Metadata: attrs})
 	verdict3, err := gate.Apply(ctx, msg3)
-	if err != nil || !verdict3.Redeliver || msg3.Classification != api.ClassificationOverflow {
+	if err != nil || verdict3.Action != pipeline.ActionRefuse || msg3.Classification != api.ClassificationOverflow {
 		t.Fatalf("Expected redeliver overflow, got %v classification %v, err: %v", verdict3, msg3.Classification, err)
 	}
 
@@ -94,7 +95,7 @@ func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	// 4th acquisition - Allowed again
 	msg4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req4", Metadata: attrs})
 	verdict4, err := gate.Apply(ctx, msg4)
-	if err != nil || verdict4.Redeliver || verdict4.Terminate || msg4.Classification != api.ClassificationReserved {
+	if err != nil || verdict4.Action != pipeline.ActionContinue || msg4.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved after window, got %v classification %v, err: %v", verdict4, msg4.Classification, err)
 	}
 }
@@ -115,14 +116,14 @@ func TestRedisQuotaGate_Classifying(t *testing.T) {
 	// 1st acquisition - Allowed and Reserved
 	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
 	verdict1, err := gate.Apply(ctx, msg1)
-	if err != nil || verdict1.Redeliver || verdict1.Terminate || msg1.Classification != api.ClassificationReserved {
+	if err != nil || verdict1.Action != pipeline.ActionContinue || msg1.Classification != api.ClassificationReserved {
 		t.Fatalf("Expected continue reserved, got %v classification %v, err: %v", verdict1, msg1.Classification, err)
 	}
 
 	// 2nd acquisition - Allowed but Overflow
 	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
 	verdict2, err := gate.Apply(ctx, msg2)
-	if err != nil || verdict2.Redeliver || verdict2.Terminate || msg2.Classification != api.ClassificationOverflow {
+	if err != nil || verdict2.Action != pipeline.ActionContinue || msg2.Classification != api.ClassificationOverflow {
 		t.Fatalf("Expected continue overflow in classifying mode, got %v classification %v, err: %v", verdict2, msg2.Classification, err)
 	}
 }
@@ -140,7 +141,7 @@ func TestRedisQuotaGate_MissingAttribute(t *testing.T) {
 
 	msg := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
 	verdict, err := gate.Apply(ctx, msg)
-	if err != nil || verdict.Redeliver || verdict.Terminate || msg.Classification != api.ClassificationNone {
+	if err != nil || verdict.Action != pipeline.ActionContinue || msg.Classification != api.ClassificationNone {
 		t.Fatalf("Expected continue none for missing attribute, got %v classification %v, err: %v", verdict, msg.Classification, err)
 	}
 }

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -91,7 +91,7 @@ type requestChannelData struct {
 	channel   pipeline.RequestChannel
 	queueName string
 	queueID   string
-	gate      pipeline.DispatchGate
+	gate      pipeline.Gate
 }
 
 var (
@@ -107,7 +107,7 @@ type RedisSortedSetFlow struct {
 	pollInterval    time.Duration
 	batchSize       int
 	activeReleases  sync.Map
-	gate            pipeline.DispatchGate
+	gate            pipeline.Gate
 	gateFactory     pipeline.GateFactory
 	configMap       map[string]queueConfig
 	workerPools     []pipeline.WorkerPoolConfig
@@ -174,7 +174,7 @@ func NewRedisSortedSetFlow(opts ...SortedSetOption) (*RedisSortedSetFlow, error)
 
 	r.configMap = make(map[string]queueConfig, len(configs))
 	for _, cfg := range configs {
-		var gate pipeline.DispatchGate
+		var gate pipeline.Gate
 		if r.gateFactory != nil && cfg.GateType != "" {
 			gate, err = r.gateFactory.CreateGate(cfg.GateType, cfg.GateParams)
 			if err != nil {
@@ -390,7 +390,7 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 	defer ticker.Stop()
 
 	// Find the gate for this queue
-	var gate pipeline.DispatchGate
+	var gate pipeline.Gate
 	for _, ch := range r.requestChannels {
 		if ch.queueName == queueName {
 			gate = ch.gate
@@ -411,7 +411,7 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan 
 	}
 }
 
-func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string, gate pipeline.DispatchGate, logger logr.Logger) {
+func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string, gate pipeline.Gate, logger logr.Logger) {
 	currentTime := float64(time.Now().Unix())
 
 	budget := gate.Budget(ctx)
@@ -450,31 +450,37 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			ir.QueueID = queueID
 		}
 
-		// Per-attribute gating
-		var release func()
-		if attrGate, ok := gate.(pipeline.AttributeGate); ok {
-			res, err := attrGate.Acquire(ctx, rview.ReqMetadata())
-			if err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to acquire attribute quota")
-				// Re-enqueue the message if acquisition fails
-				member, _ := json.Marshal(ir)
-				r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
-				continue
-			}
-			if !res.Allowed {
-				// Re-enqueue the message (wait for quota)
-				member, _ := json.Marshal(ir)
-				r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
-				continue
-			}
-			release = res.Release
-			ir.Classification = res.Classification
-		} else {
-			release = func() {}
+		// Apply gate
+		verdict, err := gate.Apply(ctx, ir)
+		if err != nil {
+			logger.V(logutil.DEFAULT).Error(err, "Gating failed")
+			// Re-enqueue the message on gating failure
+			member, _ := json.Marshal(ir)
+			r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
+			continue
 		}
 
-		if release != nil {
-			r.activeReleases.Store(rview.ReqID(), release)
+		if verdict.Redeliver {
+			// Re-enqueue the message (wait for capacity or quota)
+			member, _ := json.Marshal(ir)
+			r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
+			continue
+		}
+
+		if verdict.Terminate {
+			if verdict.Result != nil {
+				r.resultChannel <- verdict.Result.ResultMessage
+			} else {
+				r.resultChannel <- api.ResultMessage{
+					ID:      rview.ReqID(),
+					Payload: `{"status": "dropped"}`,
+				}
+			}
+			continue
+		}
+
+		if len(ir.Releases()) > 0 {
+			r.activeReleases.Store(rview.ReqID(), ir)
 		}
 
 		// Stamp ingestion time as the message enters the in-process buffer so the
@@ -493,9 +499,7 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			}); err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to re-queue message on shutdown", "id", rview.ReqID())
 			}
-			if release != nil {
-				release()
-			}
+			ir.Release()
 			return
 		}
 	}
@@ -598,8 +602,10 @@ func (r *RedisSortedSetFlow) resultWorker(ctx context.Context) {
 		batch := drainBatch(msg, r.resultChannel, maxBatchSize)
 		// Release quota for all messages in the batch
 		for _, m := range batch {
-			if rel, ok := r.activeReleases.LoadAndDelete(m.ID); ok {
-				rel.(func())()
+			if val, ok := r.activeReleases.LoadAndDelete(m.ID); ok {
+				if ir, ok := val.(*api.InternalRequest); ok {
+					ir.Release()
+				}
 			}
 		}
 		r.flushResultBatch(flushCtx, batch)

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -460,16 +460,16 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			continue
 		}
 
-		if verdict.Redeliver {
+		if verdict.Action == pipeline.ActionRefuse {
 			// Re-enqueue the message (wait for capacity or quota)
 			member, _ := json.Marshal(ir)
 			r.rdb.ZAdd(ctx, queueName, redis.Z{Score: deadline, Member: string(member)})
 			continue
 		}
 
-		if verdict.Terminate {
+		if verdict.Action == pipeline.ActionDrop {
 			if verdict.Result != nil {
-				r.resultChannel <- verdict.Result.ResultMessage
+				r.resultChannel <- *verdict.Result
 			} else {
 				r.resultChannel <- api.ResultMessage{
 					ID:      rview.ReqID(),

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // noopGate returns a gate that always returns full budget (1.0)
-func noopGate() pipeline.DispatchGate {
+func noopGate() pipeline.Gate {
 	return pipeline.ConstOpenGate()
 }
 

--- a/test/integration/gate_factory_redis_test.go
+++ b/test/integration/gate_factory_redis_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,25 +40,25 @@ func TestGateFactory_RedisQuota_ConcurrencyParsing(t *testing.T) {
 	req1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"model": "gpt-4"}})
 	verdict1, err := gate.Apply(ctx, req1)
 	require.NoError(t, err)
-	assert.False(t, verdict1.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict1.Action)
 
 	req2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"model": "gpt-4"}})
 	verdict2, err := gate.Apply(ctx, req2)
 	require.NoError(t, err)
-	assert.False(t, verdict2.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict2.Action)
 
 	// Third apply — should block/refuse.
 	req3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"model": "gpt-4"}})
 	verdict3, err := gate.Apply(ctx, req3)
 	require.NoError(t, err)
-	assert.True(t, verdict3.Redeliver, "Third request should be denied (limit=2)")
+	assert.Equal(t, pipeline.ActionRefuse, verdict3.Action, "Third request should be denied (limit=2)")
 
 	// Release one and retry.
 	req1.Release()
 
 	verdict4, err := gate.Apply(ctx, req3)
 	require.NoError(t, err)
-	assert.False(t, verdict4.Redeliver, "Should succeed after release")
+	assert.Equal(t, pipeline.ActionContinue, verdict4.Action, "Should succeed after release")
 
 	// Cleanup.
 	req2.Release()
@@ -84,14 +85,14 @@ func TestGateFactory_RedisQuota_RateLimitParsing(t *testing.T) {
 		req := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "alice"}})
 		verdict, err := gate.Apply(ctx, req)
 		require.NoError(t, err)
-		assert.False(t, verdict.Redeliver, "Request %d should be allowed", i+1)
+		assert.Equal(t, pipeline.ActionContinue, verdict.Action, "Request %d should be allowed", i+1)
 	}
 
 	// Fourth should be rate limited.
 	req4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "alice"}})
 	verdict4, err := gate.Apply(ctx, req4)
 	require.NoError(t, err)
-	assert.True(t, verdict4.Redeliver, "Fourth request should be rate limited")
+	assert.Equal(t, pipeline.ActionRefuse, verdict4.Action, "Fourth request should be rate limited")
 }
 
 // TestGateFactory_RedisQuota_MissingParams validates error handling for missing
@@ -128,10 +129,10 @@ func TestGateFactory_RedisQuota_DefaultParams(t *testing.T) {
 	req1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "bob"}})
 	verdict1, err := gate.Apply(ctx, req1)
 	require.NoError(t, err)
-	assert.False(t, verdict1.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict1.Action)
 
 	req2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "bob"}})
 	verdict2, err := gate.Apply(ctx, req2)
 	require.NoError(t, err)
-	assert.True(t, verdict2.Redeliver, "Second apply should be rate limited with default params")
+	assert.Equal(t, pipeline.ActionRefuse, verdict2.Action, "Second apply should be rate limited with default params")
 }

--- a/test/integration/gate_factory_redis_test.go
+++ b/test/integration/gate_factory_redis_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestGateFactory_RedisQuota_ConcurrencyParsing validates that GateFactory
-// correctly parses "redis-quota" params and produces a working AttributeGate.
-// Packages exercised: flowcontrol (GateFactory) -> pkg/redis (RedisQuotaGate).
+// correctly parses "redis-quota" params and produces a working Gate.
 func TestGateFactory_RedisQuota_ConcurrencyParsing(t *testing.T) {
 	s := miniredis.RunT(t)
 	factory := flowcontrol.NewGateFactory("")
@@ -34,37 +33,35 @@ func TestGateFactory_RedisQuota_ConcurrencyParsing(t *testing.T) {
 	// Budget always returns 1.0 for quota gates.
 	assert.Equal(t, 1.0, gate.Budget(context.Background()))
 
-	attrGate, ok := gate.(pipeline.AttributeGate)
-	require.True(t, ok, "redis-quota gate should implement AttributeGate")
-
 	ctx := context.Background()
-	attrs := map[string]string{"model": "gpt-4"}
 
-	// Acquire twice (limit=2) — both should succeed.
-	res1, err := attrGate.Acquire(ctx, attrs)
+	// Apply twice (limit=2) — both should succeed.
+	req1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"model": "gpt-4"}})
+	verdict1, err := gate.Apply(ctx, req1)
 	require.NoError(t, err)
-	assert.True(t, res1.Allowed)
+	assert.False(t, verdict1.Redeliver)
 
-	res2, err := attrGate.Acquire(ctx, attrs)
+	req2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"model": "gpt-4"}})
+	verdict2, err := gate.Apply(ctx, req2)
 	require.NoError(t, err)
-	assert.True(t, res2.Allowed)
+	assert.False(t, verdict2.Redeliver)
 
-	// Third acquire — should fail.
-	res3, err := attrGate.Acquire(ctx, attrs)
+	// Third apply — should block/refuse.
+	req3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"model": "gpt-4"}})
+	verdict3, err := gate.Apply(ctx, req3)
 	require.NoError(t, err)
-	assert.False(t, res3.Allowed, "Third acquire should be denied (limit=2)")
+	assert.True(t, verdict3.Redeliver, "Third request should be denied (limit=2)")
 
 	// Release one and retry.
-	res1.Release()
-	res4, err := attrGate.Acquire(ctx, attrs)
+	req1.Release()
+
+	verdict4, err := gate.Apply(ctx, req3)
 	require.NoError(t, err)
-	assert.True(t, res4.Allowed, "Should succeed after release")
+	assert.False(t, verdict4.Redeliver, "Should succeed after release")
 
 	// Cleanup.
-	res2.Release()
-	if res4.Release != nil {
-		res4.Release()
-	}
+	req2.Release()
+	req3.Release()
 }
 
 // TestGateFactory_RedisQuota_RateLimitParsing validates rate-limit mode parsing.
@@ -81,22 +78,20 @@ func TestGateFactory_RedisQuota_RateLimitParsing(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, gate)
 
-	attrGate, ok := gate.(pipeline.AttributeGate)
-	require.True(t, ok)
-
 	ctx := context.Background()
-	attrs := map[string]string{"userid": "alice"}
 
 	for i := 0; i < 3; i++ {
-		res, err := attrGate.Acquire(ctx, attrs)
+		req := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "alice"}})
+		verdict, err := gate.Apply(ctx, req)
 		require.NoError(t, err)
-		assert.True(t, res.Allowed, "Request %d should be allowed", i+1)
+		assert.False(t, verdict.Redeliver, "Request %d should be allowed", i+1)
 	}
 
 	// Fourth should be rate limited.
-	res4, err := attrGate.Acquire(ctx, attrs)
+	req4 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "alice"}})
+	verdict4, err := gate.Apply(ctx, req4)
 	require.NoError(t, err)
-	assert.False(t, res4.Allowed, "Fourth request should be rate limited")
+	assert.True(t, verdict4.Redeliver, "Fourth request should be rate limited")
 }
 
 // TestGateFactory_RedisQuota_MissingParams validates error handling for missing
@@ -128,16 +123,15 @@ func TestGateFactory_RedisQuota_DefaultParams(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	attrGate, ok := gate.(pipeline.AttributeGate)
-	require.True(t, ok)
-
 	// Default attribute is "userid", default mode is "rate-limit".
 	ctx := context.Background()
-	res1, err := attrGate.Acquire(ctx, map[string]string{"userid": "bob"})
+	req1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "bob"}})
+	verdict1, err := gate.Apply(ctx, req1)
 	require.NoError(t, err)
-	assert.True(t, res1.Allowed)
+	assert.False(t, verdict1.Redeliver)
 
-	res2, err := attrGate.Acquire(ctx, map[string]string{"userid": "bob"})
+	req2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{Metadata: map[string]string{"userid": "bob"}})
+	verdict2, err := gate.Apply(ctx, req2)
 	require.NoError(t, err)
-	assert.False(t, res2.Allowed, "Second acquire should be rate limited with default params")
+	assert.True(t, verdict2.Redeliver, "Second apply should be rate limited with default params")
 }

--- a/test/integration/sortedset_quota_gate_test.go
+++ b/test/integration/sortedset_quota_gate_test.go
@@ -17,11 +17,9 @@ import (
 )
 
 // TestSortedSetQuotaGate_AcquireDequeueRelease validates the full cross-package
-// contract: RedisQuotaGate.Acquire gates dequeue from a sorted set, the message
+// contract: RedisQuotaGate.Apply gates dequeue from a sorted set, the message
 // flows through a channel, and the release function decrements the concurrency
 // counter in Redis — allowing the next request through.
-//
-// Packages exercised: pkg/redis (quota_gate + sorted set ops), api, pipeline.
 func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	s := miniredis.RunT(t)
 	rdb := goredis.NewClient(&goredis.Options{Addr: s.Addr()})
@@ -52,7 +50,7 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Pop first message — Acquire should succeed (concurrency limit = 1).
+	// Pop first message — Apply should succeed (concurrency limit = 1).
 	results, err := rdb.ZPopMin(ctx, queueName, 1).Result()
 	require.NoError(t, err)
 	require.Len(t, results, 1)
@@ -60,12 +58,12 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	var ir1 api.InternalRequest
 	require.NoError(t, json.Unmarshal([]byte(results[0].Member.(string)), &ir1))
 
-	res1, err := gate.Acquire(ctx, ir1.PublicRequest.ReqMetadata())
+	verdict1, err := gate.Apply(ctx, &ir1)
 	require.NoError(t, err)
-	assert.True(t, res1.Allowed, "First request should be allowed")
-	require.NotNil(t, res1.Release)
+	assert.False(t, verdict1.Redeliver, "First request should be allowed")
+	assert.NotEmpty(t, ir1.Releases())
 
-	// Pop second message — Acquire should be denied (concurrency limit reached).
+	// Pop second message — Apply should be denied (concurrency limit reached).
 	results2, err := rdb.ZPopMin(ctx, queueName, 1).Result()
 	require.NoError(t, err)
 	require.Len(t, results2, 1)
@@ -73,9 +71,9 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	var ir2 api.InternalRequest
 	require.NoError(t, json.Unmarshal([]byte(results2[0].Member.(string)), &ir2))
 
-	res2, err := gate.Acquire(ctx, ir2.PublicRequest.ReqMetadata())
+	verdict2, err := gate.Apply(ctx, &ir2)
 	require.NoError(t, err)
-	assert.False(t, res2.Allowed, "Second request should be denied while first is in-flight")
+	assert.True(t, verdict2.Redeliver, "Second request should be denied while first is in-flight")
 
 	// Re-enqueue denied message (as sortedset_impl does).
 	err = rdb.ZAdd(ctx, queueName, goredis.Z{
@@ -84,7 +82,7 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Release the first request (simulates resultWorker calling release).
-	res1.Release()
+	ir1.Release()
 
 	// Now the second message should be acquirable.
 	results3, err := rdb.ZPopMin(ctx, queueName, 1).Result()
@@ -95,12 +93,10 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(results3[0].Member.(string)), &ir3))
 	assert.Equal(t, "msg-2", ir3.PublicRequest.ReqID())
 
-	res3, err := gate.Acquire(ctx, ir3.PublicRequest.ReqMetadata())
+	verdict3, err := gate.Apply(ctx, &ir3)
 	require.NoError(t, err)
-	assert.True(t, res3.Allowed, "Second request should be allowed after first was released")
-	if res3.Release != nil {
-		res3.Release()
-	}
+	assert.False(t, verdict3.Redeliver, "Second request should be allowed after first was released")
+	ir3.Release()
 }
 
 // TestSortedSetQuotaGate_RateLimitRequeue validates that rate-limited messages
@@ -126,21 +122,30 @@ func TestSortedSetQuotaGate_RateLimitRequeue(t *testing.T) {
 		},
 	)
 
-	// First acquire — allowed.
-	res, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
+	// First Apply — allowed.
+	verdict1, err := gate.Apply(ctx, ir)
 	require.NoError(t, err)
-	assert.True(t, res.Allowed)
+	assert.False(t, verdict1.Redeliver)
 
-	// Second acquire — denied (rate limit hit).
-	res2, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
+	// Second Apply — denied (rate limit hit).
+	ir2 := api.NewInternalRequest(
+		api.InternalRouting{RequestQueueName: queueName},
+		&api.RequestMessage{
+			ID: "rl-msg-2", Created: time.Now().Unix(),
+			Deadline: time.Now().Add(time.Minute).Unix(),
+			Payload:  map[string]any{"model": "test"},
+			Metadata: map[string]string{"userid": "user-b"},
+		},
+	)
+	verdict2, err := gate.Apply(ctx, ir2)
 	require.NoError(t, err)
-	assert.False(t, res2.Allowed, "Should be rate limited")
+	assert.True(t, verdict2.Redeliver, "Should be rate limited")
 
 	// Wait for window to reset.
 	time.Sleep(2100 * time.Millisecond)
 
-	// Third acquire — allowed again.
-	res3, err := gate.Acquire(ctx, ir.PublicRequest.ReqMetadata())
+	// Third Apply — allowed again.
+	verdict3, err := gate.Apply(ctx, ir2)
 	require.NoError(t, err)
-	assert.True(t, res3.Allowed, "Should be allowed after rate limit window resets")
+	assert.False(t, verdict3.Redeliver, "Should be allowed after rate limit window resets")
 }

--- a/test/integration/sortedset_quota_gate_test.go
+++ b/test/integration/sortedset_quota_gate_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	redisgate "github.com/llm-d-incubation/llm-d-async/pkg/redis"
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -60,7 +61,7 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 
 	verdict1, err := gate.Apply(ctx, &ir1)
 	require.NoError(t, err)
-	assert.False(t, verdict1.Redeliver, "First request should be allowed")
+	assert.Equal(t, pipeline.ActionContinue, verdict1.Action, "First request should be allowed")
 	assert.NotEmpty(t, ir1.Releases())
 
 	// Pop second message — Apply should be denied (concurrency limit reached).
@@ -73,7 +74,7 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 
 	verdict2, err := gate.Apply(ctx, &ir2)
 	require.NoError(t, err)
-	assert.True(t, verdict2.Redeliver, "Second request should be denied while first is in-flight")
+	assert.Equal(t, pipeline.ActionRefuse, verdict2.Action, "Second request should be denied while first is in-flight")
 
 	// Re-enqueue denied message (as sortedset_impl does).
 	err = rdb.ZAdd(ctx, queueName, goredis.Z{
@@ -95,7 +96,7 @@ func TestSortedSetQuotaGate_AcquireDequeueRelease(t *testing.T) {
 
 	verdict3, err := gate.Apply(ctx, &ir3)
 	require.NoError(t, err)
-	assert.False(t, verdict3.Redeliver, "Second request should be allowed after first was released")
+	assert.Equal(t, pipeline.ActionContinue, verdict3.Action, "Second request should be allowed after first was released")
 	ir3.Release()
 }
 
@@ -125,7 +126,7 @@ func TestSortedSetQuotaGate_RateLimitRequeue(t *testing.T) {
 	// First Apply — allowed.
 	verdict1, err := gate.Apply(ctx, ir)
 	require.NoError(t, err)
-	assert.False(t, verdict1.Redeliver)
+	assert.Equal(t, pipeline.ActionContinue, verdict1.Action)
 
 	// Second Apply — denied (rate limit hit).
 	ir2 := api.NewInternalRequest(
@@ -139,7 +140,7 @@ func TestSortedSetQuotaGate_RateLimitRequeue(t *testing.T) {
 	)
 	verdict2, err := gate.Apply(ctx, ir2)
 	require.NoError(t, err)
-	assert.True(t, verdict2.Redeliver, "Should be rate limited")
+	assert.Equal(t, pipeline.ActionRefuse, verdict2.Action, "Should be rate limited")
 
 	// Wait for window to reset.
 	time.Sleep(2100 * time.Millisecond)
@@ -147,5 +148,5 @@ func TestSortedSetQuotaGate_RateLimitRequeue(t *testing.T) {
 	// Third Apply — allowed again.
 	verdict3, err := gate.Apply(ctx, ir2)
 	require.NoError(t, err)
-	assert.False(t, verdict3.Redeliver, "Should be allowed after rate limit window resets")
+	assert.Equal(t, pipeline.ActionContinue, verdict3.Action, "Should be allowed after rate limit window resets")
 }


### PR DESCRIPTION
## What does this PR do?

 - Unifies legacy `DispatchGate` and `AttributeGate` contracts into a single `pipeline.Gate` interface returning `pipeline.Verdict`.
 - Introduces stateful resource release tracking (`AttachRelease`, `Release`, `RollbackReleases`) on `api.InternalRequest` to automate cleanup.
- Integrates `ApplyChain` evaluation and automatic release callbacks in both Redis and Pub/Sub ingestion pipelines.
- Updates all corresponding mock gates, unit tests, and integration test suites.
- Adds a new `local-max-concurrency` gate type with in-process queue concurrency limiting and dynamic budget scaling.


## Why is this change needed?

https://github.com/llm-d-incubation/llm-d-async/issues/206

Gating should support: fast fail, fail with retry and continue.
Gating should support attachment of Release callbacks to suppport stateful gates (e.g., reservation counters).

This change is needed to unblock per-pool gating and support gates label propagation.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes: https://github.com/llm-d-incubation/llm-d-async/issues/206
