### PR TITLE
chore: enforce Go conventions via linters and documentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,11 @@ linters:
   enable:
     - depguard
     - errcheck
+    - gochecknoglobals
     - govet
     - staticcheck
     - unused
+    - wrapcheck
   settings:
     depguard:
       rules:
@@ -23,3 +25,40 @@ linters:
         - (io.ReadCloser).Close
         - (*net.TCPListener).Close
         - (net.Conn).Close
+  exclusions:
+    rules:
+      # Prometheus metrics are idiomatically registered as package-level vars.
+      - path: pkg/metrics/
+        linters: [gochecknoglobals]
+      # Build-time version vars injected via -ldflags.
+      - path: pkg/version/
+        linters: [gochecknoglobals]
+      # Existing package-level state predating gochecknoglobals.
+      - path: pkg/async/inference/flowcontrol/binary_metric_dispatch_gate\.go
+        linters: [gochecknoglobals]
+      - path: pkg/plugins/registry\.go
+        linters: [gochecknoglobals]
+      - path: pkg/pubsub/pubsubimpl\.go
+        linters: [gochecknoglobals]
+      - path: pkg/redis/redisimpl\.go
+        linters: [gochecknoglobals]
+      - path: pkg/server/(options|runner)\.go
+        linters: [gochecknoglobals]
+      # Existing unwrapped errors predating wrapcheck.
+      - path: internal/health/
+        linters: [wrapcheck]
+      - path: internal/logging/
+        linters: [wrapcheck]
+      - path: internal/otel/
+        linters: [wrapcheck]
+      - path: pkg/async/inference/flowcontrol/composite_gate\.go
+        linters: [wrapcheck]
+      - path: pkg/asyncworker/transform/gcsmultipart/
+        linters: [wrapcheck]
+      - path: pkg/redis/(quota_gate|redisimpl|sortedset_impl)\.go
+        linters: [wrapcheck]
+      - path: pkg/server/runner\.go
+        linters: [wrapcheck]
+      # Test files — enforce conventions on production code first.
+      - path: _test\.go
+        linters: [gochecknoglobals, wrapcheck]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — llm-d-async
+
+Asynchronous dispatch processor for llm-d. Pulls batch requests from a message queue, gates dispatch based on system capacity, and forwards to an inference gateway.
+
+## General Principles
+
+- **Think before coding**: State assumptions explicitly. If uncertain, ask. Don't guess silently.
+- **Simplicity first**: No features beyond what was asked. No abstractions for single-use code.
+- **Surgical changes**: Only touch what you must. Don't "improve" adjacent code, comments, or formatting. Match existing style.
+
+## Code Conventions
+
+- **Logging**: Use `logr.Logger` — stdlib `log` is banned in non-test code (enforced by `depguard`).
+- **Interfaces**: Verify compliance at compile time: `var _ Interface = (*Impl)(nil)`.
+- **Errors**: Wrap with `fmt.Errorf("context: %w", err)` when returning errors from external packages. Handle errors once — return OR log, never both.
+- **No mutable globals**: Avoid package-level mutable variables. Use unexported state with constructors and accessors. Exceptions: Prometheus metric registrations and build-time version vars.
+- **No panic**: Never use `panic()` in production code. Return errors instead.
+- **YAGNI**: Don't add exported functions, methods, or types without a caller in this repo.
+- **Porting rule**: When adapting code from EPP or another repo, strip it to what is actually called and re-fit it to local idioms before opening the PR.
+
+## Build & Verify
+
+- `make build` — compile binary
+- `make ci` — run all CI checks (fmt, vet, lint, test)
+- `make lint` — run golangci-lint
+- `make lint-fix` — run golangci-lint with auto-fix
+
+## Testing
+
+- Unit tests: `make test`
+- Integration tests: `make test-integration`
+- All tests: `make test-all`
+- E2E tests: `make test-e2e` (requires Kind cluster)
+
+## Multi-Module Repo
+
+This repo has four Go modules: root, `api/`, `pipeline/`, `producer/`. Run `make fmt` and `make vet` to cover all modules. See `CONTRIBUTING.md` for release tagging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,16 @@ git push origin v0.8.0
 
 Go requires sub-module tags to carry the directory prefix — see [Managing module source](https://go.dev/doc/modules/managing-source) for details.
 
+## Go Conventions
+
+These conventions are enforced by linters where possible (see `.golangci.yml`) and by code review otherwise.
+
+1. **No mutable package globals.** Use unexported state with constructors and accessors. Exceptions: Prometheus metric registrations (`pkg/metrics/`) and build-time version vars (`pkg/version/`).
+2. **Compile-time interface assertions.** Every interface implementation (and test fake) must include `var _ Interface = (*Impl)(nil)` to catch breakage at compile time, not at runtime.
+3. **Wrap errors with context.** When returning an error from an external package, wrap it: `fmt.Errorf("doing X: %w", err)`. This makes logs actionable.
+4. **YAGNI.** Don't add exported functions, methods, or types without a caller in this repo. Unused API surface is maintenance burden.
+5. **Porting rule.** When adapting code from EPP or another repo, strip it to what is actually called and re-fit it to local idioms before opening the PR.
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for our vulnerability disclosure process.


### PR DESCRIPTION
 ## What does this PR do?

Adds two linters to `.golangci.yml` and documents Go conventions that can't be linted.

1. Enable `gochecknoglobals` and `wrapcheck` to catch mutable package globals and unwrapped errors in new code. 73 existing violations across 16 files are excluded per-file so CI passes. Exclusions can be removed as violations are addressed.
2. Add "Go Conventions" section to `CONTRIBUTING.md` with the five rules from #258.
3. Create `CLAUDE.md` with repo-specific conventions and build commands (repo previously lacked one).

## Why is this change needed?

EPP patterns ported into this repo weren't caught by CI because the linter config didn't enforce local conventions. This PR adds automated enforcement so the same class of finding doesn't recur.

 ## How was this tested?

- [x] Manual testing performed
- `make lint` passes with zero issues (exclusions working)
- Created a test file with a mutable global and unwrapped error in `pkg/` both linters caught it
- Deleted test file after verification
- [x] Linters pass (`make lint`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #258
Related: #257 (root-cause review that surfaced these gaps)