### PR TITLE
feat(metrics): add dispatch budget and pool worker-limit gauges (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem
 | `llm_d_async_async_message_latency_time_millis` | Histogram | End-to-end message latency in milliseconds (publish to successful processing). Only registered when the transport supports message latency (e.g., GCP Pub/Sub). |
 | `llm_d_async_async_inference_latency_time_millis` | Histogram | Time in milliseconds spent calling the inference gateway (IGW), measured around each request attempt. Isolates "model time" from "queue time" and is always registered. |
 | `llm_d_async_async_queue_residence_time_millis` | Histogram | Time in milliseconds a message spent buffered in-process, from broker ingestion until a worker pulled it for processing. Measures the async delay introduced by the system (queue time). Always registered. |
+| `llm_d_async_async_dispatch_budget` | Gauge | Current dispatch budget [0.0–1.0] returned by the queue's gate; the fraction of system capacity available for new requests (0.0 = gate fully closed). Useful for diagnosing why throughput is throttled. |
+| `llm_d_async_async_pool_worker_limit` | Gauge | Configured worker concurrency limit for a pool (carries only the `pool_name` label). Compare against `llm_d_async_async_inflight_requests` to compute worker utilization. |
 
 **Labels:**
 
@@ -541,6 +543,7 @@ The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem
 |-------|-------------|
 | `queue_id` | Transport-level queue identifier |
 | `queue_name` | Logical queue name from the queue configuration |
+| `pool_name` | Worker pool the queue routes to (`async_pool_worker_limit` carries only this label) |
 
 **Example PromQL queries:**
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -90,6 +90,14 @@ var (
 		Subsystem: SchedulerSubsystem, Name: "async_broker_backlog",
 		Help: "Number of undelivered/pending messages held by the broker queue.",
 	}, queueLabels)
