### PR TITLE
fix(test): correct unparseable -> unparsable typo (#202)

### DIFF
--- a/pkg/asyncworker/transform/gcsmultipart/gcsmultipart_test.go
+++ b/pkg/asyncworker/transform/gcsmultipart/gcsmultipart_test.go
@@ -181,7 +181,7 @@ func TestValidate(t *testing.T) {
 		{"expired before deadline", fmt.Sprintf(`{"gcs_uri":%q}`, v4SignedURL(deadline.Add(-time.Minute))), whisper, true},
 		{"no gcs_uri", `{"model":"whisper-1"}`, whisper, false},
 		{"provider mismatch", fmt.Sprintf(`{"gcs_uri":%q}`, v4SignedURL(deadline.Add(-time.Minute))), map[string]string{"provider": "other"}, false},
-		{"unparseable expiry", `{"gcs_uri":"https://signed/url?sig=x"}`, whisper, false},
+		{"unparsable expiry", `{"gcs_uri":"https://signed/url?sig=x"}`, whisper, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes the recurring nightly typo-scan finding from #202.

`pkg/asyncworker/transform/gcsmultipart/gcsmultipart_test.go:184` — test case name `"unparseable expiry"` → `"unparsable expiry"`.

This is the only typo currently flagged by the nightly scan (every night since 2026-06-23). The earlier `unmarshaling` finding referenced in the issue is left as-is: `unmarshaling` is the standard Go spelling (used by the stdlib) and is no longer flagged by recent scans.

## Test
`go test ./pkg/asyncworker/transform/gcsmultipart/` passes.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)