### PR TITLE
ci: fix nightly e2e test timeout 

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("General Integration", func() {
 		cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "wait", "pod",
 			"-l", "app.kubernetes.io/instance=integration",
-			"--for=delete", "--timeout=120s")
+			"--for=delete", "--timeout=150s")
 		session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Eventually(session).WithTimeout(180 * time.Second).Should(gexec.Exit(0))


### PR DESCRIPTION
## What does this PR do?

fix nightly timeout in https://github.com/llm-d-incubation/llm-d-async/issues/263

## Why is this change needed?

e2e test timed out

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

closes https://github.com/llm-d-incubation/llm-d-async/issues/263