+	DispatchBudget = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_dispatch_budget",
+		Help: "Current dispatch budget [0.0-1.0] returned by the queue's gate; the fraction of system capacity available for new requests (0.0 = gate fully closed).",
+	}, queueLabels)
+	PoolWorkerLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_pool_worker_limit",
+		Help: "Configured number of concurrent workers (the concurrency limit) for a pool. Compare against async_inflight_requests for worker utilization.",
+	}, []string{LabelPoolName})
 )
 
 func RecordRetry(queueID, queueName, poolName string) {
@@ -156,11 +164,22 @@ func SetBrokerBacklog(queueID, queueName, poolName string, n float64) {
 	BrokerBacklog.WithLabelValues(queueID, queueName, poolName).Set(n)
 }
 
+// SetDispatchBudget sets the current dispatch budget [0.0-1.0] for a queue's gate.
+func SetDispatchBudget(budget float64, queueID, queueName, poolName string) {
+	DispatchBudget.WithLabelValues(queueID, queueName, poolName).Set(budget)
+}
+
+// SetPoolWorkerLimit sets the configured worker concurrency limit for a pool.
+func SetPoolWorkerLimit(poolName string, n float64) {
+	PoolWorkerLimit.WithLabelValues(poolName).Set(n)
+}
+
 // GetCollectors returns all custom collectors for the async processor.
 func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Collector {
 	collectors := []prometheus.Collector{
 		Retries, AsyncReqs, ExceededDeadlineReqs, FailedReqs, SuccessfulReqs, SheddedRequests,
 		QueueDepth, InflightRequests, BrokerBacklog, InferenceLatencyTime, QueueResidenceTime,
+		DispatchBudget, PoolWorkerLimit,
 	}
 	if supportsMessageLatency {
 		collectors = append(collectors, MessageLatencyTime)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestGetAsyncProcessorCollectors_withoutLatency(t *testing.T) {
@@ -27,6 +28,8 @@ func TestGetAsyncProcessorCollectors_includesGauges(t *testing.T) {
 			"QueueDepth":       QueueDepth,
 			"InflightRequests": InflightRequests,
 			"BrokerBacklog":    BrokerBacklog,
+			"DispatchBudget":   DispatchBudget,
+			"PoolWorkerLimit":  PoolWorkerLimit,
 		} {
 			if !containsCollector(collectors, gauge) {
 				t.Errorf("expected %s gauge to be present (supportsMessageLatency=%v)", name, withLatency)
@@ -54,6 +57,22 @@ func TestGetAsyncProcessorCollectors_includesQueueResidence(t *testing.T) {
 		if !containsCollector(collectors, QueueResidenceTime) {
 			t.Errorf("expected QueueResidenceTime to be present (supportsMessageLatency=%v)", withLatency)
 		}
+	}
+}
+
+func TestSetDispatchBudget(t *testing.T) {
+	SetDispatchBudget(0.42, "q1", "queue-1", "pool-a")
+	got := testutil.ToFloat64(DispatchBudget.WithLabelValues("q1", "queue-1", "pool-a"))
+	if got != 0.42 {
+		t.Errorf("DispatchBudget = %v, want 0.42", got)
+	}
+}
+
+func TestSetPoolWorkerLimit(t *testing.T) {
+	SetPoolWorkerLimit("pool-a", 8)
+	got := testutil.ToFloat64(PoolWorkerLimit.WithLabelValues("pool-a"))
+	if got != 8 {
+		t.Errorf("PoolWorkerLimit = %v, want 8", got)
 	}
 }
 

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -411,6 +411,7 @@ func (r *PubSubMQFlow) requestWorker(ctx context.Context, pubSubClient *pubsub.C
 	for ctx.Err() == nil {
 		receiveCtx, cancel := context.WithCancel(ctx)
 		budget := gate.Budget(ctx)
+		metrics.SetDispatchBudget(budget, "", subscriberID, poolID)
 		go func() {
 			ticker := time.NewTicker(10 * time.Second)
 			defer ticker.Stop()

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
 
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
@@ -405,6 +406,11 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 	currentTime := float64(time.Now().Unix())
 
 	budget := gate.Budget(ctx)
+	poolName := ""
+	if cfg, ok := r.configMap[queueID]; ok {
+		poolName = cfg.WorkerPoolID
+	}
+	metrics.SetDispatchBudget(budget, queueID, queueName, poolName)
 	batchSize := int(math.Floor(float64(r.batchSize) * budget))
 
 	for i := 0; i < batchSize; i++ {

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -188,6 +188,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 		poolsMap[p.ID] = p
 		totalConcurrency += p.Workers
+		metrics.SetPoolWorkerLimit(p.ID, float64(p.Workers))
 	}
 
 	inferenceTransport := &http.Transport{


### PR DESCRIPTION
## What does this PR do?

Adds two of the unimplemented metrics from #217 — the two whose data is already available at existing hook points:

| Metric | Type | Labels | Source |
|---|---|---|---|
| `llm_d_async_async_dispatch_budget` | Gauge | `queue_id,queue_name,pool_name` | the `[0.0–1.0]` value from each queue's gate |
| `llm_d_async_async_pool_worker_limit` | Gauge | `pool_name` | configured worker concurrency per pool |

- **Dispatch budget** is emitted exactly where the flows already call `gate.Budget()` to size batches — redis sorted-set `processMessages` and gcp-pubsub `requestWorker` — so it's pure wiring, no new gate calls. Surfaces *why* throughput is throttled (gate closed → budget near 0).
- **Pool worker limit** is set once from the pool config in `runner.go`; combined with the existing `async_inflight_requests` gauge it gives worker-concurrency utilization (the gap called out in #217's Execution Layer).

Pub/Sub budget labels mirror the existing `QueueBacklog` convention for that backend (`queue_name=subscriberID`, `pool_name=poolID`).

## How was this tested?
- `go build ./...`, `make lint` → 0 issues
- `go test ./pkg/metrics/... ./pkg/redis/... ./pkg/pubsub/... ./pkg/server/...` → pass
- New unit tests assert both gauges are registered and that the setters record the expected values (via `testutil.ToFloat64`)

## Notes
- This is PR 1 of a series for #217. Follow-ups: gate-decision breakdown counter, prometheus-saturation raw value, token throughput. `async_queue_residence_time_millis` (listed ⬜ in the issue) is already implemented (#254) — the issue legend is stale.

## Related Issues
Related: #217