### PR TITLE
fix: TestPoolGating_Timeout may hang indefinitely

### DIFF
--- a/test/integration/pool_gate_test.go
+++ b/test/integration/pool_gate_test.go
@@ -117,9 +117,9 @@ func TestPoolGating_Blocking(t *testing.T) {
 // TestPoolGating_Timeout verifies that request deadline is respected
 // while worker is parked waiting for gate capacity.
 func TestPoolGating_Timeout(t *testing.T) {
+	serverDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Hang indefinitely to consume capacity
-		select {}
+		<-serverDone
 	}))
 	defer server.Close()
 
@@ -186,6 +186,7 @@ func TestPoolGating_Timeout(t *testing.T) {
 
 	cancel()
 	wg.Wait()
+	close(serverDone)
 }
 
 type customMockGate struct {

--- a/test/integration/pool_gate_test.go
+++ b/test/integration/pool_gate_test.go
@@ -117,11 +117,15 @@ func TestPoolGating_Blocking(t *testing.T) {
 // TestPoolGating_Timeout verifies that request deadline is respected
 // while worker is parked waiting for gate capacity.
 func TestPoolGating_Timeout(t *testing.T) {
+	var closeOnce sync.Once
 	serverDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-serverDone
 	}))
-	defer server.Close()
+	defer func() {
+		closeOnce.Do(func() { close(serverDone) })
+		server.Close()
+	}()
 
 	client := asyncworker.NewHTTPInferenceClient(server.Client())
 	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 2)
@@ -185,8 +189,8 @@ func TestPoolGating_Timeout(t *testing.T) {
 	}
 
 	cancel()
+	closeOnce.Do(func() { close(serverDone) })
 	wg.Wait()
-	close(serverDone)
 }
 
 type customMockGate struct {


### PR DESCRIPTION
## What does this PR do?

TestPoolGating_Timeout is a flaky test that sometimes may hang over the 5s timeout (on slow CI). We make sure that the test is cleaned up correctly instead.

## Why is this change needed?

The test fails only due to slow CI, not because it really is broken; a re-run usually fixes. The PR should "unflake" the test.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
