### PR TITLE
fix(chart): correct default image and add gcpPubSub.projectId

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -73,6 +73,9 @@ spec:
           {{- end }}
           {{- end }}
           - --message-queue-impl={{ $mqImpl }}
+          {{- if .Values.ap.gcpPubSub.projectId }}
+          - --pubsub.project-id={{ .Values.ap.gcpPubSub.projectId }}
+          {{- end }}
           - --pubsub.result-topic-id={{ .Values.ap.gcpPubSub.resultTopicId }}
           {{- if .Values.ap.gcpPubSub.topicsConfig }}
           - --pubsub.topics-config-file=/etc/async-processor/config/pubsub-topics.json
@@ -113,7 +116,7 @@ spec:
           - --tls-cert=/etc/tls/{{ .Values.ap.tls.certKey }}
           - --tls-key=/etc/tls/{{ .Values.ap.tls.keyKey }}
           {{- end }}
-        image: "{{ .Values.ap.image.repository }}:{{ .Values.ap.image.tag }}"
+        image: "{{ .Values.ap.image.repository }}:{{ .Values.ap.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.ap.imagePullPolicy }}"
         env:
           - name: LOG_LEVEL

--- a/charts/async-processor/tests/deployment_test.yaml
+++ b/charts/async-processor/tests/deployment_test.yaml
@@ -153,6 +153,43 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --message-queue-impl=gcp-pubsub
 
+  - it: should default the image to the published repo with the appVersion tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/llm-d-incubation/llm-d-async:0.7.0
+
+  - it: should honor an explicit image tag override
+    set:
+      ap.image.tag: "v1.2.3"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/llm-d-incubation/llm-d-async:v1.2.3
+
+  - it: should render --pubsub.project-id when projectId is set
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.projectId: "my-project"
+      ap.gcpPubSub.requestSubscriberId: "test-sub"
+      ap.gcpPubSub.resultTopicId: "test-topic"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --pubsub.project-id=my-project
+
+  - it: should not render --pubsub.project-id when projectId is unset
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.requestSubscriberId: "test-sub"
+      ap.gcpPubSub.resultTopicId: "test-topic"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --pubsub.project-id=
+
   - it: should inject OTel env vars when endpoint is set
     set:
       ap.otel.endpoint: "http://otel:4317"

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -15,8 +15,10 @@ ap:
       cpu: 500m
       memory: 512Mi
   image:
-    repository: ghcr.io/llm-d-incubation/async-processor
-    tag: 0.6.0
+    repository: ghcr.io/llm-d-incubation/llm-d-async
+    # Image tag. Leave empty to track the chart's appVersion (recommended so the
+    # image stays in sync with the chart). Set explicitly to pin a different tag.
+    tag: ""
   imagePullPolicy: Always
   concurrency: 8
   drainTimeout: "2m"
@@ -89,6 +91,9 @@ ap:
   messageQueueImpl: ""
   gcpPubSub:
     enabled: false
+    # GCP project ID for the Pub/Sub client. Required for the gcp-pubsub backends:
+    # the process panics on startup ("projectID string is empty") if unset.
+    projectId: ""
     requestSubscriberId: ""
     resultTopicId: ""
     requestPathURL: "/v1/completions"


### PR DESCRIPTION
## What does this PR do?

Fixes two Helm chart defects that break a fresh install of the GCP Pub/Sub backend.

### #267 — default image is wrong
- `ap.image.repository` pointed at the nonexistent `ghcr.io/llm-d-incubation/async-processor`; the images are published under `ghcr.io/llm-d-incubation/llm-d-async`.
- `ap.image.tag` defaulted to a stale `0.6.0`. The tag now defaults to `.Chart.AppVersion` when unset, so image and chart stay in sync (an explicit `ap.image.tag` still pins).

### #268 — `gcp-pubsub` backend panics (`projectID string is empty`)
- The chart never passed `--pubsub.project-id` and had no value for it, so `gcp-pubsub` / `gcp-pubsub-gated` crash-looped.
- Adds `ap.gcpPubSub.projectId` and renders `--pubsub.project-id` when set (applies to both gated and non-gated modes; mirrors the `gcp-pubsub-gated` support from #265).

## How was this tested?
- [x] `helm lint` clean
- [x] `helm unittest` — 45/45 pass, including 4 new cases (default/overridden image tag, project-id rendered when set / omitted when unset)
- [x] `helm template` confirms rendered output

## Related Issues
Fixes #267
Fixes #268