### PR TITLE
fix(chart): make empty image-tag default resolve to a published tag (#277)

### DIFF
--- a/scripts/publish-helm-chart.sh
+++ b/scripts/publish-helm-chart.sh
@@ -37,7 +37,12 @@ command -v helm >/dev/null 2>&1 || {
 }
 
 yq -i '.ap.image.tag = strenv(VERSION)' charts/async-processor/values.yaml
-yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(CHART_VERSION)' charts/async-processor/Chart.yaml
+# Chart version must be bare SemVer (OCI/Helm requirement), so it uses the
+# v-stripped CHART_VERSION. appVersion keeps the leading "v" to match the
+# published image tag (images are tagged with the git tag verbatim, e.g.
+# v0.7.1). This makes the recommended empty `ap.image.tag` default — which
+# falls back to .Chart.AppVersion — resolve to a tag that actually exists.
+yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(VERSION)' charts/async-processor/Chart.yaml
 
 helm package charts/async-processor -d release/
 


### PR DESCRIPTION
## What does this PR do?

Fixes the appVersion / image-tag `v`-prefix mismatch (#277).

The release publish script (`scripts/publish-helm-chart.sh`) tagged images with the git tag verbatim (e.g. `v0.7.1`) but stripped the leading `v` when writing `appVersion`. The chart's **recommended** "leave `ap.image.tag` empty to track appVersion" default renders `{{ .Values.ap.image.tag | default .Chart.AppVersion }}`, so clearing the tag resolved to `ghcr.io/llm-d-incubation/llm-d-async:0.7.1` — a tag that does not exist (only `v0.7.1` is published) → `ImagePullBackOff`.

### Fix
- Keep `.version` as bare SemVer (OCI/Helm requirement).
- Set `.appVersion` from the **v-prefixed** `VERSION` so the empty-tag default matches the published image.

## How was this tested?
Simulated the publish step (`yq` mutations with `VERSION=v0.7.1`) and rendered the chart:
- `version: 0.7.1`, `appVersion: "v0.7.1"`
- pinned tag → `...llm-d-async:v0.7.1`
- **empty tag (recommended) → `...llm-d-async:v0.7.1`** (previously `:0.7.1`, broken)
- `helm lint` passes

## Related Issues
Fixes #277