### PR TITLE
fix(chart): fail-fast validation for pubsub projectId, redis connection, igwBaseURL (#278, #280)

### DIFF
--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -1,3 +1,22 @@
+{{- /* ---- Fail-fast configuration validation ----
+       Turn common misconfigurations into clear install-time errors instead of
+       runtime crash-loops or silently dropped requests. */ -}}
+{{- if .Values.ap.redis.enabled }}
+{{- if and (not .Values.ap.redis.url) (not .Values.ap.redis.secretName) }}
+{{- fail "ap.redis is enabled but no connection is configured: set ap.redis.url, or set ap.redis.secretName/ap.redis.secretKey to reference an existing Secret." }}
+{{- end }}
+{{- else if .Values.ap.gcpPubSub.enabled }}
+{{- if not .Values.ap.gcpPubSub.projectId }}
+{{- fail "ap.gcpPubSub is enabled but ap.gcpPubSub.projectId is empty: the GCP Pub/Sub backend requires a project ID (the process panics on startup without it)." }}
+{{- end }}
+{{- end }}
+{{- if not .Values.ap.igwBaseURL }}
+{{- if and .Values.ap.redis.enabled (not .Values.ap.redis.queuesConfig) }}
+{{- fail "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-queue igw_base_url entries via ap.redis.queuesConfig." }}
+{{- else if and .Values.ap.gcpPubSub.enabled (not .Values.ap.gcpPubSub.topicsConfig) }}
+{{- fail "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-topic igw_base_url entries via ap.gcpPubSub.topicsConfig." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/async-processor/tests/deployment_test.yaml
+++ b/charts/async-processor/tests/deployment_test.yaml
@@ -1,8 +1,14 @@
 suite: deployment
 templates:
   - templates/ap-deployments.yaml
+# Suite-level defaults satisfy the chart's fail-fast validation (igwBaseURL,
+# a Redis connection, and a Pub/Sub projectId) so positive tests render.
+# Individual tests override these to exercise the validation guards.
 set:
   ap.redis.enabled: true
+  ap.redis.secretName: "redis-creds"
+  ap.igwBaseURL: "http://igw:80"
+  ap.gcpPubSub.projectId: "test-project"
 tests:
   - it: should render a Deployment
     asserts:
@@ -179,16 +185,57 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --pubsub.project-id=my-project
 
-  - it: should not render --pubsub.project-id when projectId is unset
+  - it: should fail when gcp-pubsub is enabled without a projectId
     set:
       ap.redis.enabled: false
       ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.projectId: ""
       ap.gcpPubSub.requestSubscriberId: "test-sub"
       ap.gcpPubSub.resultTopicId: "test-topic"
     asserts:
-      - notContains:
+      - failedTemplate:
+          errorMessage: "ap.gcpPubSub is enabled but ap.gcpPubSub.projectId is empty: the GCP Pub/Sub backend requires a project ID (the process panics on startup without it)."
+
+  - it: should fail when redis is enabled with no url and no secretName
+    set:
+      ap.redis.enabled: true
+      ap.redis.url: ""
+      ap.redis.secretName: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.redis is enabled but no connection is configured: set ap.redis.url, or set ap.redis.secretName/ap.redis.secretKey to reference an existing Secret."
+
+  - it: should fail when igwBaseURL is empty in single-queue redis mode
+    set:
+      ap.redis.enabled: true
+      ap.igwBaseURL: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-queue igw_base_url entries via ap.redis.queuesConfig."
+
+  - it: should fail when igwBaseURL is empty in single-topic gcp-pubsub mode
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.igwBaseURL: ""
+      ap.gcpPubSub.resultTopicId: "test-topic"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-topic igw_base_url entries via ap.gcpPubSub.topicsConfig."
+
+  - it: should not require igwBaseURL when redis queuesConfig is set
+    set:
+      ap.redis.enabled: true
+      ap.messageQueueImpl: "redis-sortedset"
+      ap.igwBaseURL: ""
+      ap.redis.queuesConfig:
+        - queue_name: "queue-1"
+          igw_base_url: "http://igw-1:80"
+          request_path_url: "/v1/completions"
+    asserts:
+      - contains:
           path: spec.template.spec.containers[0].args
-          content: --pubsub.project-id=
+          content: --redis.ss.queues-config
 
   - it: should inject OTel env vars when endpoint is set
     set:

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -1,5 +1,10 @@
 ap:
-  igwBaseURL: "http://infra-inference-scheduling-inference-gateway-istio.llm-d-inference-scheduler.svc.cluster.local:80"
+  # Inference gateway base URL (REQUIRED for single-queue / single-topic mode).
+  # Results are dispatched here; an empty or wrong value silently consumes
+  # requests without producing results, so it is validated at install time.
+  # For multi-queue/multi-topic setups, set per-entry igw_base_url in
+  # redis.queuesConfig / gcpPubSub.topicsConfig instead of this global value.
+  igwBaseURL: ""
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -124,7 +129,9 @@ ap:
     # For production or credentialed URLs, prefer Option 2 (secretName/secretKey).
     # url: "redis://redis-master.redis.svc.cluster.local:6379"
     # Option 2: reference a pre-existing Secret (used when url is not set).
-    secretName: "redis-creds"
+    # Empty by default so an unconfigured Redis connection fails fast at install
+    # time instead of referencing a Secret that may not exist.
+    secretName: ""
     secretKey: "url"
     requestPathURL: "/v1/completions"
     # For redis-sortedset


### PR DESCRIPTION
## What does this PR do?

Adds install-time (`helm`) validation so three common misconfigurations fail clearly instead of as late, cryptic runtime errors. Implements #278 and #280.

| Misconfig | Before | After |
|---|---|---|
| gcp-pubsub enabled, `ap.gcpPubSub.projectId` empty | container **panics** (`projectID string is empty`) | `helm` install error |
| redis enabled, neither `ap.redis.url` nor `ap.redis.secretName` | pod `CreateContainerConfigError: secret "redis-creds" not found` | `helm` install error |
| `ap.igwBaseURL` unset (single-queue/topic) | requests silently consumed, **no result, no error** | `helm` install error |

### Changes
- **values.yaml**: `ap.igwBaseURL` default `""` (was an environment-specific URL); `ap.redis.secretName` default `""` (was the misleading `redis-creds`).
- **ap-deployments.yaml**: a fail-fast validation block at the top (mirrors the existing `queuesConfig`/`gateType` `{{ fail }}`).
  - igw guard only fires in **single**-queue/topic mode; multi modes use per-entry `igw_base_url`.
  - projectId guard respects the redis-takes-precedence ordering.
- **tests**: suite-level defaults satisfy the guards for positive tests; added `failedTemplate` cases for each guard plus a "queuesConfig exempts igwBaseURL" case.

## How was this tested?
- `helm lint` clean
- `helm unittest` — **49/49 pass**
- `helm template` confirms each guard fires with its message and the happy path renders

## Notes
- Removing the `igwBaseURL` default and the `redis-creds` `secretName` default are intentional **behavior changes** (the old defaults were wrong for ~everyone). e2e helm values already set `igwBaseURL` explicitly, so they're unaffected.
- Belt-and-suspenders Go-side validation (clean fatal log instead of panic) is tracked separately in #279.

## Related Issues
Fixes #278
Fixes #280